### PR TITLE
feat: grant default credits to every user

### DIFF
--- a/dashboard/backend/api/auth.py
+++ b/dashboard/backend/api/auth.py
@@ -28,6 +28,7 @@ from dashboard.backend.api.rate_limit import (
 )
 from dashboard.backend.domain.brokers.repository import broker_store
 from dashboard.backend.domain.analytics import instrumentation as analytics_instrumentation
+from dashboard.backend.domain.credits.service import credits_service
 from dashboard.backend.infrastructure.brokers import pending_links, robinhood_oauth
 from dashboard.backend.infrastructure.email import sender as email_sender
 from dashboard.backend import users as users_module
@@ -139,6 +140,14 @@ def _login_ip_key(request: Request) -> str:
 
 def _signup_ip_key(request: Request) -> str:
     return f"signup:{client_key(request)}"
+
+
+async def _ensure_welcome_credits(user_id: int, *, category: str) -> None:
+    """Best-effort grant; login and startup provide deterministic repair."""
+    try:
+        await asyncio.to_thread(credits_service.grant_default_signup_credits, user_id)
+    except Exception:  # noqa: BLE001 - never expose a store/DSN error here
+        print(f"WARNING: credits.welcome_grant_failed category={category}")
 
 
 def _app_redirect(query: dict[str, str]) -> RedirectResponse:
@@ -437,6 +446,8 @@ async def signup(payload: SignupRequest, request: Request):
             raise HTTPException(status_code=409, detail="Email is already registered") from exc
         raise
 
+    await _ensure_welcome_credits(user["id"], category="signup")
+
     token, entitlements = await asyncio.to_thread(_issue_session, user, request)
     analytics_instrumentation.emit_account_event(
         event_name="account_signed_up",
@@ -484,6 +495,7 @@ async def login(payload: LoginRequest, request: Request):
         print(f"auth.login_failed domain={_email_domain(payload.email)}")
         raise HTTPException(status_code=401, detail=LOGIN_FAILURE_DETAIL)
 
+    await _ensure_welcome_credits(user["id"], category="login")
     token, entitlements = await asyncio.to_thread(_issue_session, user, request)
     analytics_instrumentation.emit_account_event(
         event_name="authenticated_session_started",

--- a/dashboard/backend/app.py
+++ b/dashboard/backend/app.py
@@ -13,6 +13,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import FileResponse, RedirectResponse
 from pathlib import Path
+import asyncio
 import os
 
 import dashboard.backend.database as _database
@@ -167,6 +168,20 @@ async def startup_event():
     else:
         print("⚠️ ANTHROPIC_API_KEY not set - LLM trading disabled")
     print("📊 Paper Trading: Baselines initialized on startup...")
+
+    try:
+        from dashboard.backend.domain.credits.service import credits_service
+
+        report = await asyncio.to_thread(
+            credits_service.backfill_default_signup_credits
+        )
+        print(
+            "[credits] welcome campaign "
+            f"total={report['total']} granted={report['granted']} "
+            f"existing={report['existing']} failed={report['failed']}"
+        )
+    except Exception:  # noqa: BLE001 - startup must keep serving for a retry
+        print("WARNING: credits.welcome_backfill_failed")
     
     # Initialize paper trading baselines (non-blocking)
     import threading

--- a/dashboard/backend/domain/credits/models.py
+++ b/dashboard/backend/domain/credits/models.py
@@ -15,16 +15,16 @@ from pydantic import (
 )
 
 
-CreditPackageId = Literal["usd_5", "usd_10", "usd_20", "usd_50"]
+CreditPackageId = Literal["usd_0_50", "usd_1", "usd_2", "usd_5"]
 
 FIXED_PACKAGES_USD_CENTS: dict[str, int] = {
+    "usd_0_50": 50,
+    "usd_1": 100,
+    "usd_2": 200,
     "usd_5": 500,
-    "usd_10": 1000,
-    "usd_20": 2000,
-    "usd_50": 5000,
 }
-MIN_CUSTOM_USD_CENTS = 500
-MAX_CUSTOM_USD_CENTS = 20_000
+MIN_CUSTOM_USD_CENTS = 50
+MAX_CUSTOM_USD_CENTS = 500
 MICRO_CREDITS_PER_USD_CENT = 10_000
 
 
@@ -61,7 +61,7 @@ class CheckoutRequest(BaseModel):
         if custom and not (
             MIN_CUSTOM_USD_CENTS <= self.custom_amount_usd_cents <= MAX_CUSTOM_USD_CENTS
         ):
-            raise ValueError("custom amount must be from 500 through 20,000 cents")
+            raise ValueError("custom amount must be from 50 through 500 cents")
         return self
 
     @property

--- a/dashboard/backend/domain/credits/repository.py
+++ b/dashboard/backend/domain/credits/repository.py
@@ -212,6 +212,25 @@ CREATE TABLE IF NOT EXISTS credit_grant_pool_ledger_entries (
 """
 
 
+_PROMOTION_GRANT_DDL = """
+CREATE TABLE IF NOT EXISTS credit_promotion_grants (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    campaign_key TEXT NOT NULL CHECK (length(trim(campaign_key)) > 0),
+    amount_micro INTEGER NOT NULL CHECK (amount_micro > 0),
+    operation_id TEXT NOT NULL UNIQUE CHECK (length(trim(operation_id)) > 0),
+    idempotency_key TEXT NOT NULL UNIQUE
+        CHECK (length(trim(idempotency_key)) > 0),
+    request_digest TEXT NOT NULL CHECK (length(trim(request_digest)) > 0),
+    source TEXT NOT NULL CHECK (length(trim(source)) > 0),
+    reason TEXT NOT NULL CHECK (length(trim(reason)) > 0),
+    created_at TEXT NOT NULL,
+    UNIQUE (campaign_key, user_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+)
+"""
+
+
 def _dict(row: sqlite3.Row | None) -> dict[str, Any] | None:
     return dict(row) if row is not None else None
 
@@ -342,6 +361,7 @@ class CreditsStore:
             self._migrate_credit_ledger_in_transaction(conn)
             self._create_llm_billing_schema_in_transaction(conn)
             self._create_grant_pool_schema_in_transaction(conn)
+            self._create_promotion_grant_schema_in_transaction(conn)
 
     @staticmethod
     def _table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
@@ -577,6 +597,24 @@ class CreditsStore:
             (_utcnow_iso(),),
         )
 
+    @classmethod
+    def _create_promotion_grant_schema_in_transaction(
+        cls, conn: sqlite3.Connection
+    ) -> None:
+        conn.execute(_PROMOTION_GRANT_DDL)
+        conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_credit_promotion_grants_user_id
+            ON credit_promotion_grants(user_id, id DESC)
+            """
+        )
+        conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_credit_promotion_grants_campaign_user
+            ON credit_promotion_grants(campaign_key, user_id)
+            """
+        )
+
     @staticmethod
     def _begin(conn: sqlite3.Connection) -> None:
         conn.execute("BEGIN IMMEDIATE")
@@ -632,6 +670,16 @@ class CreditsStore:
         ).fetchone()
         grant_micro = int(row["grant_committed_micro"])
         purchased_micro = int(row["purchased_committed_micro"])
+        if through_entry_id is None:
+            promotion = conn.execute(
+                """
+                SELECT COALESCE(SUM(amount_micro), 0) AS grant_micro
+                FROM credit_promotion_grants
+                WHERE user_id = ?
+                """,
+                (user_id,),
+            ).fetchone()
+            grant_micro += int(promotion["grant_micro"])
         reserved_grant_micro = 0
         reserved_purchased_micro = 0
         if through_entry_id is None:
@@ -705,6 +753,16 @@ class CreditsStore:
                 unique_ids,
             ).fetchall()
 
+            promotion_rows = conn.execute(
+                f"""
+                SELECT user_id, COALESCE(SUM(amount_micro), 0) AS grant_micro
+                FROM credit_promotion_grants
+                WHERE user_id IN ({placeholders})
+                GROUP BY user_id
+                """,
+                unique_ids,
+            ).fetchall()
+
             usage_rows = conn.execute(
                 f"""
                 SELECT
@@ -739,6 +797,10 @@ class CreditsStore:
             )
             for row in rows
         }
+        for row in promotion_rows:
+            user_id = int(row["user_id"])
+            grant, purchased = amounts.get(user_id, (0, 0))
+            amounts[user_id] = (grant + int(row["grant_micro"]), purchased)
         usage_amounts = {
             int(row["user_id"]): (
                 int(row["grant_usage_micro"]),
@@ -775,6 +837,85 @@ class CreditsStore:
 
     def get_balance_micro(self, user_id: int) -> int:
         return self.get_balance_projection(user_id)["total_available_micro"]
+
+    def list_user_ids(self) -> list[int]:
+        """Return account IDs for an idempotent promotion backfill."""
+        with self._get_connection() as conn:
+            rows = conn.execute("SELECT id FROM users ORDER BY id").fetchall()
+        return [int(row["id"]) for row in rows]
+
+    def grant_promotion_credits(
+        self,
+        *,
+        user_id: int,
+        campaign_key: str,
+        amount_micro: int,
+        operation_id: str,
+        idempotency_key: str,
+        request_digest: str,
+        source: str,
+        reason: str,
+    ) -> dict[str, Any]:
+        """Post one system promotion grant, safely replayable by its key."""
+        _positive_integer(user_id, "user_id")
+        _required_text(campaign_key, "campaign_key", max_length=120)
+        _positive_integer(amount_micro, "amount_micro")
+        _required_text(operation_id, "operation_id")
+        _required_text(idempotency_key, "idempotency_key")
+        _required_text(request_digest, "request_digest")
+        _required_text(source, "source", max_length=120)
+        _required_text(reason, "reason", max_length=500)
+        with self._get_connection() as conn:
+            self._begin(conn)
+            self._ensure_account_in_transaction(conn, user_id)
+            existing = conn.execute(
+                """
+                SELECT * FROM credit_promotion_grants
+                WHERE idempotency_key = ? OR operation_id = ?
+                """,
+                (idempotency_key, operation_id),
+            ).fetchone()
+            if existing is not None:
+                if (
+                    existing["user_id"] != user_id
+                    or existing["campaign_key"] != campaign_key
+                    or int(existing["amount_micro"]) != amount_micro
+                    or existing["operation_id"] != operation_id
+                    or existing["idempotency_key"] != idempotency_key
+                    or existing["request_digest"] != request_digest
+                    or existing["source"] != source
+                    or existing["reason"] != reason
+                ):
+                    raise IdempotencyConflictError(
+                        "Promotion idempotency key conflicts with an existing grant"
+                    )
+                return {"created": False, "grant": dict(existing)}
+            conn.execute(
+                """
+                INSERT INTO credit_promotion_grants (
+                    user_id, campaign_key, amount_micro, operation_id,
+                    idempotency_key, request_digest, source, reason, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    user_id,
+                    campaign_key,
+                    amount_micro,
+                    operation_id,
+                    idempotency_key,
+                    request_digest,
+                    source,
+                    reason,
+                    _utcnow_iso(),
+                ),
+            )
+            row = conn.execute(
+                """
+                SELECT * FROM credit_promotion_grants WHERE idempotency_key = ?
+                """,
+                (idempotency_key,),
+            ).fetchone()
+            return {"created": True, "grant": dict(row)}
 
     @staticmethod
     def _llm_reservation_result_in_transaction(
@@ -1633,7 +1774,7 @@ class CreditsStore:
                     boundary = (str(legacy["created_at"]), "ledger", decoded)
                 else:
                     boundary = decoded
-            params: list[Any] = [user_id, user_id]
+            params: list[Any] = [user_id, user_id, user_id]
             cursor_sql = ""
             if boundary is not None:
                 created_at, source_kind, source_id = boundary
@@ -1684,10 +1825,30 @@ class CreditsStore:
                     GROUP BY user_id, reservation_id, run_id, call_index,
                              evidence_json, created_at
                 ),
+                promotion_activity AS (
+                    SELECT id AS source_id, 'promotion' AS source_kind,
+                           user_id, 'grant' AS bucket,
+                           'system_promotion_grant' AS entry_type,
+                           amount_micro,
+                           NULL AS payment_order_id,
+                           NULL AS refund_request_id,
+                           NULL AS stripe_event_id,
+                           'promotion:' || operation_id AS operation_key,
+                           operation_id, idempotency_key,
+                           request_digest, NULL AS actor_user_id,
+                           source, reason, 'promotion' AS reference_type,
+                           campaign_key AS reference_id, created_at,
+                           NULL AS reservation_id, NULL AS run_id,
+                           NULL AS call_index, NULL AS evidence_json
+                    FROM credit_promotion_grants
+                    WHERE user_id = ?
+                ),
                 activity AS (
                     SELECT * FROM historical_activity
                     UNION ALL
                     SELECT * FROM llm_activity
+                    UNION ALL
+                    SELECT * FROM promotion_activity
                 )
                 SELECT * FROM activity
                 {cursor_sql}

--- a/dashboard/backend/domain/credits/repository_common.py
+++ b/dashboard/backend/domain/credits/repository_common.py
@@ -105,7 +105,7 @@ def encode_activity_cursor(
 
     if not isinstance(created_at, str) or not created_at or len(created_at) > 64:
         raise ValueError("invalid activity cursor")
-    if source_kind not in {"ledger", "llm_usage"}:
+    if source_kind not in {"ledger", "llm_usage", "promotion"}:
         raise ValueError("invalid activity cursor")
     try:
         source_id = _positive_integer(source_id, "source_id")
@@ -150,7 +150,7 @@ def decode_activity_cursor(cursor: str | int) -> tuple[str, str, int] | int:
         not isinstance(created_at, str)
         or not created_at
         or len(created_at) > 64
-        or source_kind not in {"ledger", "llm_usage"}
+        or source_kind not in {"ledger", "llm_usage", "promotion"}
         or isinstance(source_id, bool)
         or not isinstance(source_id, int)
         or source_id <= 0

--- a/dashboard/backend/domain/credits/repository_postgres.py
+++ b/dashboard/backend/domain/credits/repository_postgres.py
@@ -223,6 +223,27 @@ CREATE TABLE IF NOT EXISTS credit_grant_pool_ledger_entries (
 CREATE INDEX IF NOT EXISTS idx_credit_grant_pool_ledger_pool_id
 ON credit_grant_pool_ledger_entries(pool_id, id DESC);
 
+CREATE TABLE IF NOT EXISTS credit_promotion_grants (
+    id BIGSERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    campaign_key TEXT NOT NULL CHECK (length(trim(campaign_key)) > 0),
+    amount_micro BIGINT NOT NULL CHECK (amount_micro > 0),
+    operation_id TEXT NOT NULL UNIQUE CHECK (length(trim(operation_id)) > 0),
+    idempotency_key TEXT NOT NULL UNIQUE
+        CHECK (length(trim(idempotency_key)) > 0),
+    request_digest TEXT NOT NULL CHECK (length(trim(request_digest)) > 0),
+    source TEXT NOT NULL CHECK (length(trim(source)) > 0),
+    reason TEXT NOT NULL CHECK (length(trim(reason)) > 0),
+    created_at TEXT NOT NULL,
+    UNIQUE (campaign_key, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_credit_promotion_grants_user_id
+ON credit_promotion_grants(user_id, id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_credit_promotion_grants_campaign_user
+ON credit_promotion_grants(campaign_key, user_id);
+
 CREATE TABLE IF NOT EXISTS credit_llm_reservations (
     reservation_id TEXT PRIMARY KEY CHECK (length(trim(reservation_id)) > 0),
     user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
@@ -544,6 +565,16 @@ class PostgresCreditsStore:
                 rows = cur.fetchall()
                 cur.execute(
                     """
+                    SELECT user_id, COALESCE(SUM(amount_micro), 0) AS grant_micro
+                    FROM credit_promotion_grants
+                    WHERE user_id = ANY(%s)
+                    GROUP BY user_id
+                    """,
+                    (unique_ids,),
+                )
+                promotion_rows = cur.fetchall()
+                cur.execute(
+                    """
                     SELECT
                         user_id,
                         COALESCE(SUM(CASE WHEN bucket = 'grant' THEN amount_micro ELSE 0 END), 0)
@@ -578,6 +609,10 @@ class PostgresCreditsStore:
             )
             for row in rows
         }
+        for row in promotion_rows:
+            user_id = int(row["user_id"])
+            grant, purchased = amounts.get(user_id, (0, 0))
+            amounts[user_id] = (grant + int(row["grant_micro"]), purchased)
         usage_amounts = {
             int(row["user_id"]): (
                 int(row["grant_usage_micro"]),
@@ -610,6 +645,93 @@ class PostgresCreditsStore:
 
     def get_balance_micro(self, user_id: int) -> int:
         return self.get_balance_projection(user_id)["total_available_micro"]
+
+    def list_user_ids(self) -> list[int]:
+        """Return account IDs for an idempotent promotion backfill."""
+        with self._get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT id FROM users ORDER BY id")
+                rows = cur.fetchall()
+        return [int(row["id"]) for row in rows]
+
+    def grant_promotion_credits(
+        self,
+        *,
+        user_id: int,
+        campaign_key: str,
+        amount_micro: int,
+        operation_id: str,
+        idempotency_key: str,
+        request_digest: str,
+        source: str,
+        reason: str,
+    ) -> dict[str, Any]:
+        """Post one system promotion grant, safely replayable by its key."""
+        _positive_integer(user_id, "user_id")
+        _required_text(campaign_key, "campaign_key", max_length=120)
+        _positive_integer(amount_micro, "amount_micro")
+        _required_text(operation_id, "operation_id")
+        _required_text(idempotency_key, "idempotency_key")
+        _required_text(request_digest, "request_digest")
+        _required_text(source, "source", max_length=120)
+        _required_text(reason, "reason", max_length=500)
+        with self._get_connection() as conn:
+            with conn.cursor() as cur:
+                self._ensure_account_in_transaction(cur, user_id)
+                for lock_key in sorted(
+                    {
+                        f"promotion-idempotency:{idempotency_key}",
+                        f"promotion-operation:{operation_id}",
+                    }
+                ):
+                    cur.execute(
+                        "SELECT pg_advisory_xact_lock(hashtext(%s))", (lock_key,)
+                    )
+                cur.execute(
+                    """
+                    SELECT * FROM credit_promotion_grants
+                    WHERE idempotency_key = %s OR operation_id = %s
+                    FOR UPDATE
+                    """,
+                    (idempotency_key, operation_id),
+                )
+                existing = cur.fetchone()
+                if existing is not None:
+                    if (
+                        existing["user_id"] != user_id
+                        or existing["campaign_key"] != campaign_key
+                        or int(existing["amount_micro"]) != amount_micro
+                        or existing["operation_id"] != operation_id
+                        or existing["idempotency_key"] != idempotency_key
+                        or existing["request_digest"] != request_digest
+                        or existing["source"] != source
+                        or existing["reason"] != reason
+                    ):
+                        raise IdempotencyConflictError(
+                            "Promotion idempotency key conflicts with an existing grant"
+                        )
+                    return {"created": False, "grant": dict(existing)}
+                cur.execute(
+                    """
+                    INSERT INTO credit_promotion_grants (
+                        user_id, campaign_key, amount_micro, operation_id,
+                        idempotency_key, request_digest, source, reason, created_at
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    RETURNING *
+                    """,
+                    (
+                        user_id,
+                        campaign_key,
+                        amount_micro,
+                        operation_id,
+                        idempotency_key,
+                        request_digest,
+                        source,
+                        reason,
+                        _utcnow_iso(),
+                    ),
+                )
+                return {"created": True, "grant": dict(cur.fetchone())}
 
     @staticmethod
     def _llm_reservation_result(cur, reservation) -> dict[str, Any]:
@@ -1274,6 +1396,16 @@ class PostgresCreditsStore:
         if through_entry_id is None:
             cur.execute(
                 """
+                SELECT COALESCE(SUM(amount_micro), 0) AS grant_micro
+                FROM credit_promotion_grants
+                WHERE user_id = %s
+                """,
+                (user_id,),
+            )
+            promotion = cur.fetchone()
+            grant_micro += int(promotion["grant_micro"])
+            cur.execute(
+                """
                 SELECT
                     COALESCE(SUM(CASE WHEN bucket = 'grant' THEN amount_micro ELSE 0 END), 0)
                         AS grant_usage_micro,
@@ -1432,7 +1564,7 @@ class PostgresCreditsStore:
                         boundary = (str(legacy["created_at"]), "ledger", decoded)
                     else:
                         boundary = decoded
-                params: list[Any] = [user_id, user_id]
+                params: list[Any] = [user_id, user_id, user_id]
                 cursor_sql = ""
                 if boundary is not None:
                     created_at, source_kind, source_id = boundary
@@ -1484,10 +1616,32 @@ class PostgresCreditsStore:
                         GROUP BY user_id, reservation_id, run_id, call_index,
                                  evidence_json, created_at
                     ),
+                    promotion_activity AS (
+                        SELECT id AS source_id, 'promotion' AS source_kind,
+                               user_id, 'grant'::TEXT AS bucket,
+                               'system_promotion_grant' AS entry_type,
+                               amount_micro,
+                               NULL::TEXT AS payment_order_id,
+                               NULL::TEXT AS refund_request_id,
+                               NULL::TEXT AS stripe_event_id,
+                               'promotion:' || operation_id AS operation_key,
+                               operation_id, idempotency_key, request_digest,
+                               NULL::INTEGER AS actor_user_id,
+                               source, reason, 'promotion'::TEXT AS reference_type,
+                               campaign_key AS reference_id, created_at,
+                               NULL::TEXT AS reservation_id,
+                               NULL::TEXT AS run_id,
+                               NULL::BIGINT AS call_index,
+                               NULL::TEXT AS evidence_json
+                        FROM credit_promotion_grants
+                        WHERE user_id = %s
+                    ),
                     activity AS (
                         SELECT * FROM historical_activity
                         UNION ALL
                         SELECT * FROM llm_activity
+                        UNION ALL
+                        SELECT * FROM promotion_activity
                     )
                     SELECT * FROM activity
                     {cursor_sql}

--- a/dashboard/backend/domain/credits/service.py
+++ b/dashboard/backend/domain/credits/service.py
@@ -38,6 +38,12 @@ from dashboard.backend.domain.credits.stripe_gateway import (
 from dashboard.backend.domain.analytics import instrumentation as analytics_instrumentation
 
 
+DEFAULT_SIGNUP_CREDIT_CAMPAIGN = "default_signup_credits_v1"
+DEFAULT_SIGNUP_CREDITS_MICRO = 1_500_000
+DEFAULT_SIGNUP_CREDIT_SOURCE = "system_promotion"
+DEFAULT_SIGNUP_CREDIT_REASON = "Automatic welcome Credits."
+
+
 class CreditsServiceError(RuntimeError):
     """A sanitized, expected billing-domain failure."""
 
@@ -128,6 +134,41 @@ class CreditsService:
             account_status=account["status"],
             billing_available=(True if config is None else bool(config.ready)),
         )
+
+    def grant_default_signup_credits(self, user_id: int) -> bool:
+        """Give one account this campaign's welcome grant exactly once."""
+        user_id = int(user_id)
+        parts = {
+            "campaign_key": DEFAULT_SIGNUP_CREDIT_CAMPAIGN,
+            "user_id": user_id,
+            "amount_micro": DEFAULT_SIGNUP_CREDITS_MICRO,
+            "source": DEFAULT_SIGNUP_CREDIT_SOURCE,
+            "reason": DEFAULT_SIGNUP_CREDIT_REASON,
+        }
+        result = self.store.grant_promotion_credits(
+            **parts,
+            operation_id=_operation_id(
+                "promotion", DEFAULT_SIGNUP_CREDIT_CAMPAIGN, user_id
+            ),
+            idempotency_key=(
+                f"promotion:{DEFAULT_SIGNUP_CREDIT_CAMPAIGN}:user:{user_id}"
+            ),
+            request_digest=_canonical_digest(parts),
+        )
+        return bool(result["created"])
+
+    def backfill_default_signup_credits(self) -> dict[str, int]:
+        """Replay the welcome campaign across every durable user account."""
+        user_ids = self.store.list_user_ids()
+        report = {"total": len(user_ids), "granted": 0, "existing": 0, "failed": 0}
+        for user_id in user_ids:
+            try:
+                created = self.grant_default_signup_credits(user_id)
+            except Exception:  # noqa: BLE001 - continue so one row cannot block all
+                report["failed"] += 1
+            else:
+                report["granted" if created else "existing"] += 1
+        return report
 
     @staticmethod
     def _month_start_iso() -> str:

--- a/dashboard/backend/tests/domain/credits/test_promotion_grants.py
+++ b/dashboard/backend/tests/domain/credits/test_promotion_grants.py
@@ -1,0 +1,163 @@
+"""Welcome Credits are auditable, spendable, and exactly-once per user."""
+
+from __future__ import annotations
+
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from dashboard.backend.domain.credits.repository import CreditsStore
+from dashboard.backend.domain.credits.repository_common import (
+    CreditAccountRestrictedStoreError,
+)
+from dashboard.backend.domain.credits.service import (
+    DEFAULT_SIGNUP_CREDIT_CAMPAIGN,
+    DEFAULT_SIGNUP_CREDITS_MICRO,
+    CreditsService,
+)
+
+
+def _store(tmp_path, *, user_count: int = 2) -> CreditsStore:
+    path = tmp_path / "promotion.db"
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE users (
+                id INTEGER PRIMARY KEY,
+                email TEXT NOT NULL UNIQUE,
+                display_name TEXT NOT NULL,
+                password_hash TEXT NOT NULL,
+                role TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            )
+            """
+        )
+        conn.executemany(
+            """
+            INSERT INTO users (
+                id, email, display_name, password_hash, role, created_at
+            ) VALUES (?, ?, ?, 'unused', 'user', '2026-08-28T00:00:00+00:00')
+            """,
+            [
+                (user_id, f"user{user_id}@example.com", f"User {user_id}")
+                for user_id in range(1, user_count + 1)
+            ],
+        )
+    return CreditsStore(path)
+
+
+def test_welcome_grant_is_exactly_once_and_visible_in_activity(tmp_path):
+    store = _store(tmp_path)
+    service = CreditsService(store=store)
+
+    assert service.grant_default_signup_credits(1) is True
+    assert service.grant_default_signup_credits(1) is False
+
+    balance = service.get_balance(1)
+    assert balance.grant_available_micro == DEFAULT_SIGNUP_CREDITS_MICRO
+    assert balance.display_grant_credits == "1.500000"
+    activity = service.list_ledger(1, limit=10, cursor=None)["items"]
+    assert len(activity) == 1
+    assert activity[0]["entry_type"] == "system_promotion_grant"
+    assert activity[0]["reference_type"] == "promotion"
+    assert activity[0]["reference_id"] == DEFAULT_SIGNUP_CREDIT_CAMPAIGN
+    assert activity[0]["actor_user_id"] is None
+
+
+def test_promotion_activity_cursor_can_page_into_older_entries(tmp_path):
+    store = _store(tmp_path, user_count=1)
+    service = CreditsService(store=store)
+    service.grant_default_signup_credits(1)
+    with sqlite3.connect(str(store.db_path)) as conn:
+        conn.execute(
+            """
+            INSERT INTO credit_ledger_entries (
+                user_id, bucket, entry_type, amount_micro,
+                operation_key, operation_id, idempotency_key, request_digest,
+                actor_user_id, source, reason, reference_type, reference_id,
+                created_at
+            ) VALUES (
+                1, 'grant', 'admin_grant_assign', 250000,
+                'older-grant-operation:user', 'older-grant-operation',
+                'older-grant-idempotency:user', 'older-grant-digest',
+                1, 'test', 'Older grant.', 'grant_pool', 'test',
+                '2026-08-27T00:00:00+00:00'
+            )
+            """
+        )
+
+    first_page = service.list_ledger(1, limit=1, cursor=None)
+    assert first_page["items"][0]["entry_type"] == "system_promotion_grant"
+    assert first_page["next_cursor"]
+
+    second_page = service.list_ledger(1, limit=1, cursor=first_page["next_cursor"])
+    assert second_page["items"][0]["entry_type"] == "admin_grant_assign"
+
+
+def test_concurrent_welcome_grants_create_only_one_credit_lot(tmp_path):
+    store = _store(tmp_path)
+
+    def grant() -> bool:
+        return CreditsService(
+            store=CreditsStore(store.db_path)
+        ).grant_default_signup_credits(1)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        outcomes = list(executor.map(lambda _: grant(), range(2)))
+
+    assert sorted(outcomes) == [False, True]
+    assert store.get_balance_micro(1) == DEFAULT_SIGNUP_CREDITS_MICRO
+
+
+def test_backfill_is_rerunnable_and_covers_every_user(tmp_path):
+    store = _store(tmp_path, user_count=3)
+    service = CreditsService(store=store)
+
+    assert service.backfill_default_signup_credits() == {
+        "total": 3,
+        "granted": 3,
+        "existing": 0,
+        "failed": 0,
+    }
+    assert service.backfill_default_signup_credits() == {
+        "total": 3,
+        "granted": 0,
+        "existing": 3,
+        "failed": 0,
+    }
+    assert service.get_balance_projections([1, 2, 3])[3].grant_available_micro == (
+        DEFAULT_SIGNUP_CREDITS_MICRO
+    )
+
+
+def test_welcome_grant_funds_platform_credit_reservations(tmp_path):
+    store = _store(tmp_path)
+    service = CreditsService(store=store)
+    service.grant_default_signup_credits(1)
+
+    reservation = service.reserve_llm_credits(
+        user_id=1,
+        run_id="welcome-credit-run",
+        call_index=0,
+        amount_micro=1_000_000,
+    )
+
+    assert reservation.status == "open"
+    assert service.get_balance(1).grant_available_micro == 500_000
+
+
+def test_restricted_account_receives_campaign_but_cannot_spend_it(tmp_path):
+    store = _store(tmp_path)
+    service = CreditsService(store=store)
+    store.restrict_account(1)
+
+    assert service.grant_default_signup_credits(1) is True
+    assert store.get_balance_micro(1) == DEFAULT_SIGNUP_CREDITS_MICRO
+    with pytest.raises(CreditAccountRestrictedStoreError):
+        service.reserve_llm_credits(
+            user_id=1,
+            run_id="restricted-run",
+            call_index=0,
+            amount_micro=1,
+        )

--- a/dashboard/backend/tests/domain/credits/test_repository_postgres.py
+++ b/dashboard/backend/tests/domain/credits/test_repository_postgres.py
@@ -48,6 +48,16 @@ def test_build_credits_store_defaults_to_sqlite(monkeypatch, capsys):
     )
 
 
+def test_postgres_schema_declares_the_welcome_promotion_ledger():
+    ddl = pg_module.CREDITS_POSTGRES_DDL
+
+    assert "CREATE TABLE IF NOT EXISTS credit_promotion_grants" in ddl
+    assert "campaign_key TEXT NOT NULL" in ddl
+    assert "operation_id TEXT NOT NULL UNIQUE" in ddl
+    assert "idempotency_key TEXT NOT NULL UNIQUE" in ddl
+    assert "UNIQUE (campaign_key, user_id)" in ddl
+
+
 def test_build_credits_store_picks_postgres_from_users_url(monkeypatch, capsys):
     created = {}
 

--- a/dashboard/backend/tests/domain/credits/test_service.py
+++ b/dashboard/backend/tests/domain/credits/test_service.py
@@ -107,7 +107,7 @@ def _checkout(service, *, cents=None, request_id=CLIENT_REQUEST_ID):
         if cents is not None
         else CheckoutRequest(
             client_request_id=request_id,
-            package_id="usd_10",
+            package_id="usd_5",
         )
     )
     return service.create_checkout(1, request)
@@ -180,7 +180,7 @@ def _refund_event(
 
 @pytest.mark.parametrize(
     ("package_id", "cents"),
-    [("usd_5", 500), ("usd_10", 1000), ("usd_20", 2000), ("usd_50", 5000)],
+    [("usd_0_50", 50), ("usd_1", 100), ("usd_2", 200), ("usd_5", 500)],
 )
 def test_fixed_packages_are_resolved_server_side(package_id, cents):
     request = CheckoutRequest(
@@ -192,7 +192,7 @@ def test_fixed_packages_are_resolved_server_side(package_id, cents):
     assert credits_micro_for_cents(cents) == cents * 10_000
 
 
-@pytest.mark.parametrize("cents", [500, 501, 20_000])
+@pytest.mark.parametrize("cents", [50, 51, 500])
 def test_custom_amount_accepts_integer_cent_boundaries(cents):
     request = CheckoutRequest(
         client_request_id=CLIENT_REQUEST_ID,
@@ -202,12 +202,21 @@ def test_custom_amount_accepts_integer_cent_boundaries(cents):
     assert request.amount_usd_cents == cents
 
 
-@pytest.mark.parametrize("cents", [499, 20_001, 500.0, True])
+@pytest.mark.parametrize("cents", [49, 501, 50.0, True])
 def test_custom_amount_rejects_out_of_range_or_non_integer_values(cents):
     with pytest.raises(ValidationError):
         CheckoutRequest(
             client_request_id=CLIENT_REQUEST_ID,
             custom_amount_usd_cents=cents,
+        )
+
+
+@pytest.mark.parametrize("package_id", ["usd_10", "usd_20", "usd_50"])
+def test_retired_large_packages_are_rejected(package_id):
+    with pytest.raises(ValidationError):
+        CheckoutRequest(
+            client_request_id=CLIENT_REQUEST_ID,
+            package_id=package_id,
         )
 
 
@@ -282,7 +291,7 @@ def test_same_client_request_cannot_change_the_purchase_amount(tmp_path):
     _checkout(service)
 
     with pytest.raises(OrderConflictError, match="different purchase"):
-        _checkout(service, cents=500)
+        _checkout(service, cents=400)
 
 
 def test_checkout_gateway_timeout_leaves_one_retryable_pending_order(tmp_path):
@@ -309,9 +318,9 @@ def test_paid_checkout_posts_once_and_duplicate_events_are_noops(tmp_path):
     gateway.event = _checkout_event(checkout, event_id="evt_checkout_paid_again")
     second_event = service.handle_webhook(b"paid-again", "valid")
 
-    assert first.balance_micro == 10_000_000
+    assert first.balance_micro == 5_000_000
     assert duplicate.outcome == second_event.outcome == "duplicate"
-    assert service.get_balance(1).balance_micro == 10_000_000
+    assert service.get_balance(1).balance_micro == 5_000_000
     assert len(service.store.list_ledger_entries(1)["items"]) == 1
 
 
@@ -424,7 +433,7 @@ def test_admin_refund_reserves_calls_stripe_and_settles_negative_entry(tmp_path)
     settled = service.handle_webhook(b"refund", "valid")
 
     assert settled.outcome == "processed"
-    assert settled.balance_micro == 6_000_000
+    assert settled.balance_micro == 1_000_000
     assert service.store.get_order_for_admin(checkout.order_id)["status"] == (
         "partially_refunded"
     )
@@ -453,9 +462,9 @@ def test_duplicate_refund_events_never_reverse_credits_twice(tmp_path):
     )
     second_event = service.handle_webhook(b"refund-again", "valid")
 
-    assert first.balance_micro == 6_000_000
+    assert first.balance_micro == 1_000_000
     assert duplicate.outcome == second_event.outcome == "duplicate"
-    assert service.get_balance(1).balance_micro == 6_000_000
+    assert service.get_balance(1).balance_micro == 1_000_000
     assert len(service.store.list_ledger_entries(1)["items"]) == 2
 
 
@@ -491,8 +500,8 @@ def test_pending_refund_event_records_no_credit_change_then_success_can_settle(
     succeeded = service.handle_webhook(b"succeeded", "valid")
 
     assert pending.outcome == "ignored"
-    assert balance_while_pending == 10_000_000
-    assert succeeded.balance_micro == 6_000_000
+    assert balance_while_pending == 5_000_000
+    assert succeeded.balance_micro == 1_000_000
 
 
 def test_live_mode_refund_is_rejected_without_balance_change(tmp_path):
@@ -512,7 +521,7 @@ def test_live_mode_refund_is_rejected_without_balance_change(tmp_path):
     result = service.handle_webhook(b"live-refund", "valid")
 
     assert result.outcome == "rejected"
-    assert service.get_balance(1).balance_micro == 10_000_000
+    assert service.get_balance(1).balance_micro == 5_000_000
 
 
 def test_refund_gateway_timeout_keeps_one_retryable_reservation(tmp_path):
@@ -536,7 +545,7 @@ def test_refund_gateway_timeout_keeps_one_retryable_reservation(tmp_path):
         gateway.refund_calls[1]["idempotency_key"]
     )
     assert (
-        service.store.list_orders_for_admin()["items"][0]["refundable_usd_cents"] == 600
+        service.store.list_orders_for_admin()["items"][0]["refundable_usd_cents"] == 100
     )
 
 
@@ -547,7 +556,7 @@ def test_failed_refund_event_releases_reservation(tmp_path):
     request = AdminRefundRequest(
         client_request_id=UUID("44444444-4444-4444-8444-444444444444"),
         payment_order_id=checkout.order_id,
-        amount_usd_cents=1000,
+        amount_usd_cents=500,
     )
     refund = service.create_admin_refund(2, request)
     gateway.event = _refund_event(
@@ -562,7 +571,7 @@ def test_failed_refund_event_releases_reservation(tmp_path):
     assert failed.outcome == "processed"
     assert (
         service.store.list_orders_for_admin()["items"][0]["refundable_usd_cents"]
-        == 1000
+        == 500
     )
 
 
@@ -585,11 +594,11 @@ def test_succeeded_dashboard_refund_is_reconciled_without_local_metadata(tmp_pat
     reconciled = service.handle_webhook(b"external", "valid")
 
     assert reconciled.outcome == "processed"
-    assert reconciled.balance_micro == 6_000_000
+    assert reconciled.balance_micro == 1_000_000
     ledger = service.store.list_ledger_entries(1)["items"]
     assert sorted(entry["amount_micro"] for entry in ledger) == [
         -4_000_000,
-        10_000_000,
+        5_000_000,
     ]
 
 
@@ -615,7 +624,7 @@ def test_unaffordable_dashboard_refund_restricts_account(tmp_path):
     assert result.account_restricted is True
     admin_order = service.store.list_orders_for_admin()["items"][0]
     assert admin_order["account_status"] == "restricted"
-    assert service.get_balance(1).balance_micro == 10_000_000
+    assert service.get_balance(1).balance_micro == 5_000_000
 
 
 class RefundCreationResultFixture:

--- a/dashboard/backend/tests/integration/test_credits_checkout_flow.py
+++ b/dashboard/backend/tests/integration/test_credits_checkout_flow.py
@@ -172,11 +172,11 @@ def _checkout(flow, token, *, request_id="11111111-1111-4111-8111-111111111111")
     return flow.client.post(
         "/api/credits/checkout-sessions",
         headers=_auth(token),
-        json={"client_request_id": request_id, "package_id": "usd_10"},
+        json={"client_request_id": request_id, "package_id": "usd_5"},
     )
 
 
-def _checkout_object(checkout, user_id, *, amount=1000, payment_status="paid"):
+def _checkout_object(checkout, user_id, *, amount=500, payment_status="paid"):
     return {
         "id": checkout["checkout_session_id"],
         "object": "checkout.session",
@@ -188,7 +188,7 @@ def _checkout_object(checkout, user_id, *, amount=1000, payment_status="paid"):
         "metadata": {
             "atl_order_id": checkout["order_id"],
             "atl_user_reference": str(user_id),
-            "atl_credits_micro": "10000000",
+            "atl_credits_micro": "5000000",
         },
     }
 
@@ -231,7 +231,7 @@ def test_purchase_replay_refund_and_portfolio_cash_are_isolated(checkout_flow):
     )
     assert paid.status_code == replay.status_code == 200
     assert replay.json()["result"]["outcome"] == "duplicate"
-    assert flow.credits.get_balance_micro(buyer["id"]) == 10_000_000
+    assert flow.credits.get_balance_micro(buyer["id"]) == 5_000_000
 
     refund_response = flow.client.post(
         "/api/admin/credits/refunds",
@@ -260,12 +260,12 @@ def test_purchase_replay_refund_and_portfolio_cash_are_isolated(checkout_flow):
         data_object=refund_object,
     )
     assert settled.status_code == 200, settled.text
-    assert settled.json()["result"]["balance_micro"] == 6_000_000
+    assert settled.json()["result"]["balance_micro"] == 1_000_000
 
     ledger = flow.client.get(
         "/api/credits/ledger", headers=_auth(buyer_token)
     ).json()["items"]
-    assert [entry["amount_micro"] for entry in ledger] == [-4_000_000, 10_000_000]
+    assert [entry["amount_micro"] for entry in ledger] == [-4_000_000, 5_000_000]
     portfolio_after = flow.client.get(
         "/api/v1/portfolio", headers=_auth(buyer_token)
     ).json()["portfolio"]
@@ -373,4 +373,4 @@ def test_checkout_timeout_refund_replay_and_over_refund_are_bounded(checkout_flo
     assert first_refund.json() == repeated_refund.json()
     assert flow.refunds.calls[0][1]["idempotency_key"] == flow.refunds.calls[1][1]["idempotency_key"]
     assert over_refund.status_code == 409
-    assert flow.credits.get_balance_micro(buyer["id"]) == 10_000_000
+    assert flow.credits.get_balance_micro(buyer["id"]) == 5_000_000

--- a/dashboard/backend/tests/test_auth.py
+++ b/dashboard/backend/tests/test_auth.py
@@ -32,11 +32,43 @@ def temp_user_store():
 @pytest.fixture
 def client(temp_user_store, monkeypatch):
     from dashboard.backend import users
+    from dashboard.backend.api import auth
+    from dashboard.backend.domain.credits.repository import CreditsStore
+    from dashboard.backend.domain.credits.service import CreditsService
 
     monkeypatch.setattr(users, "user_store", temp_user_store)
+    monkeypatch.setattr(
+        auth,
+        "credits_service",
+        CreditsService(store=CreditsStore(temp_user_store.db_path)),
+    )
     # The process-global auth limiters are reset by conftest's autouse
     # _reset_shared_scale_state, which pytest runs before this fixture.
     return TestClient(app)
+
+
+def test_signup_and_login_keep_one_welcome_credit_grant(client):
+    from dashboard.backend.api import auth
+
+    signup = client.post(
+        "/api/auth/signup",
+        json={
+            "email": "welcome@example.com",
+            "display_name": "Welcome",
+            "password": "securepass1",
+        },
+    )
+    assert signup.status_code == 200
+    user_id = signup.json()["user"]["id"]
+    assert auth.credits_service.get_balance(user_id).display_credits == "1.500000"
+
+    login = client.post(
+        "/api/auth/login",
+        json={"email": "welcome@example.com", "password": "securepass1"},
+    )
+    assert login.status_code == 200
+    activity = auth.credits_service.list_ledger(user_id, limit=10, cursor=None)
+    assert len(activity["items"]) == 1
 
 
 def test_api_health(client):

--- a/dashboard/backend/tests/test_credits_api.py
+++ b/dashboard/backend/tests/test_credits_api.py
@@ -114,11 +114,11 @@ def _checkout(client, token, *, request_id="11111111-1111-4111-8111-111111111111
     return client.post(
         "/api/credits/checkout-sessions",
         headers=_auth(token),
-        json={"client_request_id": request_id, "package_id": "usd_10"},
+        json={"client_request_id": request_id, "package_id": "usd_5"},
     )
 
 
-def _paid_checkout_event(checkout: dict, *, amount=1000, event_id="evt_paid"):
+def _paid_checkout_event(checkout: dict, *, amount=500, event_id="evt_paid"):
     return StripeWebhookEvent(
         event_id=event_id,
         event_type="checkout.session.completed",
@@ -135,7 +135,7 @@ def _paid_checkout_event(checkout: dict, *, amount=1000, event_id="evt_paid"):
             "metadata": {
                 "atl_order_id": checkout["order_id"],
                 "atl_user_reference": "1",
-                "atl_credits_micro": "10000000",
+                "atl_credits_micro": "5000000",
             },
         },
     )
@@ -194,8 +194,8 @@ def test_balance_ledger_and_order_return_only_public_fields(billing_api):
     assert checkout_response.status_code == 200
     assert checkout_response.json()["test_mode"] is True
     assert paid.status_code == 200
-    assert paid.json()["result"]["balance_micro"] == 10_000_000
-    assert ledger.json()["items"][0]["amount_micro"] == 10_000_000
+    assert paid.json()["result"]["balance_micro"] == 5_000_000
+    assert ledger.json()["items"][0]["amount_micro"] == 5_000_000
     assert ledger.json()["items"][0]["bucket"] == "purchased"
     assert ledger.json()["items"][0]["source"] == "stripe"
     assert ledger.json()["items"][0]["reason"] == "Stripe checkout purchase."
@@ -277,16 +277,41 @@ def test_checkout_input_is_server_allowlisted_and_idempotent(billing_api):
             "custom_amount_usd_cents": 500.0,
         },
     )
+    too_small = billing_api.client.post(
+        "/api/credits/checkout-sessions",
+        headers=_auth(token),
+        json={
+            "client_request_id": "44444444-4444-4444-8444-444444444444",
+            "custom_amount_usd_cents": 49,
+        },
+    )
+    too_large = billing_api.client.post(
+        "/api/credits/checkout-sessions",
+        headers=_auth(token),
+        json={
+            "client_request_id": "55555555-5555-4555-8555-555555555555",
+            "custom_amount_usd_cents": 501,
+        },
+    )
+    retired = billing_api.client.post(
+        "/api/credits/checkout-sessions",
+        headers=_auth(token),
+        json={
+            "client_request_id": "66666666-6666-4666-8666-666666666666",
+            "package_id": "usd_10",
+        },
+    )
     first = _checkout(billing_api.client, token)
     retried = _checkout(billing_api.client, token)
 
     assert tampered.status_code == float_amount.status_code == 422
+    assert too_small.status_code == too_large.status_code == retired.status_code == 422
     assert first.status_code == retried.status_code == 200
     assert first.json() == retried.json()
     first_call, second_call = billing_api.gateway.checkout_calls[-2:]
     assert first_call["idempotency_key"] == second_call["idempotency_key"]
-    assert first_call["amount_usd_cents"] == 1000
-    assert first_call["credits_micro"] == 10_000_000
+    assert first_call["amount_usd_cents"] == 500
+    assert first_call["credits_micro"] == 5_000_000
 
 
 def test_forged_or_tampered_webhook_never_changes_balance(billing_api):
@@ -319,7 +344,7 @@ def test_duplicate_webhook_returns_fast_success_without_double_credit(billing_ap
 
     assert first.status_code == duplicate.status_code == 200
     assert duplicate.json()["result"]["outcome"] == "duplicate"
-    assert billing_api.store.get_balance_micro(1) == 10_000_000
+    assert billing_api.store.get_balance_micro(1) == 5_000_000
 
 
 def test_other_users_order_is_hidden_as_not_found(billing_api):
@@ -360,7 +385,7 @@ def test_admin_gate_and_refund_flow(billing_api):
     )
 
     assert listed.status_code == 200
-    assert listed.json()["items"][0]["refundable_usd_cents"] == 1000
+    assert listed.json()["items"][0]["refundable_usd_cents"] == 500
     assert "stripe_payment_intent_id" not in str(listed.json())
     assert refund.status_code == 200
     assert refund.json()["refund"]["amount_usd_cents"] == 400

--- a/dashboard/backend/tests/test_credits_api_review_fixes.py
+++ b/dashboard/backend/tests/test_credits_api_review_fixes.py
@@ -58,7 +58,7 @@ def test_checkout_reports_bad_billing_config_as_503_not_422(billing_api):
         headers=_auth(token),
         json={
             "client_request_id": "22222222-2222-4222-8222-222222222222",
-            "package_id": "usd_10",
+            "package_id": "usd_5",
         },
     )
 
@@ -195,7 +195,7 @@ def test_admin_can_reinstate_a_restricted_account(billing_api):
         headers=_auth(token),
         json={
             "client_request_id": "33333333-3333-4333-8333-333333333333",
-            "package_id": "usd_10",
+            "package_id": "usd_5",
         },
     )
     assert blocked.status_code == 403
@@ -211,7 +211,7 @@ def test_admin_can_reinstate_a_restricted_account(billing_api):
         headers=_auth(token),
         json={
             "client_request_id": "33333333-3333-4333-8333-333333333333",
-            "package_id": "usd_10",
+            "package_id": "usd_5",
         },
     )
     assert allowed.status_code == 200

--- a/dashboard/backend/tests/test_credits_frontend.py
+++ b/dashboard/backend/tests/test_credits_frontend.py
@@ -17,12 +17,28 @@ def test_credits_page_is_reachable_from_the_account_menu():
     assert "navigateToPage('credits')" in APP_JS
 
 
-def test_credits_page_ships_test_mode_and_purchase_controls():
+def test_credits_page_ships_small_purchase_controls():
     assert 'id="creditsTestModeBadge"' in APP_HTML
     assert 'id="creditsBalance"' in APP_HTML
-    assert 'data-credit-package="usd_5"' in APP_HTML
-    assert 'data-credit-package="usd_50"' in APP_HTML
+    expected_packages = {
+        'data-credit-package="usd_0_50" data-credit-cents="50"',
+        'data-credit-package="usd_1" data-credit-cents="100"',
+        'data-credit-package="usd_2" data-credit-cents="200"',
+        'data-credit-package="usd_5" data-credit-cents="500"',
+    }
+    assert all(package in APP_HTML for package in expected_packages)
+    assert 'data-credit-package="usd_10"' not in APP_HTML
+    assert 'data-credit-package="usd_20"' not in APP_HTML
+    assert 'data-credit-package="usd_50"' not in APP_HTML
+    package_grid_start = APP_HTML.index('<div id="creditsPackageGrid"')
+    package_grid_end = APP_HTML.index('</div>', package_grid_start)
+    package_grid = APP_HTML[package_grid_start:package_grid_end]
+    assert package_grid.count('aria-checked="true"') == 1
+    assert 'aria-checked="true" data-credit-package="usd_1"' in package_grid
     assert 'id="creditsCustomAmount"' in APP_HTML
+    assert 'id="creditsCustomAmount" type="number"' in APP_HTML
+    assert 'min="0.50" max="5.00" step="0.01"' in APP_HTML
+    assert 'Minimum $0.50, maximum $5.00.' in APP_HTML
     assert 'id="creditsPurchaseBtn"' in APP_HTML
     assert 'id="creditsLedgerList"' in APP_HTML
 
@@ -45,6 +61,14 @@ def test_credits_client_keeps_stripe_authoritative():
     assert "/api/credits/orders/" in source
     assert "Payment confirmation pending" in source
     assert "checkout.session_id" not in source
+
+
+def test_credits_client_enforces_the_small_custom_range():
+    source = CREDITS_JS_PATH.read_text(encoding="utf-8")
+
+    assert "value: 'usd_1'" in source
+    assert "cents < 50 || cents > 500" in source
+    assert "Enter a custom amount from $0.50 through $5.00." in source
 
 
 def test_credits_api_values_never_enter_inner_html():

--- a/dashboard/backend/tests/test_credits_frontend.py
+++ b/dashboard/backend/tests/test_credits_frontend.py
@@ -85,6 +85,13 @@ def test_activity_renders_negative_model_usage_with_safe_context():
     assert "String(entry.run_id).slice(0, 12)" in source
 
 
+def test_activity_names_the_automatic_welcome_grant():
+    source = CREDITS_JS_PATH.read_text(encoding="utf-8")
+
+    assert "entry.entry_type === 'system_promotion_grant'" in source
+    assert "'Welcome Credits'" in source
+
+
 def test_refund_retry_reuses_its_request_id_only_while_unchanged():
     """The server derives the refund id from client_request_id.
 

--- a/dashboard/backend/tests/test_frontend_fast_boot.py
+++ b/dashboard/backend/tests/test_frontend_fast_boot.py
@@ -195,4 +195,4 @@ def test_cache_busters_bumped():
     assert "styles.css?v=125" in APP_HTML
     assert "js/leaderboard.js?v=32" in APP_HTML
     assert "home-page.js?v=50" in APP_HTML
-    assert "js/credits.js?v=4" in APP_HTML
+    assert "js/credits.js?v=5" in APP_HTML

--- a/dashboard/backend/tests/test_frontend_fast_boot.py
+++ b/dashboard/backend/tests/test_frontend_fast_boot.py
@@ -195,4 +195,4 @@ def test_cache_busters_bumped():
     assert "styles.css?v=125" in APP_HTML
     assert "js/leaderboard.js?v=32" in APP_HTML
     assert "home-page.js?v=50" in APP_HTML
-    assert "js/credits.js?v=5" in APP_HTML
+    assert "js/credits.js?v=6" in APP_HTML

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -2402,7 +2402,7 @@
     <script src="app.js?v=116" defer></script>
     <script src="js/analytics.js?v=1" defer></script>
     <script src="js/agent-editor.js?v=28" defer></script>
-    <script src="js/credits.js?v=4" defer></script>
+    <script src="js/credits.js?v=5" defer></script>
     <script src="js/admin-model-providers.js?v=1" defer></script>
     <script src="js/admin-credits.js?v=5" defer></script>
     <script src="js/admin-analytics.js?v=1" defer></script>

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -1893,18 +1893,18 @@
                         <span class="credits-rate">$1 = 1 Credit</span>
                     </div>
                     <div id="creditsPackageGrid" class="credits-package-grid" role="radiogroup" aria-label="Credit package">
+                        <button class="credits-package-btn" type="button" role="radio" aria-checked="false" data-credit-package="usd_0_50" data-credit-cents="50"><strong>$0.50</strong><span>0.5 Credits</span></button>
+                        <button class="credits-package-btn is-selected" type="button" role="radio" aria-checked="true" data-credit-package="usd_1" data-credit-cents="100"><strong>$1</strong><span>1 Credit</span></button>
+                        <button class="credits-package-btn" type="button" role="radio" aria-checked="false" data-credit-package="usd_2" data-credit-cents="200"><strong>$2</strong><span>2 Credits</span></button>
                         <button class="credits-package-btn" type="button" role="radio" aria-checked="false" data-credit-package="usd_5" data-credit-cents="500"><strong>$5</strong><span>5 Credits</span></button>
-                        <button class="credits-package-btn is-selected" type="button" role="radio" aria-checked="true" data-credit-package="usd_10" data-credit-cents="1000"><strong>$10</strong><span>10 Credits</span></button>
-                        <button class="credits-package-btn" type="button" role="radio" aria-checked="false" data-credit-package="usd_20" data-credit-cents="2000"><strong>$20</strong><span>20 Credits</span></button>
-                        <button class="credits-package-btn" type="button" role="radio" aria-checked="false" data-credit-package="usd_50" data-credit-cents="5000"><strong>$50</strong><span>50 Credits</span></button>
                     </div>
                     <div class="credits-custom-row">
                         <label for="creditsCustomAmount">Custom amount</label>
                         <div class="credits-money-input">
                             <span aria-hidden="true">$</span>
-                            <input id="creditsCustomAmount" inputmode="decimal" autocomplete="off" placeholder="5.00–200.00" aria-describedby="creditsCustomHint">
+                            <input id="creditsCustomAmount" type="number" min="0.50" max="5.00" step="0.01" inputmode="decimal" autocomplete="off" placeholder="0.50-5.00" aria-describedby="creditsCustomHint">
                         </div>
-                        <p id="creditsCustomHint">Minimum $5, maximum $200.</p>
+                        <p id="creditsCustomHint">Minimum $0.50, maximum $5.00.</p>
                     </div>
                     <button id="creditsPurchaseBtn" class="auth-btn auth-btn-primary credits-purchase-btn" type="button">
                         <svg aria-hidden="true"><use href="#icon-wallet"/></svg>
@@ -2402,7 +2402,7 @@
     <script src="app.js?v=116" defer></script>
     <script src="js/analytics.js?v=1" defer></script>
     <script src="js/agent-editor.js?v=28" defer></script>
-    <script src="js/credits.js?v=5" defer></script>
+    <script src="js/credits.js?v=6" defer></script>
     <script src="js/admin-model-providers.js?v=1" defer></script>
     <script src="js/admin-credits.js?v=5" defer></script>
     <script src="js/admin-analytics.js?v=1" defer></script>

--- a/dashboard/frontend/js/credits.js
+++ b/dashboard/frontend/js/credits.js
@@ -14,7 +14,7 @@
   const state = {
     initialized: false,
     user: null,
-    selection: { kind: 'package', value: 'usd_10' },
+    selection: { kind: 'package', value: 'usd_1' },
     pendingPurchase: null,
     pendingRefund: null,
     selectedAdminOrder: null,
@@ -522,8 +522,8 @@
       return { package_id: state.selection.value };
     }
     const cents = parseUsdCents(element('creditsCustomAmount')?.value);
-    if (cents === null || cents < 500 || cents > 20000) {
-      throw new Error('Enter a custom amount from $5.00 through $200.00.');
+    if (cents === null || cents < 50 || cents > 500) {
+      throw new Error('Enter a custom amount from $0.50 through $5.00.');
     }
     return { custom_amount_usd_cents: cents };
   }

--- a/dashboard/frontend/js/credits.js
+++ b/dashboard/frontend/js/credits.js
@@ -1,4 +1,4 @@
-/** Credits & Billing page. Stripe webhooks remain the only source of balance changes. */
+/** Credits & Billing page. Server ledgers remain the only source of balance changes. */
 (function () {
   'use strict';
 
@@ -453,10 +453,13 @@
       const meta = document.createElement('div');
       meta.className = 'credits-ledger-meta';
       const isUsage = entry.entry_type === 'llm_usage';
+      const isWelcomeGrant = entry.entry_type === 'system_promotion_grant';
       const isNegative = isUsage || entry.entry_type === 'refund';
       const title = isUsage
         ? 'Model usage'
-        : (entry.entry_type === 'refund' ? 'Refund' : 'Credit purchase');
+        : (entry.entry_type === 'refund'
+          ? 'Refund'
+          : (isWelcomeGrant ? 'Welcome Credits' : 'Credit purchase'));
       meta.appendChild(textNode('strong', '', title));
       const usageDetail = isUsage
         ? [entry.provider_id, entry.model_id, entry.run_id ? `run ${String(entry.run_id).slice(0, 12)}` : null]

--- a/docs/superpowers/plans/2026-08-28-small-credit-top-ups.md
+++ b/docs/superpowers/plans/2026-08-28-small-credit-top-ups.md
@@ -1,0 +1,438 @@
+# Small Credit Top-Ups Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Limit every new ATL Credit purchase to $0.50-$5.00 while offering $0.50, $1, $2, and $5 presets.
+
+**Architecture:** Keep `CheckoutRequest` as the server-authoritative package allowlist and custom-amount boundary. Mirror that contract in the no-build Credits frontend, then update API/integration fixtures so all purchase, webhook, refund, and idempotency paths exercise valid small packages without changing persisted order or ledger schemas.
+
+**Tech Stack:** Python 3.13, FastAPI, Pydantic v2, pytest, vanilla HTML/JavaScript, Stripe test-mode gateway.
+
+**Spec:** `docs/superpowers/specs/2026-08-28-small-credit-top-ups-design.md`
+
+## Global Constraints
+
+- New Checkout Sessions must charge from 50 through 500 US cents, inclusive.
+- Fixed packages must be exactly `usd_0_50`, `usd_1`, `usd_2`, and `usd_5`.
+- The one-dollar-to-one-ATL-Credit conversion remains unchanged.
+- The backend remains authoritative; direct API requests cannot bypass the range.
+- Existing orders, refunds, ledger entries, welcome Credits, and Grant Pool behavior remain unchanged.
+- Zero-dollar Checkout Sessions are not supported.
+- User-visible copy uses `$0.50-$5.00`; code, filenames, commits, and PR text remain English.
+- Do not add dependencies, database migrations, secrets, or deployment configuration.
+
+## File Structure
+
+- `dashboard/backend/domain/credits/models.py`: owns fixed package IDs, cent values, custom amount limits, and typed checkout validation.
+- `dashboard/backend/tests/domain/credits/test_service.py`: proves package resolution, conversion, and custom amount boundaries at the domain boundary.
+- `dashboard/backend/tests/test_credits_api.py`: proves API requests cannot submit retired packages or out-of-range custom amounts and keeps webhook expectations aligned with a valid package.
+- `dashboard/backend/tests/test_credits_api_review_fixes.py`: keeps error-mapping and account-reinstatement requests on a valid package.
+- `dashboard/backend/tests/integration/test_credits_checkout_flow.py`: proves purchase, signed webhook, refund, replay, and isolation behavior with the new maximum package.
+- `dashboard/frontend/app.html`: renders presets, range guidance, numeric input attributes, default selection, and the Credits script cache-buster.
+- `dashboard/frontend/js/credits.js`: owns the initial package selection and client-side custom amount guard.
+- `dashboard/backend/tests/test_credits_frontend.py`: statically verifies the no-build UI and client validation contract.
+- `dashboard/backend/tests/test_frontend_fast_boot.py`: remains the single exact cache-buster owner.
+
+---
+
+### Task 1: Enforce the Small Purchase Contract Across Backend Consumers
+
+**Files:**
+- Modify: `dashboard/backend/tests/domain/credits/test_service.py:181-225`
+- Modify: `dashboard/backend/domain/credits/models.py:18-73`
+- Modify: `dashboard/backend/tests/test_credits_api.py:113-138,175-365`
+- Modify: `dashboard/backend/tests/test_credits_api_review_fixes.py:50-65,190-218`
+- Modify: `dashboard/backend/tests/integration/test_credits_checkout_flow.py:171-376`
+
+**Interfaces:**
+- Consumes: `CheckoutRequest(client_request_id: UUID, package_id: CreditPackageId | None, custom_amount_usd_cents: StrictInt | None)`.
+- Produces: `CreditPackageId = Literal["usd_0_50", "usd_1", "usd_2", "usd_5"]`, `FIXED_PACKAGES_USD_CENTS`, `MIN_CUSTOM_USD_CENTS = 50`, `MAX_CUSTOM_USD_CENTS = 500`, and API/integration fixtures that use `usd_5` with a 500-cent charge and 5,000,000 purchased microcredits.
+
+- [ ] **Step 1: Replace the domain expectations with the new allowlist and boundaries**
+
+```python
+@pytest.mark.parametrize(
+    ("package_id", "cents"),
+    [("usd_0_50", 50), ("usd_1", 100), ("usd_2", 200), ("usd_5", 500)],
+)
+def test_fixed_packages_are_resolved_server_side(package_id, cents):
+    request = CheckoutRequest(
+        client_request_id=CLIENT_REQUEST_ID,
+        package_id=package_id,
+    )
+    assert request.amount_usd_cents == cents
+    assert credits_micro_for_cents(cents) == cents * 10_000
+
+
+@pytest.mark.parametrize("cents", [50, 51, 500])
+def test_custom_amount_accepts_integer_cent_boundaries(cents):
+    request = CheckoutRequest(
+        client_request_id=CLIENT_REQUEST_ID,
+        custom_amount_usd_cents=cents,
+    )
+    assert request.amount_usd_cents == cents
+
+
+@pytest.mark.parametrize("cents", [49, 501, 50.0, True])
+def test_custom_amount_rejects_out_of_range_or_non_integer_values(cents):
+    with pytest.raises(ValidationError):
+        CheckoutRequest(
+            client_request_id=CLIENT_REQUEST_ID,
+            custom_amount_usd_cents=cents,
+        )
+
+
+@pytest.mark.parametrize("package_id", ["usd_10", "usd_20", "usd_50"])
+def test_retired_large_packages_are_rejected(package_id):
+    with pytest.raises(ValidationError):
+        CheckoutRequest(
+            client_request_id=CLIENT_REQUEST_ID,
+            package_id=package_id,
+        )
+```
+
+- [ ] **Step 2: Run the domain tests to verify the new contract fails**
+
+Run:
+
+```bash
+pytest -q dashboard/backend/tests/domain/credits/test_service.py \
+  -k 'fixed_packages or custom_amount or retired_large_packages'
+```
+
+Expected: failures show `usd_0_50`, `usd_1`, and `usd_2` are not accepted, while 50-cent custom amounts are below the old minimum.
+
+- [ ] **Step 3: Replace the backend allowlist and limits**
+
+```python
+CreditPackageId = Literal["usd_0_50", "usd_1", "usd_2", "usd_5"]
+
+FIXED_PACKAGES_USD_CENTS: dict[str, int] = {
+    "usd_0_50": 50,
+    "usd_1": 100,
+    "usd_2": 200,
+    "usd_5": 500,
+}
+MIN_CUSTOM_USD_CENTS = 50
+MAX_CUSTOM_USD_CENTS = 500
+```
+
+Change the validation error to:
+
+```python
+raise ValueError("custom amount must be from 50 through 500 cents")
+```
+
+- [ ] **Step 4: Run the complete domain Credits service test**
+
+Run: `pytest -q dashboard/backend/tests/domain/credits/test_service.py`
+
+Expected: PASS. Package resolution produces 500,000 microcredits for `$0.50` and 5,000,000 microcredits for `$5.00`.
+
+- [ ] **Step 5: Run API and integration tests against the new allowlist**
+
+Run:
+
+```bash
+pytest -q \
+  dashboard/backend/tests/test_credits_api.py \
+  dashboard/backend/tests/test_credits_api_review_fixes.py \
+  dashboard/backend/tests/integration/test_credits_checkout_flow.py
+```
+
+Expected: FAIL because helpers still submit the retired `usd_10` package and receive `422`.
+
+- [ ] **Step 6: Add API coverage for both custom boundaries and retired packages**
+
+Extend `test_checkout_input_is_server_allowlisted_and_idempotent` with direct requests using unique UUIDs:
+
+```python
+too_small = billing_api.client.post(
+    "/api/credits/checkout-sessions",
+    headers=_auth(token),
+    json={
+        "client_request_id": "44444444-4444-4444-8444-444444444444",
+        "custom_amount_usd_cents": 49,
+    },
+)
+too_large = billing_api.client.post(
+    "/api/credits/checkout-sessions",
+    headers=_auth(token),
+    json={
+        "client_request_id": "55555555-5555-4555-8555-555555555555",
+        "custom_amount_usd_cents": 501,
+    },
+)
+retired = billing_api.client.post(
+    "/api/credits/checkout-sessions",
+    headers=_auth(token),
+    json={
+        "client_request_id": "66666666-6666-4666-8666-666666666666",
+        "package_id": "usd_10",
+    },
+)
+assert too_small.status_code == too_large.status_code == retired.status_code == 422
+```
+
+- [ ] **Step 7: Migrate API helpers and expectations to the `$5` package**
+
+In `test_credits_api.py`, make `_checkout` submit `usd_5`. Set `_paid_checkout_event`'s default `amount` to `500`, set `atl_credits_micro` to `"5000000"`, and update purchase-connected assertions from 10,000,000 to 5,000,000 and refundable cents from 1,000 to 500. Keep explicit refund amounts and unrelated ledger setup unchanged.
+
+```python
+json={"client_request_id": request_id, "package_id": "usd_5"}
+def _paid_checkout_event(checkout: dict, *, amount=500, event_id="evt_paid"):
+"atl_credits_micro": "5000000"
+```
+
+In `test_credits_api_review_fixes.py`, replace valid `usd_10` requests with `usd_5`; these tests assert error mapping and authorization rather than a price.
+
+- [ ] **Step 8: Migrate the end-to-end checkout fixture to `$5`**
+
+In `test_credits_checkout_flow.py`, use:
+
+```python
+json={"client_request_id": request_id, "package_id": "usd_5"}
+def _checkout_object(checkout, user_id, *, amount=500, payment_status="paid"):
+"atl_credits_micro": "5000000"
+```
+
+Update only assertions derived from that purchase:
+
+```python
+assert flow.credits.get_balance_micro(buyer["id"]) == 5_000_000
+assert settled.json()["result"]["balance_micro"] == 1_000_000
+assert [entry["amount_micro"] for entry in ledger] == [-4_000_000, 5_000_000]
+```
+
+The existing 400-cent refund remains valid against a 500-cent purchase, while the 700-cent over-refund remains rejected.
+
+- [ ] **Step 9: Run the API and integration tests**
+
+Run:
+
+```bash
+pytest -q \
+  dashboard/backend/tests/test_credits_api.py \
+  dashboard/backend/tests/test_credits_api_review_fixes.py \
+  dashboard/backend/tests/integration/test_credits_checkout_flow.py
+```
+
+Expected: PASS, including signed webhook settlement, duplicate delivery, refund, restriction, and checkout idempotency cases.
+
+- [ ] **Step 10: Commit the complete backend contract and its consumers**
+
+```bash
+git add dashboard/backend/domain/credits/models.py \
+  dashboard/backend/tests/domain/credits/test_service.py \
+  dashboard/backend/tests/test_credits_api.py \
+  dashboard/backend/tests/test_credits_api_review_fixes.py \
+  dashboard/backend/tests/integration/test_credits_checkout_flow.py
+git commit -m "feat: limit credit purchase amounts"
+```
+
+---
+
+### Task 2: Replace the Credits Page with Small Presets
+
+**Files:**
+- Modify: `dashboard/backend/tests/test_credits_frontend.py:19-29`
+- Modify: `dashboard/backend/tests/test_frontend_fast_boot.py:185-198`
+- Modify: `dashboard/frontend/app.html:1895-1910,2405`
+- Modify: `dashboard/frontend/js/credits.js:14-20,520-529`
+
+**Interfaces:**
+- Consumes: Task 1 package IDs and 50-500-cent custom range.
+- Produces: an accessible four-option radio group, `usd_1` default selection, numeric custom input, matching client validation, and `credits.js?v=6`.
+
+- [ ] **Step 1: Strengthen the static frontend contract**
+
+Replace the purchase-control assertions with exact small-package and range checks:
+
+```python
+def test_credits_page_ships_small_purchase_controls():
+    expected_packages = {
+        'data-credit-package="usd_0_50" data-credit-cents="50"',
+        'data-credit-package="usd_1" data-credit-cents="100"',
+        'data-credit-package="usd_2" data-credit-cents="200"',
+        'data-credit-package="usd_5" data-credit-cents="500"',
+    }
+    assert all(package in APP_HTML for package in expected_packages)
+    assert 'data-credit-package="usd_1"' in APP_HTML
+    assert 'data-credit-package="usd_10"' not in APP_HTML
+    assert 'data-credit-package="usd_20"' not in APP_HTML
+    assert 'data-credit-package="usd_50"' not in APP_HTML
+    package_grid_start = APP_HTML.index('<div id="creditsPackageGrid"')
+    package_grid_end = APP_HTML.index('</div>', package_grid_start)
+    package_grid = APP_HTML[package_grid_start:package_grid_end]
+    assert package_grid.count('aria-checked="true"') == 1
+    assert 'aria-checked="true" data-credit-package="usd_1"' in package_grid
+    assert 'id="creditsCustomAmount" type="number"' in APP_HTML
+    assert 'min="0.50" max="5.00" step="0.01"' in APP_HTML
+    assert 'Minimum $0.50, maximum $5.00.' in APP_HTML
+```
+
+Add client assertions:
+
+```python
+def test_credits_client_enforces_the_small_custom_range():
+    source = CREDITS_JS_PATH.read_text(encoding="utf-8")
+    assert "value: 'usd_1'" in source
+    assert "cents < 50 || cents > 500" in source
+    assert "Enter a custom amount from $0.50 through $5.00." in source
+```
+
+Change the cache-buster expectation in `test_frontend_fast_boot.py` to `js/credits.js?v=6`.
+
+- [ ] **Step 2: Run frontend tests to verify the old controls fail**
+
+Run:
+
+```bash
+pytest -q \
+  dashboard/backend/tests/test_credits_frontend.py \
+  dashboard/backend/tests/test_frontend_fast_boot.py::test_cache_busters_bumped
+```
+
+Expected: FAIL because the page still contains large presets, the old `$5-$200` range, and `credits.js?v=5`.
+
+- [ ] **Step 3: Render the four small presets and numeric custom input**
+
+Use this package markup in `app.html`, retaining the existing radiogroup and button classes:
+
+```html
+<button class="credits-package-btn" type="button" role="radio" aria-checked="false" data-credit-package="usd_0_50" data-credit-cents="50"><strong>$0.50</strong><span>0.5 Credits</span></button>
+<button class="credits-package-btn is-selected" type="button" role="radio" aria-checked="true" data-credit-package="usd_1" data-credit-cents="100"><strong>$1</strong><span>1 Credit</span></button>
+<button class="credits-package-btn" type="button" role="radio" aria-checked="false" data-credit-package="usd_2" data-credit-cents="200"><strong>$2</strong><span>2 Credits</span></button>
+<button class="credits-package-btn" type="button" role="radio" aria-checked="false" data-credit-package="usd_5" data-credit-cents="500"><strong>$5</strong><span>5 Credits</span></button>
+```
+
+Use this labelled custom input and visible hint:
+
+```html
+<input id="creditsCustomAmount" type="number" inputmode="decimal" autocomplete="off" min="0.50" max="5.00" step="0.01" placeholder="0.50-5.00" aria-describedby="creditsCustomHint">
+<p id="creditsCustomHint">Minimum $0.50, maximum $5.00.</p>
+```
+
+- [ ] **Step 4: Match JavaScript selection and validation to the backend**
+
+```javascript
+selection: { kind: 'package', value: 'usd_1' },
+```
+
+```javascript
+const cents = parseUsdCents(element('creditsCustomAmount')?.value);
+if (cents === null || cents < 50 || cents > 500) {
+  throw new Error('Enter a custom amount from $0.50 through $5.00.');
+}
+return { custom_amount_usd_cents: cents };
+```
+
+Change the script tag to `js/credits.js?v=6`.
+
+- [ ] **Step 5: Run frontend contracts**
+
+Run:
+
+```bash
+pytest -q \
+  dashboard/backend/tests/test_credits_frontend.py \
+  dashboard/backend/tests/test_frontend_fast_boot.py::test_cache_busters_bumped
+```
+
+Expected: PASS. The radio group has one selected preset, the input remains labelled through `for="creditsCustomAmount"`, and the hint remains connected through `aria-describedby="creditsCustomHint"`.
+
+- [ ] **Step 6: Commit the Credits UI**
+
+```bash
+git add dashboard/frontend/app.html dashboard/frontend/js/credits.js \
+  dashboard/backend/tests/test_credits_frontend.py \
+  dashboard/backend/tests/test_frontend_fast_boot.py
+git commit -m "feat: offer small credit top-ups"
+```
+
+---
+
+### Task 3: Run Regression Checks and Update PR #410
+
+**Files:**
+- Verify only; no additional source file is expected.
+- Update: GitHub PR #410 description and branch.
+
+**Interfaces:**
+- Consumes: all Task 1-2 commits.
+- Produces: a clean branch with test evidence and an updated remote PR.
+
+- [ ] **Step 1: Confirm retired packages are absent from production code**
+
+Run:
+
+```bash
+rg -n 'usd_10|usd_20|usd_50|200\.00|20_000|cents > 20000' \
+  dashboard/backend/domain/credits dashboard/frontend
+```
+
+Expected: no matches. Tests and design documents may mention retired values only to assert rejection or describe the old state.
+
+- [ ] **Step 2: Run the focused checkout suite**
+
+Run:
+
+```bash
+pytest -q \
+  dashboard/backend/tests/domain/credits/test_service.py \
+  dashboard/backend/tests/test_credits_api.py \
+  dashboard/backend/tests/test_credits_api_review_fixes.py \
+  dashboard/backend/tests/integration/test_credits_checkout_flow.py \
+  dashboard/backend/tests/test_credits_frontend.py \
+  dashboard/backend/tests/test_frontend_fast_boot.py::test_cache_busters_bumped
+```
+
+Expected: PASS with no checkout, webhook, refund, frontend, or cache-buster failures.
+
+- [ ] **Step 3: Run the broader Credits/Auth/store-parity regression suite**
+
+Run:
+
+```bash
+pytest -q \
+  dashboard/backend/tests/domain/credits \
+  dashboard/backend/tests/test_auth.py \
+  dashboard/backend/tests/test_credits_frontend.py \
+  dashboard/backend/tests/test_frontend_fast_boot.py \
+  dashboard/backend/tests/test_store_twin_parity.py
+```
+
+Expected: PASS, apart from environment-gated Postgres tests that are explicitly skipped when their test database is unavailable.
+
+- [ ] **Step 4: Check formatting, scope, and secrets**
+
+Run:
+
+```bash
+git diff main...HEAD --check
+git status --short --branch
+git diff main...HEAD --name-only
+```
+
+Expected: no whitespace errors and changes limited to the approved Credits implementation, its tests, spec, and plan. Leave every unrelated tracked or untracked path untouched and unstaged.
+
+- [ ] **Step 5: Push the branch and update the PR description**
+
+```bash
+git push origin feature/default-user-credits
+gh pr edit 410 --repo Open-Finance-Lab/AgenticTrading --body '## Summary
+
+- Grant every existing and new account 1.500000 welcome Credits exactly once.
+- Limit new Stripe top-ups to $0.50-$5.00 on both the backend and frontend.
+- Offer $0.50, $1, $2, and $5 presets with $1 selected by default.
+- Keep welcome promotions separate from the admin Grant Pool.
+
+## Verification
+
+- Focused checkout, webhook, refund, frontend, and cache-buster suite: passed.
+- Credits, auth, frontend, and store-parity regression suite: passed.
+- `git diff main...HEAD --check`: passed.'
+gh pr checks 410 --repo Open-Finance-Lab/AgenticTrading --watch --interval 10
+```
+
+Expected: PR #410 contains the welcome-credit feature plus the approved small top-up contract. Report any unrelated baseline CI failure separately rather than changing out-of-scope marketplace code.

--- a/docs/superpowers/specs/2026-08-28-small-credit-top-ups-design.md
+++ b/docs/superpowers/specs/2026-08-28-small-credit-top-ups-design.md
@@ -1,7 +1,7 @@
 # Small Credit Top-Ups Design
 
-**Date:** 2026-08-28  
-**Status:** Approved for planning  
+**Date:** 2026-08-28
+**Status:** Approved for planning
 **PR:** #410 (`feature/default-user-credits`)
 
 ## Goal

--- a/docs/superpowers/specs/2026-08-28-small-credit-top-ups-design.md
+++ b/docs/superpowers/specs/2026-08-28-small-credit-top-ups-design.md
@@ -1,0 +1,118 @@
+# Small Credit Top-Ups Design
+
+**Date:** 2026-08-28  
+**Status:** Approved for planning  
+**PR:** #410 (`feature/default-user-credits`)
+
+## Goal
+
+Limit new ATL Credit purchases to small test amounts from **$0.50 through
+$5.00**, inclusive. The Credits page must offer useful small presets while the
+backend remains the authoritative enforcement boundary.
+
+## Context
+
+The current Credits page offers $5, $10, $20, and $50 packages and accepts
+custom purchases from $5 through $200. Those amounts are unnecessarily large
+for product testing. The application uses a fixed one-to-one rate: one US
+dollar purchases one ATL Credit.
+
+Stripe Checkout cannot create a useful zero-dollar top-up. The requested
+"$0-$5" range is therefore represented by the smallest payable amount,
+$0.50, through $5.00. A zero or empty amount is an invalid selection and must
+not create a Checkout Session.
+
+## Decisions
+
+### Preset Packages
+
+Replace the existing packages with four server-allowlisted packages:
+
+| Package ID | Charge | Credits |
+| --- | ---: | ---: |
+| `usd_0_50` | $0.50 | 0.5 |
+| `usd_1` | $1.00 | 1 |
+| `usd_2` | $2.00 | 2 |
+| `usd_5` | $5.00 | 5 |
+
+The $1 package is selected by default. Package IDs remain symbolic API values;
+the backend resolves each ID to cents and ignores any client-provided credit
+quantity.
+
+### Custom Amount
+
+The custom input accepts decimal US-dollar values that resolve to an integer
+number of cents from 50 through 500, inclusive. The UI copy, placeholder,
+input attributes, client validation, and server validation use the same range:
+`$0.50-$5.00`.
+
+Values below $0.50, above $5.00, malformed decimals, fractional cents, booleans,
+and floating-point JSON values are rejected. The browser must not be treated as
+the security boundary; a direct API request is subject to the same backend
+limit.
+
+## Architecture
+
+### Backend Contract
+
+`dashboard/backend/domain/credits/models.py` remains the authoritative price
+allowlist. It will:
+
+- replace the large package IDs and their cent values with the four small
+  packages;
+- set the custom amount boundaries to 50 and 500 cents;
+- keep `StrictInt` validation for custom cent amounts;
+- continue resolving the purchased Credits from the server-side cent amount.
+
+No database schema or ledger representation changes. Existing payment orders,
+refunds, completed Checkout Sessions, webhook settlement, and displayed
+activity remain valid because persisted orders store their resolved cent and
+microcredit amounts rather than a package ID.
+
+### Frontend Contract
+
+`dashboard/frontend/app.html` will render the four small presets, mark `$1` as
+selected, and describe the custom range as `$0.50-$5.00`. The custom input will
+expose matching `min`, `max`, and `step` attributes as browser affordances.
+
+`dashboard/frontend/js/credits.js` will default to `usd_1`, validate custom
+amounts from 50 through 500 cents, and show a matching display-safe validation
+message. Its cache-buster will be incremented so deployed browsers load the new
+contract.
+
+### Error Handling
+
+Invalid frontend input produces an inline status message and does not call the
+checkout endpoint. Invalid or retired package IDs and out-of-range direct API
+requests receive the existing Pydantic `422` response. Stripe, webhook, retry,
+and idempotency error handling are unchanged.
+
+### Accessibility
+
+The package buttons remain a keyboard-accessible radio group with exactly one
+selected package. The custom input remains labelled and connected to visible
+range guidance with `aria-describedby`. The change does not introduce a new
+interaction pattern.
+
+## Testing
+
+Tests will verify:
+
+- the exact preset allowlist and server-side cent resolution;
+- acceptance of the 50-cent and 500-cent custom boundaries;
+- rejection of 49 cents, 501 cents, non-integers, and retired large packages;
+- frontend preset markup, default selection, input attributes, range copy, and
+  client validation;
+- checkout idempotency and the existing one-dollar-to-one-Credit conversion;
+- the Credits script cache-buster.
+
+Run the focused Credits model, API, frontend, integration, and cache-buster
+tests, followed by the established Credits/Auth/store-parity regression suite.
+
+## Out of Scope
+
+- Changing the `$1 = 1 Credit` conversion rate.
+- Creating free or zero-dollar Checkout Sessions.
+- Modifying welcome Credits, admin Grant Pool behavior, refunds, or historical
+  orders.
+- Changing Stripe test/live mode selection or deployment configuration.


### PR DESCRIPTION
## Summary

- Grant every existing and new account 1.500000 welcome Credits exactly once.
- Limit new Stripe top-ups to $0.50-$5.00 on both the backend and frontend.
- Offer $0.50, $1, $2, and $5 presets with $1 selected by default.
- Keep welcome promotions separate from the admin Grant Pool.

## Verification

- Focused checkout, webhook, refund, frontend, and cache-buster suite: 79 passed.
- Credits, auth, frontend, and store-parity regression suite: 385 passed, 20 skipped.
- JavaScript syntax check and git diff check: passed.