### PR TITLE
ux(community): rename Agent Marketplace to Agent Supermarket

### DIFF
--- a/dashboard/backend/api/routers/agents.py
+++ b/dashboard/backend/api/routers/agents.py
@@ -231,7 +231,7 @@ def list_agents(
 
 @router.get("/marketplace")
 def list_marketplace_agents():
-    """List open agent templates available in the Agent Marketplace.
+    """List open agent templates available in the Agent Supermarket.
 
     Public and unauthenticated. Templates are config-driven and do not expose
     API keys or owner information.

--- a/dashboard/backend/domain/agents/marketplace.py
+++ b/dashboard/backend/domain/agents/marketplace.py
@@ -1,4 +1,4 @@
-"""Open agent templates for the Agent Marketplace.
+"""Open agent templates for the Agent Supermarket.
 
 Templates are defined in ``dashboard/config/marketplace.json`` so baseline open
 agents can be added without schema migrations. The listing is public; cloning

--- a/dashboard/backend/tests/test_frontend_marketplace_placement.py
+++ b/dashboard/backend/tests/test_frontend_marketplace_placement.py
@@ -1,4 +1,4 @@
-"""Guards for the Agent Marketplace living on the Community page.
+"""Guards for the Agent Supermarket living on the Community page.
 
 The marketplace moved out of Playground (where it was a subtab) and became a
 section of Community. Nothing about that move is enforceable at runtime -- the
@@ -130,9 +130,9 @@ def test_community_page_header_matches_the_nav_button():
     assert title, "#communityView has no page title"
     assert title.group(1).strip() == label
 
-    # The marketplace is a section *within* that page, so it must not also claim
+    # The supermarket is a section *within* that page, so it must not also claim
     # the page-level heading.
-    assert 'class="marketplace-section-title">Agent Marketplace<' in view
+    assert 'class="marketplace-section-title">Agent Supermarket<' in view
     assert view.count('class="page-title"') == 1
 
 

--- a/dashboard/backend/tests/test_frontend_model_facets.py
+++ b/dashboard/backend/tests/test_frontend_model_facets.py
@@ -487,9 +487,11 @@ const closedHasBadge = closedHtml.includes('marketplace-licence-badge');
 // Strip only the exact badge span (proves it was actually there) and
 // normalise only the one known-legitimate difference (the model label) --
 // a blanket strip would hide any other marker instead of catching it.
+// replaceAll: the label is in both the submeta title attribute and the
+// visible text; String.replace(string) would only hit the first.
 const openWithoutBadge = openHtml.split(BADGE).join('')
-  .replace('Powered by DeepSeek', 'POWERED_BY_MODEL');
-const closedNormalized = closedHtml.replace('Powered by Claude', 'POWERED_BY_MODEL');
+  .replaceAll('Powered by DeepSeek', 'POWERED_BY_MODEL');
+const closedNormalized = closedHtml.replaceAll('Powered by Claude', 'POWERED_BY_MODEL');
 
 console.log(JSON.stringify({{
   openHasBadge,

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -1714,7 +1714,7 @@
         </div>
     </div>
 
-    <!-- Community -- Agent Marketplace is its first section, not the whole page:
+    <!-- Community -- Agent Supermarket is its first section, not the whole page:
          the nav button says "Community", so the page has to say it too. -->
     <div id="communityView" class="page-view community-view" style="display: none;">
         <div class="page-header">
@@ -1726,7 +1726,7 @@
         <div class="marketplace-section">
             <div class="marketplace-section-head">
                 <div>
-                    <h3 class="marketplace-section-title">Agent Marketplace</h3>
+                    <h3 class="marketplace-section-title">Agent Supermarket</h3>
                     <p class="marketplace-section-sub">Browse open agent templates and add them to My Agents to customize and backtest.</p>
                 </div>
                 <div class="agent-toolbar-search marketplace-search">

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -10169,7 +10169,7 @@ body.agent-editor-open {
     background: rgba(16, 185, 129, 0.12);
 }
 
-/* Agent Marketplace */
+/* Agent Supermarket */
 .marketplace-section {
     display: flex;
     flex-direction: column;

--- a/docs/source/lab/getting_started.rst
+++ b/docs/source/lab/getting_started.rst
@@ -96,7 +96,7 @@ Start from a template
 ---------------------
 
 Rather than writing an agent from scratch, open **Community → Agent
-Marketplace** and add a ready-made template to **My Agents**, then edit its
+Supermarket** and add a ready-made template to **My Agents**, then edit its
 prompts and backtest it. The section chips there filter templates by market, so
 you can jump straight to U.S. stocks or A-shares. See :doc:`marketplace`.
 

--- a/docs/source/lab/live_trading.rst
+++ b/docs/source/lab/live_trading.rst
@@ -28,7 +28,7 @@ You need:
   against it, so live trading is not available to signed-out browser sessions;
 - a **real agent** under **Playground → My Agents**. The demo agents on the
   dashboard cannot be connected; create one, or add one from the
-  :doc:`Agent Marketplace <marketplace>` first;
+  :doc:`Agent Supermarket <marketplace>` first;
 - a **Robinhood account** eligible for Robinhood's Agentic Trading (MCP) access;
 - a deployment configured for Robinhood (:ref:`robinhood-config`). If it is not,
   connecting fails with *Robinhood OAuth is not configured*.
@@ -160,8 +160,8 @@ Troubleshooting
    * - *Robinhood OAuth is not configured*
      - The deployment has no Robinhood settings. See :ref:`robinhood-config`.
    * - *Create a real agent in My Agents first*
-     - You are on a demo agent. Create one, or add one from the marketplace,
-       then retry.
+     - You are on a demo agent. Create one, or add one from the Agent
+       Supermarket, then retry.
    * - *Connect Robinhood first*
      - No brokerage account is linked to your ATL account.
    * - *Enable live trading for this agent*

--- a/docs/source/lab/marketplace.rst
+++ b/docs/source/lab/marketplace.rst
@@ -1,11 +1,11 @@
-Agent Marketplace
+Agent Supermarket
 =================
 
-The **Agent Marketplace** is a catalog of ready-made agent templates. Add one to
+The **Agent Supermarket** is a catalog of ready-made agent templates. Add one to
 **My Agents** (see :ref:`my-agents-sections`), then edit, backtest, or run it
 like any agent you built yourself.
 
-Open the dashboard, go to **Community**, and use the **Agent Marketplace**.
+Open the dashboard, go to **Community**, and use the **Agent Supermarket**.
 Browsing needs no account.
 
 


### PR DESCRIPTION
## Summary
- Rename the Community catalog heading from **Agent Marketplace** to **Agent Supermarket**. The Community nav button and page title are unchanged.
- Update user-facing docs (`marketplace.rst`, `getting_started.rst`, `live_trading.rst`) and the source-shape guard in `test_frontend_marketplace_placement.py`.
- Leave API paths (`/api/v1/agents/marketplace`), CSS class names, and `?view=marketplace` aliases as-is.

## Test plan
- [x] `pytest dashboard/backend/tests/test_frontend_marketplace_placement.py -v` (11 passed)
- [ ] Open `/app` → Community and confirm the section heading reads **Agent Supermarket**
- [ ] Confirm the primary nav still says **Community**, and `?view=marketplace` still lands on that page


Made with [Cursor](https://cursor.com)