### PR TITLE
Fix backtest Credit activity precision

### DIFF
--- a/dashboard/backend/api/routers/credits.py
+++ b/dashboard/backend/api/routers/credits.py
@@ -92,14 +92,15 @@ def _public_ledger_entry(entry: dict[str, Any]) -> dict[str, Any]:
         "payment_order_id": entry["payment_order_id"],
         "created_at": entry["created_at"],
     }
-    if entry.get("entry_type") == "llm_usage":
+    if entry.get("entry_type") == "backtest_usage":
         result.update(
             {
-                "reservation_id": entry.get("reservation_id"),
                 "run_id": entry.get("run_id"),
-                "call_index": entry.get("call_index"),
+                "model_call_count": entry.get("model_call_count"),
                 "provider_id": entry.get("provider_id"),
                 "model_id": entry.get("model_id"),
+                "provider_mixed": bool(entry.get("provider_mixed")),
+                "model_mixed": bool(entry.get("model_mixed")),
                 "billing_source": entry.get("billing_source"),
             }
         )

--- a/dashboard/backend/domain/credits/repository.py
+++ b/dashboard/backend/domain/credits/repository.py
@@ -1661,28 +1661,30 @@ class CreditsStore:
                            request_digest, actor_user_id, source, reason,
                            reference_type, reference_id, created_at,
                            NULL AS reservation_id, NULL AS run_id,
-                           NULL AS call_index, NULL AS evidence_json
+                           NULL AS call_index, NULL AS model_call_count,
+                           NULL AS evidence_json
                     FROM credit_ledger_entries
                     WHERE user_id = ?
                 ),
                 llm_activity AS (
                     SELECT MAX(id) AS source_id, 'llm_usage' AS source_kind,
                            user_id, NULL AS bucket,
-                           'llm_usage' AS entry_type,
+                           'backtest_usage' AS entry_type,
                            SUM(amount_micro) AS amount_micro,
                            NULL AS payment_order_id,
                            NULL AS refund_request_id, NULL AS stripe_event_id,
                            NULL AS operation_key, NULL AS operation_id,
                            NULL AS idempotency_key, NULL AS request_digest,
                            NULL AS actor_user_id, 'llm_execution' AS source,
-                           'Model usage.' AS reason,
+                           'Backtest usage.' AS reason,
                            NULL AS reference_type, NULL AS reference_id,
-                           created_at,
-                           reservation_id, run_id, call_index, evidence_json
+                           MAX(created_at) AS created_at,
+                           NULL AS reservation_id, run_id, NULL AS call_index,
+                           COUNT(DISTINCT call_index) AS model_call_count,
+                           NULL AS evidence_json
                     FROM credit_llm_usage_entries
                     WHERE user_id = ?
-                    GROUP BY user_id, reservation_id, run_id, call_index,
-                             evidence_json, created_at
+                    GROUP BY user_id, run_id
                 ),
                 activity AS (
                     SELECT * FROM historical_activity
@@ -1696,8 +1698,40 @@ class CreditsStore:
                 """,
                 params,
             ).fetchall()
+            selected_rows = rows[:page_size]
+            run_ids = list(
+                dict.fromkeys(
+                    str(row["run_id"])
+                    for row in selected_rows
+                    if row["source_kind"] == "llm_usage"
+                    and row["run_id"] is not None
+                )
+            )
+            evidence_by_run: dict[str, list[object]] = {
+                run_id: [] for run_id in run_ids
+            }
+            if run_ids:
+                placeholders = ", ".join("?" for _ in run_ids)
+                evidence_rows = conn.execute(
+                    f"""
+                    SELECT DISTINCT run_id, evidence_json
+                    FROM credit_llm_usage_entries
+                    WHERE user_id = ? AND run_id IN ({placeholders})
+                    """,
+                    [user_id, *run_ids],
+                ).fetchall()
+                for evidence_row in evidence_rows:
+                    evidence_by_run[str(evidence_row["run_id"])].append(
+                        evidence_row["evidence_json"]
+                    )
         has_more = len(rows) > page_size
-        items = [normalize_activity_item(dict(row)) for row in rows[:page_size]]
+        items = [
+            normalize_activity_item(
+                dict(row),
+                evidence_json_values=evidence_by_run.get(str(row["run_id"]), ()),
+            )
+            for row in selected_rows
+        ]
         return {
             "items": items,
             "next_cursor": (

--- a/dashboard/backend/domain/credits/repository_common.py
+++ b/dashboard/backend/domain/credits/repository_common.py
@@ -6,7 +6,7 @@ import base64
 import binascii
 import hashlib
 import json
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from datetime import datetime, timezone
 
 
@@ -159,37 +159,83 @@ def decode_activity_cursor(cursor: str | int) -> tuple[str, str, int] | int:
     return created_at, source_kind, source_id
 
 
-def normalize_activity_item(value: Mapping[str, object]) -> dict[str, object]:
+def summarize_activity_evidence(values: Iterable[object]) -> dict[str, object]:
+    """Reduce private per-call evidence to safe run-level display fields."""
+
+    providers: set[str] = set()
+    models: set[str] = set()
+    billing_sources: set[str] = set()
+    provider_unknown = False
+    model_unknown = False
+    billing_unknown = False
+    for raw in values:
+        try:
+            evidence = json.loads(raw) if isinstance(raw, str) else {}
+        except json.JSONDecodeError:
+            evidence = {}
+        if not isinstance(evidence, dict):
+            evidence = {}
+        snapshot = evidence.get("pricing_snapshot")
+        if not isinstance(snapshot, dict):
+            snapshot = {}
+        provider = snapshot.get("provider_id")
+        model = snapshot.get("model_id")
+        billing = evidence.get("billing_source")
+        if isinstance(provider, str) and provider.strip():
+            providers.add(provider)
+        else:
+            provider_unknown = True
+        if isinstance(model, str) and model.strip():
+            models.add(model)
+        else:
+            model_unknown = True
+        if isinstance(billing, str) and billing.strip():
+            billing_sources.add(billing)
+        else:
+            billing_unknown = True
+
+    return {
+        "provider_id": (
+            next(iter(providers))
+            if len(providers) == 1 and not provider_unknown
+            else None
+        ),
+        "model_id": (
+            next(iter(models)) if len(models) == 1 and not model_unknown else None
+        ),
+        "billing_source": (
+            next(iter(billing_sources))
+            if len(billing_sources) == 1 and not billing_unknown
+            else None
+        ),
+        "provider_mixed": len(providers) > 1,
+        "model_mixed": len(models) > 1,
+    }
+
+
+def normalize_activity_item(
+    value: Mapping[str, object],
+    *,
+    evidence_json_values: Iterable[object] = (),
+) -> dict[str, object]:
     """Return one public-safe activity row and discard raw billing evidence."""
 
     item = dict(value)
-    evidence_json = item.pop("evidence_json", None)
+    item.pop("evidence_json", None)
     item["id"] = int(item.pop("source_id"))
     item["amount_micro"] = int(item["amount_micro"])
-    if item.get("call_index") is not None:
-        item["call_index"] = int(item["call_index"])
     if item.get("source_kind") != "llm_usage":
+        item.pop("model_call_count", None)
         return item
     item.update(
         {
-            "entry_type": "llm_usage",
+            "entry_type": "backtest_usage",
             "source": "llm_execution",
-            "reason": "Model usage.",
+            "reason": "Backtest usage.",
+            "model_call_count": int(item["model_call_count"]),
+            **summarize_activity_evidence(evidence_json_values),
         }
     )
-    try:
-        evidence = json.loads(evidence_json) if isinstance(evidence_json, str) else {}
-    except json.JSONDecodeError:
-        evidence = {}
-    if not isinstance(evidence, dict):
-        evidence = {}
-    snapshot = evidence.get("pricing_snapshot")
-    if not isinstance(snapshot, dict):
-        snapshot = {}
-    for field, raw in (
-        ("provider_id", snapshot.get("provider_id")),
-        ("model_id", snapshot.get("model_id")),
-        ("billing_source", evidence.get("billing_source")),
-    ):
-        item[field] = raw if isinstance(raw, str) and raw.strip() else None
+    item.pop("reservation_id", None)
+    item.pop("call_index", None)
     return item

--- a/dashboard/backend/domain/credits/repository_postgres.py
+++ b/dashboard/backend/domain/credits/repository_postgres.py
@@ -1457,14 +1457,16 @@ class PostgresCreditsStore:
                                source, reason, reference_type, reference_id,
                                created_at,
                                NULL::TEXT AS reservation_id, NULL::TEXT AS run_id,
-                               NULL::BIGINT AS call_index, NULL::TEXT AS evidence_json
+                               NULL::BIGINT AS call_index,
+                               NULL::BIGINT AS model_call_count,
+                               NULL::TEXT AS evidence_json
                         FROM credit_ledger_entries
                         WHERE user_id = %s
                     ),
                     llm_activity AS (
                         SELECT MAX(id) AS source_id, 'llm_usage' AS source_kind,
                                user_id, NULL::TEXT AS bucket,
-                               'llm_usage' AS entry_type,
+                               'backtest_usage' AS entry_type,
                                SUM(amount_micro) AS amount_micro,
                                NULL::TEXT AS payment_order_id,
                                NULL::TEXT AS refund_request_id,
@@ -1474,15 +1476,18 @@ class PostgresCreditsStore:
                                NULL::TEXT AS idempotency_key,
                                NULL::TEXT AS request_digest,
                                NULL::INTEGER AS actor_user_id,
-                               'llm_execution' AS source, 'Model usage.' AS reason,
+                               'llm_execution' AS source,
+                               'Backtest usage.' AS reason,
                                NULL::TEXT AS reference_type,
                                NULL::TEXT AS reference_id,
-                               created_at, reservation_id, run_id, call_index,
-                               evidence_json
+                               MAX(created_at) AS created_at,
+                               NULL::TEXT AS reservation_id, run_id,
+                               NULL::BIGINT AS call_index,
+                               COUNT(DISTINCT call_index) AS model_call_count,
+                               NULL::TEXT AS evidence_json
                         FROM credit_llm_usage_entries
                         WHERE user_id = %s
-                        GROUP BY user_id, reservation_id, run_id, call_index,
-                                 evidence_json, created_at
+                        GROUP BY user_id, run_id
                     ),
                     activity AS (
                         SELECT * FROM historical_activity
@@ -1497,8 +1502,39 @@ class PostgresCreditsStore:
                     params,
                 )
                 rows = cur.fetchall()
+                selected_rows = rows[:page_size]
+                run_ids = list(
+                    dict.fromkeys(
+                        str(row["run_id"])
+                        for row in selected_rows
+                        if row["source_kind"] == "llm_usage"
+                        and row["run_id"] is not None
+                    )
+                )
+                evidence_by_run: dict[str, list[object]] = {
+                    run_id: [] for run_id in run_ids
+                }
+                if run_ids:
+                    cur.execute(
+                        """
+                        SELECT DISTINCT run_id, evidence_json
+                        FROM credit_llm_usage_entries
+                        WHERE user_id = %s AND run_id = ANY(%s)
+                        """,
+                        (user_id, run_ids),
+                    )
+                    for evidence_row in cur.fetchall():
+                        evidence_by_run[str(evidence_row["run_id"])].append(
+                            evidence_row["evidence_json"]
+                        )
         has_more = len(rows) > page_size
-        items = [normalize_activity_item(dict(row)) for row in rows[:page_size]]
+        items = [
+            normalize_activity_item(
+                dict(row),
+                evidence_json_values=evidence_by_run.get(str(row["run_id"]), ()),
+            )
+            for row in selected_rows
+        ]
         return {
             "items": items,
             "next_cursor": (

--- a/dashboard/backend/tests/domain/credits/test_repository.py
+++ b/dashboard/backend/tests/domain/credits/test_repository.py
@@ -91,6 +91,39 @@ def _pay_order(
     return result
 
 
+def _settle_activity_call(
+    store: CreditsStore,
+    *,
+    user_id: int = 1,
+    run_id: str,
+    call_index: int,
+    actual_micro: int,
+    provider_id: str = "openrouter",
+    model_id: str = "anthropic/claude-haiku-4-5",
+):
+    reservation_id = f"activity:{user_id}:{run_id}:{call_index}"
+    reservation = store.reserve_llm_credits(
+        reservation_id=reservation_id,
+        user_id=user_id,
+        run_id=run_id,
+        call_index=call_index,
+        reserved_micro=actual_micro,
+        operation_key=f"reserve:{reservation_id}",
+        request_digest=f"{user_id}{call_index}".ljust(64, "a")[:64],
+    )
+    return store.settle_llm_credits(
+        reservation["reservation_id"],
+        actual_micro=actual_micro,
+        evidence={
+            "billing_source": "platform_credits",
+            "pricing_snapshot": {
+                "provider_id": provider_id,
+                "model_id": model_id,
+            },
+        },
+    )
+
+
 def test_schema_is_created_and_new_account_balance_is_zero(tmp_path):
     store = _store(tmp_path)
 
@@ -412,7 +445,7 @@ def test_ledger_is_cursor_paginated_and_exposes_no_mutation_method(tmp_path):
     assert not hasattr(store, "delete_ledger_entry")
 
 
-def test_activity_merges_two_bucket_llm_usage_with_opaque_cursor(tmp_path):
+def test_activity_aggregates_settled_calls_and_buckets_by_run(tmp_path):
     store = _store(tmp_path)
     grant_common = {
         "pool_id": "default",
@@ -420,7 +453,7 @@ def test_activity_merges_two_bucket_llm_usage_with_opaque_cursor(tmp_path):
         "source": "test",
     }
     store.fund_grant_pool(
-        amount_micro=1_000_000,
+        amount_micro=500,
         operation_id="activity-fund",
         idempotency_key="activity-fund-key",
         request_digest="activity-fund-digest",
@@ -429,7 +462,7 @@ def test_activity_merges_two_bucket_llm_usage_with_opaque_cursor(tmp_path):
     )
     store.assign_grant(
         user_id=1,
-        amount_micro=1_000_000,
+        amount_micro=500,
         operation_id="activity-assign",
         idempotency_key="activity-assign-key",
         request_digest="activity-assign-digest",
@@ -438,57 +471,153 @@ def test_activity_merges_two_bucket_llm_usage_with_opaque_cursor(tmp_path):
     )
     _pending_order(store)
     _pay_order(store)
-    reservation = store.reserve_llm_credits(
-        reservation_id="activity-reservation",
-        user_id=1,
-        run_id="run-activity-evidence",
-        call_index=3,
-        reserved_micro=1_500_000,
-        operation_key="activity-reserve",
-        request_digest="e" * 64,
+    _settle_activity_call(
+        store, run_id="run-aggregate", call_index=0, actual_micro=600
     )
-    store.settle_llm_credits(
-        reservation["reservation_id"],
-        actual_micro=1_500_000,
-        evidence={
-            "billing_source": "platform_credits",
-            "pricing_snapshot": {
-                "provider_id": "openrouter",
-                "model_id": "openai/gpt-5.5",
-            },
-            "provider_cost_credits_micro": 1_500_000,
-            "debited_credits_micro": 1_500_000,
-            "api_key": "must-not-leak",
-        },
+    _settle_activity_call(
+        store, run_id="run-aggregate", call_index=1, actual_micro=684
     )
 
-    first = store.list_ledger_entries(1, limit=1)
-    all_items = list(first["items"])
-    cursor = first["next_cursor"]
-    assert isinstance(cursor, str) and not cursor.isdecimal()
-    while cursor:
+    items = store.list_ledger_entries(1, limit=50)["items"]
+    usage = [item for item in items if item["entry_type"] == "backtest_usage"]
+
+    assert len(usage) == 1
+    assert usage[0]["amount_micro"] == -1_284
+    assert usage[0]["model_call_count"] == 2
+    assert usage[0]["run_id"] == "run-aggregate"
+    assert usage[0]["provider_id"] == "openrouter"
+    assert usage[0]["model_id"] == "anthropic/claude-haiku-4-5"
+    assert usage[0]["provider_mixed"] is False
+    assert usage[0]["model_mixed"] is False
+    assert usage[0]["billing_source"] == "platform_credits"
+    assert "reservation_id" not in usage[0]
+    assert "call_index" not in usage[0]
+    assert "evidence_json" not in usage[0]
+    with store._get_connection() as conn:
+        row_count = conn.execute(
+            "SELECT COUNT(*) FROM credit_llm_usage_entries WHERE run_id = ?",
+            ("run-aggregate",),
+        ).fetchone()[0]
+    assert row_count == 3
+
+
+def test_activity_summarizes_mixed_and_malformed_evidence(tmp_path):
+    store = _store(tmp_path)
+    _pending_order(store)
+    _pay_order(store)
+    _settle_activity_call(
+        store,
+        run_id="run-mixed",
+        call_index=0,
+        actual_micro=100,
+        provider_id="openrouter",
+        model_id="model-a",
+    )
+    _settle_activity_call(
+        store,
+        run_id="run-mixed",
+        call_index=1,
+        actual_micro=200,
+        provider_id="openai",
+        model_id="model-b",
+    )
+    _settle_activity_call(
+        store,
+        run_id="run-unknown",
+        call_index=0,
+        actual_micro=300,
+    )
+    with store._get_connection() as conn:
+        conn.execute(
+            "UPDATE credit_llm_usage_entries SET evidence_json = ? WHERE run_id = ?",
+            ("not-json", "run-unknown"),
+        )
+
+    items = store.list_ledger_entries(1, limit=50)["items"]
+    mixed = next(item for item in items if item.get("run_id") == "run-mixed")
+    unknown = next(item for item in items if item.get("run_id") == "run-unknown")
+
+    assert mixed["provider_id"] is None
+    assert mixed["model_id"] is None
+    assert mixed["provider_mixed"] is True
+    assert mixed["model_mixed"] is True
+    assert unknown["amount_micro"] == -300
+    assert unknown["provider_id"] is None
+    assert unknown["model_id"] is None
+    assert unknown["provider_mixed"] is False
+    assert unknown["model_mixed"] is False
+
+
+def test_activity_paginates_whole_runs_and_isolates_equal_run_ids(tmp_path):
+    store = _store(tmp_path)
+    _pending_order(store)
+    _pay_order(store)
+    _pending_order(
+        store,
+        order_id="ord_other",
+        user_id=3,
+        client_request_id="33333333-3333-4333-8333-333333333333",
+    )
+    _pay_order(store, order_id="ord_other", event_id="evt_paid_other")
+    for call_index, amount in enumerate((101, 102, 103)):
+        _settle_activity_call(
+            store,
+            user_id=1,
+            run_id="run-shared",
+            call_index=call_index,
+            actual_micro=amount,
+        )
+    _settle_activity_call(
+        store,
+        user_id=3,
+        run_id="run-shared",
+        call_index=0,
+        actual_micro=900,
+    )
+
+    pages = []
+    cursor = None
+    while True:
         page = store.list_ledger_entries(1, limit=1, cursor=cursor)
-        all_items.extend(page["items"])
+        pages.extend(page["items"])
         cursor = page["next_cursor"]
+        if cursor is None:
+            break
 
-    identities = [(item["source_kind"], item["id"]) for item in all_items]
-    assert len(identities) == len(set(identities))
-    usage = next(item for item in all_items if item["entry_type"] == "llm_usage")
-    assert usage["amount_micro"] == -1_500_000
-    assert usage["run_id"] == "run-activity-evidence"
-    assert usage["provider_id"] == "openrouter"
-    assert usage["model_id"] == "openai/gpt-5.5"
-    assert usage["billing_source"] == "platform_credits"
-    assert "evidence_json" not in usage
-    assert "must-not-leak" not in str(usage)
-
-    purchase = next(item for item in all_items if item["entry_type"] == "purchase")
-    legacy_page = store.list_ledger_entries(
-        1,
-        limit=10,
-        cursor=purchase["id"],
+    user_one = [item for item in pages if item.get("run_id") == "run-shared"]
+    user_three = store.list_ledger_entries(3, limit=50)["items"]
+    user_three_usage = next(
+        item for item in user_three if item.get("run_id") == "run-shared"
     )
-    assert isinstance(legacy_page["items"], list)
+    assert len(user_one) == 1
+    assert user_one[0]["amount_micro"] == -306
+    assert user_one[0]["model_call_count"] == 3
+    assert user_three_usage["amount_micro"] == -900
+    assert user_three_usage["model_call_count"] == 1
+
+
+def test_activity_omits_released_run_without_settled_usage(tmp_path):
+    store = _store(tmp_path)
+    _pending_order(store)
+    _pay_order(store)
+    reservation = store.reserve_llm_credits(
+        reservation_id="activity-released",
+        user_id=1,
+        run_id="run-released-without-charge",
+        call_index=0,
+        reserved_micro=1_000,
+        operation_key="activity-released-reserve",
+        request_digest="r" * 64,
+    )
+    store.release_llm_credits(
+        reservation["reservation_id"],
+        reason="synthetic provider failure",
+    )
+
+    items = store.list_ledger_entries(1, limit=50)["items"]
+    assert all(
+        item.get("run_id") != "run-released-without-charge" for item in items
+    )
 
 
 def test_partial_refund_posts_negative_entry_and_updates_refundable_amount(tmp_path):

--- a/dashboard/backend/tests/domain/credits/test_repository_postgres.py
+++ b/dashboard/backend/tests/domain/credits/test_repository_postgres.py
@@ -494,6 +494,49 @@ def test_postgres_batch_projection_and_activity_pagination(pg_credits_store):
 
 
 @pg_only
+def test_postgres_activity_aggregates_calls_before_pagination(pg_credits_store):
+    store = pg_credits_store
+    _pending_order(store)
+    _pay_order(store)
+    for call_index, amount in enumerate((137, 1_147)):
+        reservation_id = f"pg-activity:{call_index}"
+        reservation = store.reserve_llm_credits(
+            reservation_id=reservation_id,
+            user_id=1,
+            run_id="run-pg-activity",
+            call_index=call_index,
+            reserved_micro=amount,
+            operation_key=f"reserve:{reservation_id}",
+            request_digest=str(call_index).ljust(64, "b"),
+        )
+        store.settle_llm_credits(
+            reservation["reservation_id"],
+            actual_micro=amount,
+            evidence={
+                "billing_source": "platform_credits",
+                "pricing_snapshot": {
+                    "provider_id": "openrouter",
+                    "model_id": "anthropic/claude-haiku-4-5",
+                },
+            },
+        )
+
+    first = store.list_ledger_entries(1, limit=1)
+    second = store.list_ledger_entries(1, limit=1, cursor=first["next_cursor"])
+    usage = next(
+        item
+        for item in [*first["items"], *second["items"]]
+        if item["entry_type"] == "backtest_usage"
+    )
+
+    assert usage["amount_micro"] == -1_284
+    assert usage["model_call_count"] == 2
+    assert usage["provider_id"] == "openrouter"
+    assert usage["model_id"] == "anthropic/claude-haiku-4-5"
+    assert first["items"][0]["id"] != second["items"][0]["id"]
+
+
+@pg_only
 def test_postgres_grant_pair_rolls_back_on_second_insert_failure(
     pg_credits_store, monkeypatch
 ):

--- a/dashboard/backend/tests/test_admin_analytics_frontend.py
+++ b/dashboard/backend/tests/test_admin_analytics_frontend.py
@@ -91,7 +91,7 @@ def test_admin_analytics_surface_and_module_exist():
     assert 'id="adminPanelAnalytics"' in APP_HTML
     assert 'id="adminAnalyticsOverview"' in APP_HTML
     assert 'id="adminAnalyticsProfile"' in APP_HTML
-    assert 'js/admin-analytics.js?v=1' in APP_HTML
+    assert 'js/admin-analytics.js?v=2' in APP_HTML
     assert ANALYTICS_JS_PATH.exists()
     assert ".admin-analytics-overview" in STYLES
     assert ".admin-analytics-profile" in STYLES
@@ -192,8 +192,14 @@ def test_app_lifecycle_and_cache_versions_are_wired():
     assert "window.AdminAnalytics.refresh()" in APP_JS
     assert 'styles.css?v=125' in APP_HTML
     assert 'app.js?v=116' in APP_HTML
-    assert 'js/admin-analytics.js?v=1' in APP_HTML
+    assert 'js/admin-analytics.js?v=2' in APP_HTML
     assert 'js/admin-tabs.js?v=3' in APP_HTML
+
+
+def test_credit_costs_use_the_shared_exact_formatter():
+    source = analytics_source()
+    assert "window.CreditFormat.formatCreditsMicro(value)" in source
+    assert "numeric / 1000000" not in source
 
 
 def test_scoped_responsive_accessible_styles_exist():

--- a/dashboard/backend/tests/test_admin_credits_frontend.py
+++ b/dashboard/backend/tests/test_admin_credits_frontend.py
@@ -67,8 +67,9 @@ def test_admin_grant_client_uses_server_api_and_never_persists_secrets():
     assert "parseSignedCreditsMicro" in ADMIN_JS
     assert "source: 'admin-console'" in ADMIN_JS
     assert "Math.abs(signedAmountMicro)" in ADMIN_JS
-    assert "display_pool_available_credits" in ADMIN_JS
-    assert "display_allocated_to_users_credits" in ADMIN_JS
+    assert "pool.pool_available_micro" in ADMIN_JS
+    assert "pool.allocated_to_users_micro" in ADMIN_JS
+    assert "formatCreditsMicro" in ADMIN_JS
     assert "strokeDasharray" in ADMIN_JS
     assert "localStorage" not in ADMIN_JS
     assert "api_key" not in ADMIN_JS
@@ -111,5 +112,5 @@ def test_admin_tabs_have_four_tabs_in_usage_order_and_legacy_alias():
 
 
 def test_admin_visual_assets_use_fresh_cache_versions():
-    assert 'js/admin-credits.js?v=5' in APP_HTML
+    assert 'js/admin-credits.js?v=6' in APP_HTML
     assert 'js/admin-tabs.js?v=3' in APP_HTML

--- a/dashboard/backend/tests/test_credit_format_frontend.py
+++ b/dashboard/backend/tests/test_credit_format_frontend.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
+FORMAT_JS = FRONTEND / "js" / "credit-format.js"
+APP_HTML = (FRONTEND / "app.html").read_text(encoding="utf-8")
+
+
+requires_node = pytest.mark.skipif(
+    shutil.which("node") is None,
+    reason="node is required for exact Credits formatter tests",
+)
+
+
+def _run_formatter(expressions: list[str]) -> list[str]:
+    source = FORMAT_JS.read_text(encoding="utf-8")
+    script = "\n".join(
+        [
+            "const window = globalThis;",
+            source,
+            f"console.log(JSON.stringify([{', '.join(expressions)}]));",
+        ]
+    )
+    result = subprocess.run(
+        ["node", "-e", script],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
+    )
+    return json.loads(result.stdout)
+
+
+@requires_node
+def test_credit_formatter_keeps_exact_fixed_six_decimal_values():
+    assert _run_formatter(
+        [
+            'CreditFormat.formatCredits("4.79")',
+            'CreditFormat.formatCredits("-0.000137")',
+            'CreditFormat.formatCredits("1234")',
+            "CreditFormat.formatCreditsMicro(4790000)",
+            "CreditFormat.formatCreditsMicro(-137)",
+            'CreditFormat.formatCreditsMicro("9007199254740993")',
+        ]
+    ) == [
+        "4.790000",
+        "-0.000137",
+        "1,234.000000",
+        "4.790000",
+        "-0.000137",
+        "9,007,199,254.740993",
+    ]
+
+
+@requires_node
+def test_credit_formatter_rejects_missing_float_and_overprecision_values():
+    assert _run_formatter(
+        [
+            "CreditFormat.formatCredits(null)",
+            'CreditFormat.formatCredits("1.0000001")',
+            "CreditFormat.formatCreditsMicro(0.5)",
+            "CreditFormat.formatCreditsMicro(Number.NaN)",
+        ]
+    ) == ["—", "—", "—", "—"]
+
+
+def test_credit_formatter_loads_before_every_consumer():
+    formatter_at = APP_HTML.index('src="js/credit-format.js?v=1"')
+    for asset in (
+        'src="js/credits.js?v=5"',
+        'src="js/admin-credits.js?v=6"',
+        'src="js/admin-analytics.js?v=2"',
+    ):
+        assert formatter_at < APP_HTML.index(asset)
+
+
+def test_static_credit_package_amounts_use_six_decimals():
+    for amount in ("5.000000", "10.000000", "20.000000", "50.000000"):
+        assert f">{amount} Credits</span>" in APP_HTML
+    assert "$1 = 1.000000 Credits" in APP_HTML

--- a/dashboard/backend/tests/test_credits_api.py
+++ b/dashboard/backend/tests/test_credits_api.py
@@ -206,47 +206,58 @@ def test_balance_ledger_and_order_return_only_public_fields(billing_api):
     assert "checkout_session_id" not in serialized
 
 
-def test_credit_activity_exposes_safe_aggregated_llm_usage(billing_api):
+def test_credit_activity_exposes_safe_aggregated_backtest_usage(billing_api):
     token = _signup(billing_api.client, "usage-api@example.com")
     checkout = _checkout(billing_api.client, token).json()["checkout"]
     billing_api.gateway.event = _paid_checkout_event(checkout)
     assert _deliver_webhook(billing_api).status_code == 200
-    reservation = billing_api.store.reserve_llm_credits(
-        reservation_id="api-usage-reservation",
-        user_id=1,
-        run_id="run-api-usage",
-        call_index=0,
-        reserved_micro=1_000_000,
-        operation_key="api-usage-reserve",
-        request_digest="f" * 64,
-    )
-    billing_api.store.settle_llm_credits(
-        reservation["reservation_id"],
-        actual_micro=1_000_000,
-        evidence={
-            "billing_source": "platform_credits",
-            "pricing_snapshot": {
-                "provider_id": "openrouter",
-                "model_id": "openai/gpt-5.5",
+    for call_index, amount in enumerate((137, 1_147)):
+        reservation_id = f"api-usage-reservation-{call_index}"
+        reservation = billing_api.store.reserve_llm_credits(
+            reservation_id=reservation_id,
+            user_id=1,
+            run_id="run-api-usage",
+            call_index=call_index,
+            reserved_micro=amount,
+            operation_key=f"api-usage-reserve-{call_index}",
+            request_digest=str(call_index).ljust(64, "f"),
+        )
+        billing_api.store.settle_llm_credits(
+            reservation["reservation_id"],
+            actual_micro=amount,
+            evidence={
+                "billing_source": "platform_credits",
+                "pricing_snapshot": {
+                    "provider_id": "openrouter",
+                    "model_id": "anthropic/claude-haiku-4-5",
+                },
+                "api_key": "synthetic-secret-must-not-leak",
             },
-            "api_key": "raw-provider-secret",
-        },
-    )
+        )
 
     response = billing_api.client.get(
         "/api/credits/ledger?limit=1",
         headers=_auth(token),
     )
     body = response.json()
+    usage = body["items"][0]
 
     assert response.status_code == 200
-    assert body["items"][0]["entry_type"] == "llm_usage"
-    assert body["items"][0]["amount_micro"] == -1_000_000
-    assert body["items"][0]["provider_id"] == "openrouter"
-    assert body["items"][0]["model_id"] == "openai/gpt-5.5"
+    assert usage["entry_type"] == "backtest_usage"
+    assert usage["amount_micro"] == -1_284
+    assert usage["display_credits"] == "-0.001284"
+    assert usage["run_id"] == "run-api-usage"
+    assert usage["model_call_count"] == 2
+    assert usage["provider_id"] == "openrouter"
+    assert usage["model_id"] == "anthropic/claude-haiku-4-5"
+    assert usage["provider_mixed"] is False
+    assert usage["model_mixed"] is False
+    assert usage["billing_source"] == "platform_credits"
+    assert "reservation_id" not in usage
+    assert "call_index" not in usage
     assert isinstance(body["next_cursor"], str)
     assert "evidence_json" not in str(body)
-    assert "raw-provider-secret" not in str(body)
+    assert "synthetic-secret-must-not-leak" not in str(body)
 
     second = billing_api.client.get(
         "/api/credits/ledger",

--- a/dashboard/backend/tests/test_credits_frontend.py
+++ b/dashboard/backend/tests/test_credits_frontend.py
@@ -76,13 +76,17 @@ def test_balance_copy_describes_platform_and_byok_lanes():
     assert ">Available balance<" not in APP_HTML
 
 
-def test_activity_renders_negative_model_usage_with_safe_context():
+def test_activity_renders_one_backtest_usage_summary_with_safe_context():
     source = CREDITS_JS_PATH.read_text(encoding="utf-8")
-    assert "entry.entry_type === 'llm_usage'" in source
-    assert "'Model usage'" in source
+    assert "entry.entry_type === 'backtest_usage'" in source
+    assert "'Backtest usage'" in source
+    assert "entry.model_call_count" in source
+    assert "'Multiple providers'" in source
+    assert "'Multiple models'" in source
     assert "entry.provider_id" in source
     assert "entry.model_id" in source
     assert "String(entry.run_id).slice(0, 12)" in source
+    assert "entry.call_index" not in source
 
 
 def test_refund_retry_reuses_its_request_id_only_while_unchanged():

--- a/dashboard/backend/tests/test_frontend_fast_boot.py
+++ b/dashboard/backend/tests/test_frontend_fast_boot.py
@@ -195,4 +195,7 @@ def test_cache_busters_bumped():
     assert "styles.css?v=125" in APP_HTML
     assert "js/leaderboard.js?v=32" in APP_HTML
     assert "home-page.js?v=50" in APP_HTML
-    assert "js/credits.js?v=4" in APP_HTML
+    assert "js/credit-format.js?v=1" in APP_HTML
+    assert "js/credits.js?v=5" in APP_HTML
+    assert "js/admin-credits.js?v=6" in APP_HTML
+    assert "js/admin-analytics.js?v=2" in APP_HTML

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -1890,13 +1890,13 @@
                             <p class="credits-section-kicker">Top up</p>
                             <h3 id="creditsPurchaseHeading">Choose an amount</h3>
                         </div>
-                        <span class="credits-rate">$1 = 1 Credit</span>
+                        <span class="credits-rate">$1 = 1.000000 Credits</span>
                     </div>
                     <div id="creditsPackageGrid" class="credits-package-grid" role="radiogroup" aria-label="Credit package">
-                        <button class="credits-package-btn" type="button" role="radio" aria-checked="false" data-credit-package="usd_5" data-credit-cents="500"><strong>$5</strong><span>5 Credits</span></button>
-                        <button class="credits-package-btn is-selected" type="button" role="radio" aria-checked="true" data-credit-package="usd_10" data-credit-cents="1000"><strong>$10</strong><span>10 Credits</span></button>
-                        <button class="credits-package-btn" type="button" role="radio" aria-checked="false" data-credit-package="usd_20" data-credit-cents="2000"><strong>$20</strong><span>20 Credits</span></button>
-                        <button class="credits-package-btn" type="button" role="radio" aria-checked="false" data-credit-package="usd_50" data-credit-cents="5000"><strong>$50</strong><span>50 Credits</span></button>
+                        <button class="credits-package-btn" type="button" role="radio" aria-checked="false" data-credit-package="usd_5" data-credit-cents="500"><strong>$5</strong><span>5.000000 Credits</span></button>
+                        <button class="credits-package-btn is-selected" type="button" role="radio" aria-checked="true" data-credit-package="usd_10" data-credit-cents="1000"><strong>$10</strong><span>10.000000 Credits</span></button>
+                        <button class="credits-package-btn" type="button" role="radio" aria-checked="false" data-credit-package="usd_20" data-credit-cents="2000"><strong>$20</strong><span>20.000000 Credits</span></button>
+                        <button class="credits-package-btn" type="button" role="radio" aria-checked="false" data-credit-package="usd_50" data-credit-cents="5000"><strong>$50</strong><span>50.000000 Credits</span></button>
                     </div>
                     <div class="credits-custom-row">
                         <label for="creditsCustomAmount">Custom amount</label>
@@ -2402,10 +2402,11 @@
     <script src="app.js?v=116" defer></script>
     <script src="js/analytics.js?v=1" defer></script>
     <script src="js/agent-editor.js?v=28" defer></script>
-    <script src="js/credits.js?v=4" defer></script>
+    <script src="js/credit-format.js?v=1" defer></script>
+    <script src="js/credits.js?v=5" defer></script>
     <script src="js/admin-model-providers.js?v=1" defer></script>
-    <script src="js/admin-credits.js?v=5" defer></script>
-    <script src="js/admin-analytics.js?v=1" defer></script>
+    <script src="js/admin-credits.js?v=6" defer></script>
+    <script src="js/admin-analytics.js?v=2" defer></script>
     <script src="js/admin-tabs.js?v=3" defer></script>
     <script src="js/leaderboard.js?v=32" defer></script>
     <script src="home-page.js?v=50" defer></script>

--- a/dashboard/frontend/js/admin-analytics.js
+++ b/dashboard/frontend/js/admin-analytics.js
@@ -216,10 +216,8 @@
   }
 
   function formatCreditsMicro(value) {
-    if (value == null || value === '') return '—';
-    const numeric = Number(value);
-    if (!Number.isFinite(numeric)) return '—';
-    return `${new Intl.NumberFormat(undefined, { maximumFractionDigits: 6 }).format(numeric / 1000000)} Credits`;
+    const formatted = window.CreditFormat.formatCreditsMicro(value);
+    return formatted === '—' ? '—' : `${formatted} Credits`;
   }
 
   function formatTimestamp(value, fallback = '—') {

--- a/dashboard/frontend/js/admin-credits.js
+++ b/dashboard/frontend/js/admin-credits.js
@@ -2,6 +2,7 @@
 (function () {
   'use strict';
 
+  const { formatCredits, formatCreditsMicro } = window.CreditFormat;
   const state = {
     initialized: false,
     users: [],
@@ -74,12 +75,6 @@
     return Number(negative ? -micro : micro);
   }
 
-  function formatCredits(value) {
-    const text = String(value ?? '0.000000');
-    if (/^-?\d+(?:\.\d+)?$/.test(text)) return text;
-    return '0.000000';
-  }
-
   function formatTime(value) {
     const date = new Date(value);
     if (!value || Number.isNaN(date.getTime())) return 'Unknown time';
@@ -129,16 +124,22 @@
 
   function renderPool(pool) {
     if (!pool) return;
-    const availableText = formatCredits(pool.display_pool_available_credits);
-    const allocatedText = formatCredits(pool.display_allocated_to_users_credits);
-    const available = Number.parseFloat(availableText);
-    const allocated = Number.parseFloat(allocatedText);
-    const safeAvailable = Number.isFinite(available) && available > 0 ? available : 0;
-    const safeAllocated = Number.isFinite(allocated) && allocated > 0 ? allocated : 0;
-    const total = safeAvailable + safeAllocated;
-    const totalText = formatCredits(total.toFixed(6));
-    const availableRatio = total > 0 ? safeAvailable / total : 0;
-    const allocatedRatio = total > 0 ? safeAllocated / total : 0;
+    const availableMicro = pool.pool_available_micro;
+    const allocatedMicro = pool.allocated_to_users_micro;
+    const validAvailable = Number.isSafeInteger(availableMicro);
+    const validAllocated = Number.isSafeInteger(allocatedMicro);
+    const totalMicro = validAvailable && validAllocated
+      && Number.isSafeInteger(availableMicro + allocatedMicro)
+      ? availableMicro + allocatedMicro
+      : null;
+    const availableText = formatCreditsMicro(availableMicro);
+    const allocatedText = formatCreditsMicro(allocatedMicro);
+    const totalText = formatCreditsMicro(totalMicro);
+    const chartAvailable = validAvailable && availableMicro > 0 ? availableMicro : 0;
+    const chartAllocated = validAllocated && allocatedMicro > 0 ? allocatedMicro : 0;
+    const chartTotal = chartAvailable + chartAllocated;
+    const availableRatio = chartTotal > 0 ? chartAvailable / chartTotal : 0;
+    const allocatedRatio = chartTotal > 0 ? chartAllocated / chartTotal : 0;
     const allocatedLength = setPoolRingSegment('adminCreditsPoolRingAllocated', allocatedRatio);
     setPoolRingSegment('adminCreditsPoolRingAvailable', availableRatio, -allocatedLength);
     element('adminCreditsPoolTotal').textContent = totalText;
@@ -403,7 +404,7 @@
       return;
     }
     state.pendingGrantReason = { user, amountInput, amountMicro };
-    element('adminGrantReasonSummary').textContent = `${userName(user)} · ${amountInput.value.trim()} Credits`;
+    element('adminGrantReasonSummary').textContent = `${userName(user)} · ${formatCreditsMicro(amountMicro)} Credits`;
     element('adminGrantReasonStatus').textContent = '';
     reasonInput.value = DEFAULT_ASSIGN_REASON;
     if (!dialog.open) dialog.showModal();

--- a/dashboard/frontend/js/credit-format.js
+++ b/dashboard/frontend/js/credit-format.js
@@ -1,0 +1,35 @@
+/** Exact ATL Credit formatting. One Credit is 1,000,000 micro-Credits. */
+(function () {
+  'use strict';
+
+  const UNAVAILABLE = '—';
+
+  function groupWhole(value) {
+    return value.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  }
+
+  function formatCredits(value) {
+    const text = value == null ? '' : String(value);
+    const match = /^(-?)(\d+)(?:\.(\d{1,6}))?$/.exec(text);
+    if (!match) return UNAVAILABLE;
+    const fraction = (match[3] || '').padEnd(6, '0');
+    const isZero = /^0+$/.test(match[2]) && !/[1-9]/.test(fraction);
+    const sign = match[1] && !isZero ? '-' : '';
+    return `${sign}${groupWhole(match[2])}.${fraction}`;
+  }
+
+  function formatCreditsMicro(value) {
+    const text = typeof value === 'number' && Number.isSafeInteger(value)
+      ? String(value)
+      : (typeof value === 'string' && /^-?\d+$/.test(value) ? value : '');
+    if (!text) return UNAVAILABLE;
+    const micro = BigInt(text);
+    const sign = micro < 0n ? '-' : '';
+    const absolute = micro < 0n ? -micro : micro;
+    const whole = groupWhole(String(absolute / 1000000n));
+    const fraction = String(absolute % 1000000n).padStart(6, '0');
+    return `${sign}${whole}.${fraction}`;
+  }
+
+  window.CreditFormat = Object.freeze({ formatCredits, formatCreditsMicro });
+})();

--- a/dashboard/frontend/js/credits.js
+++ b/dashboard/frontend/js/credits.js
@@ -2,6 +2,7 @@
 (function () {
   'use strict';
 
+  const { formatCredits } = window.CreditFormat;
   const MAX_ORDER_POLLS = 8;
   const ORDER_POLL_DELAYS_MS = [0, 1000, 1500, 2500, 4000, 6000, 8000, 10000];
   const TERMINAL_ORDER_STATUSES = new Set(['paid', 'partially_refunded', 'refunded']);
@@ -40,15 +41,6 @@
     target.classList.toggle('is-error', tone === 'error');
     target.classList.toggle('is-success', tone === 'success');
     target.classList.toggle('is-pending', tone === 'pending');
-  }
-
-  function formatCreditDisplay(value, digits = 2) {
-    const match = /^(-?)(\d+)(?:\.(\d{1,6}))?$/.exec(String(value ?? ''));
-    if (!match) return '—';
-    const sign = match[1];
-    const whole = match[2].replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-    const fraction = (match[3] || '').padEnd(6, '0').slice(0, digits);
-    return `${sign}${whole}${digits ? `.${fraction}` : ''}`;
   }
 
   function formatUsdCents(cents) {
@@ -426,7 +418,7 @@
 
   function renderBalance(balance) {
     state.balanceMicro = Number.isSafeInteger(balance.balance_micro) ? balance.balance_micro : 0;
-    element('creditsBalance').textContent = `${formatCreditDisplay(balance.display_credits)} Credits`;
+    element('creditsBalance').textContent = `${formatCredits(balance.display_credits)} Credits`;
     const accountStatus = element('creditsAccountStatus');
     const restricted = balance.account_status !== 'active';
     if (restricted) {
@@ -452,14 +444,23 @@
 
       const meta = document.createElement('div');
       meta.className = 'credits-ledger-meta';
-      const isUsage = entry.entry_type === 'llm_usage';
+      const isUsage = entry.entry_type === 'backtest_usage';
       const isNegative = isUsage || entry.entry_type === 'refund';
       const title = isUsage
-        ? 'Model usage'
+        ? 'Backtest usage'
         : (entry.entry_type === 'refund' ? 'Refund' : 'Credit purchase');
       meta.appendChild(textNode('strong', '', title));
+      const callCount = Number.isSafeInteger(entry.model_call_count)
+        && entry.model_call_count > 0
+        ? `${entry.model_call_count} model call${entry.model_call_count === 1 ? '' : 's'}`
+        : null;
       const usageDetail = isUsage
-        ? [entry.provider_id, entry.model_id, entry.run_id ? `run ${String(entry.run_id).slice(0, 12)}` : null]
+        ? [
+          entry.provider_mixed ? 'Multiple providers' : entry.provider_id,
+          entry.model_mixed ? 'Multiple models' : entry.model_id,
+          callCount,
+          entry.run_id ? `run ${String(entry.run_id).slice(0, 12)}` : null,
+        ]
           .filter(Boolean)
           .join(' · ')
         : null;
@@ -469,7 +470,7 @@
         [usageDetail, formatTimestamp(entry.created_at)].filter(Boolean).join(' · '),
       ));
 
-      const formatted = formatCreditDisplay(entry.display_credits);
+      const formatted = formatCredits(entry.display_credits);
       const amount = textNode(
         'span',
         `credits-ledger-amount ${isNegative ? 'is-negative' : 'is-positive'}`,

--- a/docs/superpowers/plans/2026-08-28-backtest-credit-activity.md
+++ b/docs/superpowers/plans/2026-08-28-backtest-credit-activity.md
@@ -1,0 +1,1162 @@
+# Backtest Credit Activity Precision and Aggregation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Display every ATL Credit amount with exactly six decimal places and project all settled model calls for one backtest as one exact run-level Activity debit.
+
+**Architecture:** Keep the append-only per-call micro-Credit ledger unchanged. Aggregate usage by `user_id` and `run_id` in each persistence backend before pagination, fetch safe evidence for only the selected page in one additional query, normalize provider/model context in shared Python, and expose one public `backtest_usage` item. A small no-build frontend formatter renders decimal strings and integer micro-Credits without binary floating point conversion across Credits, Admin Grant Credits, and Admin Analytics.
+
+**Tech Stack:** Python 3.12, FastAPI, SQLite, PostgreSQL/psycopg, pytest, vanilla JavaScript, Node.js behavioral frontend tests
+
+**Spec:** `docs/superpowers/specs/2026-08-28-backtest-credit-activity-design.md`
+
+## Global Constraints
+
+- One Credit equals exactly `1,000,000` integer micro-Credits.
+- Every displayed ATL Credit amount has exactly six fractional digits; USD remains at two digits.
+- Activity aggregates settled usage by both `user_id` and `run_id`; equal run ids from different users never combine.
+- Aggregation occurs before ordering, cursor filtering, and page limiting.
+- Charged failed runs remain visible; released or failed calls without a usage row remain absent.
+- The existing per-call reservation and usage tables, Grant-first allocation, Stripe behavior, BYOK behavior, and pricing calculations do not change.
+- Raw evidence, provider response bodies, credentials, API keys, local databases, `.superpowers/`, and `work/` never enter public responses or commits.
+- Preserve SQLite/PostgreSQL behavior parity and existing legacy decimal cursor support.
+- Use synthetic run ids, amounts, and pricing evidence in all tests.
+- The unrelated `test_frontend_model_facets.py::test_closed_card_differs_from_open_card_by_exactly_the_badge` baseline failure is outside this branch; do not modify marketplace-card code to hide it.
+
+---
+
+### Task 1: Shared Evidence Normalization and SQLite Run Projection
+
+**Files:**
+- Modify: `dashboard/backend/domain/credits/repository_common.py:9,162-195`
+- Modify: `dashboard/backend/domain/credits/repository.py:1613-1712`
+- Test: `dashboard/backend/tests/domain/credits/test_repository.py:415-492`
+
+**Interfaces:**
+- Produces: `summarize_activity_evidence(values: Iterable[object]) -> dict[str, object]`
+- Produces: `normalize_activity_item(value: Mapping[str, object], *, evidence_json_values: Iterable[object] = ()) -> dict[str, object]`
+- Produces: `CreditsStore.list_ledger_entries(...)` items with `entry_type="backtest_usage"`, exact summed `amount_micro`, `model_call_count`, safe provider/model fields, and no call-level evidence.
+- Preserves: `source_kind="llm_usage"` and the existing opaque cursor encoder/decoder.
+
+- [ ] **Step 1: Add failing SQLite run-level Activity fixtures and assertions**
+
+Add this helper near the existing `_pay_order` helper in `test_repository.py`:
+
+```python
+def _settle_activity_call(
+    store: CreditsStore,
+    *,
+    user_id: int = 1,
+    run_id: str,
+    call_index: int,
+    actual_micro: int,
+    provider_id: str = "openrouter",
+    model_id: str = "anthropic/claude-haiku-4-5",
+    evidence: object | None = None,
+):
+    reservation_id = f"activity:{user_id}:{run_id}:{call_index}"
+    reservation = store.reserve_llm_credits(
+        reservation_id=reservation_id,
+        user_id=user_id,
+        run_id=run_id,
+        call_index=call_index,
+        reserved_micro=actual_micro,
+        operation_key=f"reserve:{reservation_id}",
+        request_digest=f"{user_id}{call_index}".ljust(64, "a")[:64],
+    )
+    safe_evidence = evidence if evidence is not None else {
+        "billing_source": "platform_credits",
+        "pricing_snapshot": {
+            "provider_id": provider_id,
+            "model_id": model_id,
+        },
+    }
+    return store.settle_llm_credits(
+        reservation["reservation_id"],
+        actual_micro=actual_micro,
+        evidence=safe_evidence,
+    )
+```
+
+Replace the call-level Activity expectation with run-level tests covering two
+calls, a split Grant/Purchased debit, evidence handling, pagination, and account
+isolation:
+
+```python
+def test_activity_aggregates_settled_calls_and_buckets_by_run(tmp_path):
+    store = _store(tmp_path)
+    store.fund_grant_pool(
+        pool_id="default",
+        amount_micro=500,
+        operation_id="activity-fund",
+        idempotency_key="activity-fund-key",
+        request_digest="activity-fund-digest",
+        actor_user_id=2,
+        source="test",
+        reason="Fund run aggregation test.",
+    )
+    store.assign_grant(
+        pool_id="default",
+        user_id=1,
+        amount_micro=500,
+        operation_id="activity-assign",
+        idempotency_key="activity-assign-key",
+        request_digest="activity-assign-digest",
+        actor_user_id=2,
+        source="test",
+        reason="Assign run aggregation test Credits.",
+    )
+    _pending_order(store)
+    _pay_order(store)
+    _settle_activity_call(
+        store, run_id="run-aggregate", call_index=0, actual_micro=600
+    )
+    _settle_activity_call(
+        store, run_id="run-aggregate", call_index=1, actual_micro=684
+    )
+
+    items = store.list_ledger_entries(1, limit=50)["items"]
+    usage = [item for item in items if item["entry_type"] == "backtest_usage"]
+
+    assert len(usage) == 1
+    assert usage[0]["amount_micro"] == -1_284
+    assert usage[0]["model_call_count"] == 2
+    assert usage[0]["run_id"] == "run-aggregate"
+    assert usage[0]["provider_id"] == "openrouter"
+    assert usage[0]["model_id"] == "anthropic/claude-haiku-4-5"
+    assert usage[0]["provider_mixed"] is False
+    assert usage[0]["model_mixed"] is False
+    assert usage[0]["billing_source"] == "platform_credits"
+    assert "reservation_id" not in usage[0]
+    assert "call_index" not in usage[0]
+    assert "evidence_json" not in usage[0]
+    with store._get_connection() as conn:
+        row_count = conn.execute(
+            "SELECT COUNT(*) FROM credit_llm_usage_entries WHERE run_id = ?",
+            ("run-aggregate",),
+        ).fetchone()[0]
+    assert row_count == 3
+
+
+def test_activity_summarizes_mixed_and_malformed_evidence(tmp_path):
+    store = _store(tmp_path)
+    _pending_order(store)
+    _pay_order(store)
+    _settle_activity_call(
+        store,
+        run_id="run-mixed",
+        call_index=0,
+        actual_micro=100,
+        provider_id="openrouter",
+        model_id="model-a",
+    )
+    _settle_activity_call(
+        store,
+        run_id="run-mixed",
+        call_index=1,
+        actual_micro=200,
+        provider_id="openai",
+        model_id="model-b",
+    )
+    _settle_activity_call(
+        store,
+        run_id="run-unknown",
+        call_index=0,
+        actual_micro=300,
+    )
+    with store._get_connection() as conn:
+        conn.execute(
+            "UPDATE credit_llm_usage_entries SET evidence_json = ? WHERE run_id = ?",
+            ("not-json", "run-unknown"),
+        )
+
+    items = store.list_ledger_entries(1, limit=50)["items"]
+    mixed = next(item for item in items if item.get("run_id") == "run-mixed")
+    unknown = next(item for item in items if item.get("run_id") == "run-unknown")
+
+    assert mixed["provider_id"] is None
+    assert mixed["model_id"] is None
+    assert mixed["provider_mixed"] is True
+    assert mixed["model_mixed"] is True
+    assert unknown["amount_micro"] == -300
+    assert unknown["provider_id"] is None
+    assert unknown["model_id"] is None
+    assert unknown["provider_mixed"] is False
+    assert unknown["model_mixed"] is False
+
+
+def test_activity_paginates_whole_runs_and_isolates_equal_run_ids(tmp_path):
+    store = _store(tmp_path)
+    _pending_order(store)
+    _pay_order(store)
+    _pending_order(
+        store,
+        order_id="ord_other",
+        user_id=3,
+        client_request_id="33333333-3333-4333-8333-333333333333",
+    )
+    _pay_order(store, order_id="ord_other", event_id="evt_paid_other")
+    for call_index, amount in enumerate((101, 102, 103)):
+        _settle_activity_call(
+            store,
+            user_id=1,
+            run_id="run-shared",
+            call_index=call_index,
+            actual_micro=amount,
+        )
+    _settle_activity_call(
+        store,
+        user_id=3,
+        run_id="run-shared",
+        call_index=0,
+        actual_micro=900,
+    )
+
+    pages = []
+    cursor = None
+    while True:
+        page = store.list_ledger_entries(1, limit=1, cursor=cursor)
+        pages.extend(page["items"])
+        cursor = page["next_cursor"]
+        if cursor is None:
+            break
+
+    user_one = [item for item in pages if item.get("run_id") == "run-shared"]
+    user_three = store.list_ledger_entries(3, limit=50)["items"]
+    user_three_usage = next(
+        item for item in user_three if item.get("run_id") == "run-shared"
+    )
+    assert len(user_one) == 1
+    assert user_one[0]["amount_micro"] == -306
+    assert user_one[0]["model_call_count"] == 3
+    assert user_three_usage["amount_micro"] == -900
+    assert user_three_usage["model_call_count"] == 1
+
+
+def test_activity_omits_released_run_without_settled_usage(tmp_path):
+    store = _store(tmp_path)
+    _pending_order(store)
+    _pay_order(store)
+    reservation = store.reserve_llm_credits(
+        reservation_id="activity-released",
+        user_id=1,
+        run_id="run-released-without-charge",
+        call_index=0,
+        reserved_micro=1_000,
+        operation_key="activity-released-reserve",
+        request_digest="r" * 64,
+    )
+    store.release_llm_credits(
+        reservation["reservation_id"],
+        reason="synthetic provider failure",
+    )
+
+    items = store.list_ledger_entries(1, limit=50)["items"]
+    assert all(
+        item.get("run_id") != "run-released-without-charge" for item in items
+    )
+```
+
+- [ ] **Step 2: Run the SQLite tests and verify the existing call-level query fails them**
+
+Run:
+
+```bash
+pytest dashboard/backend/tests/domain/credits/test_repository.py -q -k "activity"
+```
+
+Expected: FAIL because multiple calls still produce multiple `llm_usage` rows,
+`model_call_count` and mixed flags are absent, and malformed evidence is tied to
+one call-level row.
+
+- [ ] **Step 3: Add shared tolerant evidence summarization**
+
+Import `Iterable` beside `Mapping` in `repository_common.py`, then add this
+helper and extend `normalize_activity_item`:
+
+```python
+def summarize_activity_evidence(values: Iterable[object]) -> dict[str, object]:
+    providers: set[str] = set()
+    models: set[str] = set()
+    billing_sources: set[str] = set()
+    provider_unknown = False
+    model_unknown = False
+    billing_unknown = False
+    for raw in values:
+        try:
+            evidence = json.loads(raw) if isinstance(raw, str) else {}
+        except json.JSONDecodeError:
+            evidence = {}
+        if not isinstance(evidence, dict):
+            evidence = {}
+        snapshot = evidence.get("pricing_snapshot")
+        if not isinstance(snapshot, dict):
+            snapshot = {}
+        provider = snapshot.get("provider_id")
+        model = snapshot.get("model_id")
+        billing = evidence.get("billing_source")
+        if isinstance(provider, str) and provider.strip():
+            providers.add(provider)
+        else:
+            provider_unknown = True
+        if isinstance(model, str) and model.strip():
+            models.add(model)
+        else:
+            model_unknown = True
+        if isinstance(billing, str) and billing.strip():
+            billing_sources.add(billing)
+        else:
+            billing_unknown = True
+
+    return {
+        "provider_id": (
+            next(iter(providers))
+            if len(providers) == 1 and not provider_unknown
+            else None
+        ),
+        "model_id": (
+            next(iter(models)) if len(models) == 1 and not model_unknown else None
+        ),
+        "billing_source": (
+            next(iter(billing_sources))
+            if len(billing_sources) == 1 and not billing_unknown
+            else None
+        ),
+        "provider_mixed": len(providers) > 1,
+        "model_mixed": len(models) > 1,
+    }
+
+
+def normalize_activity_item(
+    value: Mapping[str, object],
+    *,
+    evidence_json_values: Iterable[object] = (),
+) -> dict[str, object]:
+    item = dict(value)
+    item.pop("evidence_json", None)
+    item["id"] = int(item.pop("source_id"))
+    item["amount_micro"] = int(item["amount_micro"])
+    if item.get("source_kind") != "llm_usage":
+        item.pop("model_call_count", None)
+        return item
+    item.update(
+        {
+            "entry_type": "backtest_usage",
+            "source": "llm_execution",
+            "reason": "Backtest usage.",
+            "model_call_count": int(item["model_call_count"]),
+            **summarize_activity_evidence(evidence_json_values),
+        }
+    )
+    item.pop("reservation_id", None)
+    item.pop("call_index", None)
+    return item
+```
+
+- [ ] **Step 4: Aggregate SQLite usage before cursor filtering and page limiting**
+
+In `CreditsStore.list_ledger_entries`, add `NULL AS model_call_count` to the
+historical projection and replace the usage CTE with:
+
+```sql
+llm_activity AS (
+    SELECT MAX(id) AS source_id, 'llm_usage' AS source_kind,
+           user_id, NULL AS bucket,
+           'backtest_usage' AS entry_type,
+           SUM(amount_micro) AS amount_micro,
+           NULL AS payment_order_id,
+           NULL AS refund_request_id, NULL AS stripe_event_id,
+           NULL AS operation_key, NULL AS operation_id,
+           NULL AS idempotency_key, NULL AS request_digest,
+           NULL AS actor_user_id, 'llm_execution' AS source,
+           'Backtest usage.' AS reason,
+           NULL AS reference_type, NULL AS reference_id,
+           MAX(created_at) AS created_at,
+           NULL AS reservation_id, run_id, NULL AS call_index,
+           COUNT(DISTINCT call_index) AS model_call_count,
+           NULL AS evidence_json
+    FROM credit_llm_usage_entries
+    WHERE user_id = ?
+    GROUP BY user_id, run_id
+)
+```
+
+Before the connection closes, load evidence for only the selected run summaries
+with one bounded query:
+
+```python
+selected_rows = rows[:page_size]
+run_ids = list(
+    dict.fromkeys(
+        str(row["run_id"])
+        for row in selected_rows
+        if row["source_kind"] == "llm_usage" and row["run_id"] is not None
+    )
+)
+evidence_by_run: dict[str, list[object]] = {run_id: [] for run_id in run_ids}
+if run_ids:
+    placeholders = ", ".join("?" for _ in run_ids)
+    evidence_rows = conn.execute(
+        f"""
+        SELECT DISTINCT run_id, evidence_json
+        FROM credit_llm_usage_entries
+        WHERE user_id = ? AND run_id IN ({placeholders})
+        """,
+        [user_id, *run_ids],
+    ).fetchall()
+    for evidence_row in evidence_rows:
+        evidence_by_run[str(evidence_row["run_id"])].append(
+            evidence_row["evidence_json"]
+        )
+```
+
+Normalize the selected rows with their page-local evidence sets:
+
+```python
+items = [
+    normalize_activity_item(
+        dict(row),
+        evidence_json_values=evidence_by_run.get(str(row["run_id"]), ()),
+    )
+    for row in selected_rows
+]
+```
+
+- [ ] **Step 5: Run SQLite repository tests**
+
+Run:
+
+```bash
+pytest dashboard/backend/tests/domain/credits/test_repository.py -q
+```
+
+Expected: PASS. The original purchase/refund and legacy-cursor tests remain
+green, and each run appears exactly once.
+
+- [ ] **Step 6: Commit the SQLite projection**
+
+```bash
+git add dashboard/backend/domain/credits/repository_common.py dashboard/backend/domain/credits/repository.py dashboard/backend/tests/domain/credits/test_repository.py
+git commit -m "fix(credits): aggregate SQLite activity by backtest"
+```
+
+---
+
+### Task 2: PostgreSQL Projection Parity
+
+**Files:**
+- Modify: `dashboard/backend/domain/credits/repository_postgres.py:1410-1513`
+- Test: `dashboard/backend/tests/domain/credits/test_repository_postgres.py:467-492`
+
+**Interfaces:**
+- Consumes: `normalize_activity_item(..., evidence_json_values=...)` from Task 1.
+- Produces: `PostgresCreditsStore.list_ledger_entries(...)` with the same run-level item shape, ordering, and cursor behavior as SQLite.
+
+- [ ] **Step 1: Add a failing live-PostgreSQL run aggregation test**
+
+Add this test beside the current Postgres projection/pagination test:
+
+```python
+@pg_only
+def test_postgres_activity_aggregates_calls_before_pagination(pg_credits_store):
+    store = pg_credits_store
+    _pending_order(store)
+    _pay_order(store)
+    for call_index, amount in enumerate((137, 1_147)):
+        reservation_id = f"pg-activity:{call_index}"
+        reservation = store.reserve_llm_credits(
+            reservation_id=reservation_id,
+            user_id=1,
+            run_id="run-pg-activity",
+            call_index=call_index,
+            reserved_micro=amount,
+            operation_key=f"reserve:{reservation_id}",
+            request_digest=str(call_index).ljust(64, "b"),
+        )
+        store.settle_llm_credits(
+            reservation["reservation_id"],
+            actual_micro=amount,
+            evidence={
+                "billing_source": "platform_credits",
+                "pricing_snapshot": {
+                    "provider_id": "openrouter",
+                    "model_id": "anthropic/claude-haiku-4-5",
+                },
+            },
+        )
+
+    first = store.list_ledger_entries(1, limit=1)
+    second = store.list_ledger_entries(1, limit=1, cursor=first["next_cursor"])
+    usage = next(
+        item
+        for item in [*first["items"], *second["items"]]
+        if item["entry_type"] == "backtest_usage"
+    )
+
+    assert usage["amount_micro"] == -1_284
+    assert usage["model_call_count"] == 2
+    assert usage["provider_id"] == "openrouter"
+    assert usage["model_id"] == "anthropic/claude-haiku-4-5"
+    assert first["items"][0]["id"] != second["items"][0]["id"]
+```
+
+- [ ] **Step 2: Run the Postgres test and verify it fails when Postgres is configured**
+
+Run:
+
+```bash
+pytest dashboard/backend/tests/domain/credits/test_repository_postgres.py -q -k "activity_aggregates"
+```
+
+Expected with `TEST_POSTGRES_URL` configured: FAIL because each call is still a
+separate item. Expected without it: one documented SKIP; CI performs the live
+contract run.
+
+- [ ] **Step 3: Mirror the SQLite aggregation in PostgreSQL**
+
+Add `NULL::BIGINT AS model_call_count` to the historical projection. Replace
+the Postgres usage CTE with the typed equivalent:
+
+```sql
+llm_activity AS (
+    SELECT MAX(id) AS source_id, 'llm_usage' AS source_kind,
+           user_id, NULL::TEXT AS bucket,
+           'backtest_usage' AS entry_type,
+           SUM(amount_micro) AS amount_micro,
+           NULL::TEXT AS payment_order_id,
+           NULL::TEXT AS refund_request_id,
+           NULL::TEXT AS stripe_event_id,
+           NULL::TEXT AS operation_key,
+           NULL::TEXT AS operation_id,
+           NULL::TEXT AS idempotency_key,
+           NULL::TEXT AS request_digest,
+           NULL::INTEGER AS actor_user_id,
+           'llm_execution' AS source, 'Backtest usage.' AS reason,
+           NULL::TEXT AS reference_type,
+           NULL::TEXT AS reference_id,
+           MAX(created_at) AS created_at,
+           NULL::TEXT AS reservation_id, run_id,
+           NULL::BIGINT AS call_index,
+           COUNT(DISTINCT call_index) AS model_call_count,
+           NULL::TEXT AS evidence_json
+    FROM credit_llm_usage_entries
+    WHERE user_id = %s
+    GROUP BY user_id, run_id
+)
+```
+
+Fetch selected-page evidence inside the same connection and transaction scope:
+
+```python
+selected_rows = rows[:page_size]
+run_ids = list(
+    dict.fromkeys(
+        str(row["run_id"])
+        for row in selected_rows
+        if row["source_kind"] == "llm_usage" and row["run_id"] is not None
+    )
+)
+evidence_by_run: dict[str, list[object]] = {run_id: [] for run_id in run_ids}
+if run_ids:
+    cur.execute(
+        """
+        SELECT DISTINCT run_id, evidence_json
+        FROM credit_llm_usage_entries
+        WHERE user_id = %s AND run_id = ANY(%s)
+        """,
+        (user_id, run_ids),
+    )
+    for evidence_row in cur.fetchall():
+        evidence_by_run[str(evidence_row["run_id"])].append(
+            evidence_row["evidence_json"]
+        )
+```
+
+Normalize the selected Postgres rows with the shared function:
+
+```python
+items = [
+    normalize_activity_item(
+        dict(row),
+        evidence_json_values=evidence_by_run.get(str(row["run_id"]), ()),
+    )
+    for row in selected_rows
+]
+```
+
+- [ ] **Step 4: Run Postgres and store-parity tests**
+
+Run:
+
+```bash
+pytest dashboard/backend/tests/domain/credits/test_repository_postgres.py dashboard/backend/tests/test_store_twin_parity.py -q
+```
+
+Expected: PASS when Postgres is available; otherwise only the tests explicitly
+marked `pg_only` skip and the structural twin checks pass.
+
+- [ ] **Step 5: Commit PostgreSQL parity**
+
+```bash
+git add dashboard/backend/domain/credits/repository_postgres.py dashboard/backend/tests/domain/credits/test_repository_postgres.py
+git commit -m "fix(credits): match Postgres backtest activity"
+```
+
+---
+
+### Task 3: Public Run-Level Credits API Contract
+
+**Files:**
+- Modify: `dashboard/backend/api/routers/credits.py:82-106`
+- Test: `dashboard/backend/tests/test_credits_api.py:209-257`
+
+**Interfaces:**
+- Consumes: repository items with `entry_type="backtest_usage"` from Tasks 1 and 2.
+- Produces: authenticated `GET /api/credits/ledger` items containing `run_id`, `model_call_count`, safe provider/model summary fields, `billing_source`, exact `display_credits`, and no reservation/call/evidence fields.
+
+- [ ] **Step 1: Replace the API test with a failing two-call run contract**
+
+Update `test_credit_activity_exposes_safe_aggregated_llm_usage` so it settles
+two calls for one run and asserts one public item:
+
+```python
+def test_credit_activity_exposes_safe_aggregated_backtest_usage(billing_api):
+    token = _signup(billing_api.client, "usage-api@example.com")
+    checkout = _checkout(billing_api.client, token).json()["checkout"]
+    billing_api.gateway.event = _paid_checkout_event(checkout)
+    assert _deliver_webhook(billing_api).status_code == 200
+    for call_index, amount in enumerate((137, 1_147)):
+        reservation_id = f"api-usage-reservation-{call_index}"
+        reservation = billing_api.store.reserve_llm_credits(
+            reservation_id=reservation_id,
+            user_id=1,
+            run_id="run-api-usage",
+            call_index=call_index,
+            reserved_micro=amount,
+            operation_key=f"api-usage-reserve-{call_index}",
+            request_digest=str(call_index).ljust(64, "f"),
+        )
+        billing_api.store.settle_llm_credits(
+            reservation["reservation_id"],
+            actual_micro=amount,
+            evidence={
+                "billing_source": "platform_credits",
+                "pricing_snapshot": {
+                    "provider_id": "openrouter",
+                    "model_id": "anthropic/claude-haiku-4-5",
+                },
+                "api_key": "synthetic-secret-must-not-leak",
+            },
+        )
+
+    response = billing_api.client.get(
+        "/api/credits/ledger?limit=1",
+        headers=_auth(token),
+    )
+    body = response.json()
+    usage = body["items"][0]
+
+    assert response.status_code == 200
+    assert usage["entry_type"] == "backtest_usage"
+    assert usage["amount_micro"] == -1_284
+    assert usage["display_credits"] == "-0.001284"
+    assert usage["run_id"] == "run-api-usage"
+    assert usage["model_call_count"] == 2
+    assert usage["provider_id"] == "openrouter"
+    assert usage["model_id"] == "anthropic/claude-haiku-4-5"
+    assert usage["provider_mixed"] is False
+    assert usage["model_mixed"] is False
+    assert usage["billing_source"] == "platform_credits"
+    assert "reservation_id" not in usage
+    assert "call_index" not in usage
+    assert isinstance(body["next_cursor"], str)
+    assert "evidence_json" not in str(body)
+    assert "synthetic-secret-must-not-leak" not in str(body)
+
+    second = billing_api.client.get(
+        "/api/credits/ledger",
+        params={"limit": 1, "cursor": body["next_cursor"]},
+        headers=_auth(token),
+    )
+    assert second.status_code == 200
+    assert second.json()["items"][0]["entry_type"] == "purchase"
+```
+
+- [ ] **Step 2: Run the API test and verify the call-level serializer fails**
+
+Run:
+
+```bash
+pytest dashboard/backend/tests/test_credits_api.py -q -k "aggregated_backtest_usage"
+```
+
+Expected: FAIL until `_public_ledger_entry` recognizes `backtest_usage` and
+allowlists the new summary fields.
+
+- [ ] **Step 3: Update the public serializer allowlist**
+
+Replace the usage-specific branch in `_public_ledger_entry` with:
+
+```python
+if entry.get("entry_type") == "backtest_usage":
+    result.update(
+        {
+            "run_id": entry.get("run_id"),
+            "model_call_count": entry.get("model_call_count"),
+            "provider_id": entry.get("provider_id"),
+            "model_id": entry.get("model_id"),
+            "provider_mixed": bool(entry.get("provider_mixed")),
+            "model_mixed": bool(entry.get("model_mixed")),
+            "billing_source": entry.get("billing_source"),
+        }
+    )
+```
+
+Do not serialize `reservation_id`, `call_index`, `evidence_json`, or any raw
+evidence keys.
+
+- [ ] **Step 4: Run Credits API and service contracts**
+
+Run:
+
+```bash
+pytest dashboard/backend/tests/test_credits_api.py dashboard/backend/tests/test_credits_api_review_fixes.py dashboard/backend/tests/domain/credits/test_service.py -q
+```
+
+Expected: PASS with exact six-decimal API strings and unchanged authentication,
+purchase, refund, and error boundaries.
+
+- [ ] **Step 5: Commit the API contract**
+
+```bash
+git add dashboard/backend/api/routers/credits.py dashboard/backend/tests/test_credits_api.py
+git commit -m "fix(credits): expose backtest usage summaries"
+```
+
+---
+
+### Task 4: Exact Six-Decimal Frontend and Run-Level Activity UI
+
+**Files:**
+- Create: `dashboard/frontend/js/credit-format.js`
+- Create: `dashboard/backend/tests/test_credit_format_frontend.py`
+- Modify: `dashboard/frontend/app.html:1893-1899,2401-2409`
+- Modify: `dashboard/frontend/js/credits.js:45-52,443-479`
+- Modify: `dashboard/frontend/js/admin-credits.js:77-81,130-153,406`
+- Modify: `dashboard/frontend/js/admin-analytics.js:218-223`
+- Modify: `dashboard/backend/tests/test_credits_frontend.py:20-86`
+- Modify: `dashboard/backend/tests/test_admin_credits_frontend.py:107-115`
+- Modify: `dashboard/backend/tests/test_admin_analytics_frontend.py:90-95,190-196`
+- Modify: `dashboard/backend/tests/test_frontend_fast_boot.py:188-199`
+
+**Interfaces:**
+- Produces: `window.CreditFormat.formatCredits(value: unknown) -> string`
+- Produces: `window.CreditFormat.formatCreditsMicro(value: unknown) -> string`
+- Consumes: Task 3 `backtest_usage` fields and exact `display_credits`.
+- Preserves: safe `textContent` rendering, no-build deferred script order, tab behavior, and existing ARIA live regions.
+
+- [ ] **Step 1: Add behavioral tests for the exact formatter and static UI contract**
+
+Create `test_credit_format_frontend.py`:
+
+```python
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
+FORMAT_JS = FRONTEND / "js" / "credit-format.js"
+APP_HTML = (FRONTEND / "app.html").read_text(encoding="utf-8")
+
+
+requires_node = pytest.mark.skipif(
+    shutil.which("node") is None,
+    reason="node is required for exact Credits formatter tests",
+)
+
+
+def _run_formatter(expressions: list[str]) -> list[str]:
+    source = FORMAT_JS.read_text(encoding="utf-8")
+    script = "\n".join(
+        [
+            "const window = globalThis;",
+            source,
+            f"console.log(JSON.stringify([{', '.join(expressions)}]));",
+        ]
+    )
+    result = subprocess.run(
+        ["node", "-e", script],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
+    )
+    return json.loads(result.stdout)
+
+
+@requires_node
+def test_credit_formatter_keeps_exact_fixed_six_decimal_values():
+    assert _run_formatter(
+        [
+            'CreditFormat.formatCredits("4.79")',
+            'CreditFormat.formatCredits("-0.000137")',
+            'CreditFormat.formatCredits("1234")',
+            "CreditFormat.formatCreditsMicro(4790000)",
+            "CreditFormat.formatCreditsMicro(-137)",
+            'CreditFormat.formatCreditsMicro("9007199254740993")',
+        ]
+    ) == [
+        "4.790000",
+        "-0.000137",
+        "1,234.000000",
+        "4.790000",
+        "-0.000137",
+        "9,007,199,254.740993",
+    ]
+
+
+@requires_node
+def test_credit_formatter_rejects_missing_float_and_overprecision_values():
+    assert _run_formatter(
+        [
+            "CreditFormat.formatCredits(null)",
+            'CreditFormat.formatCredits("1.0000001")',
+            "CreditFormat.formatCreditsMicro(0.5)",
+            "CreditFormat.formatCreditsMicro(Number.NaN)",
+        ]
+    ) == ["—", "—", "—", "—"]
+
+
+def test_credit_formatter_loads_before_every_consumer():
+    formatter_at = APP_HTML.index('src="js/credit-format.js?v=1"')
+    for asset in (
+        'src="js/credits.js?v=5"',
+        'src="js/admin-credits.js?v=6"',
+        'src="js/admin-analytics.js?v=2"',
+    ):
+        assert formatter_at < APP_HTML.index(asset)
+
+
+def test_static_credit_package_amounts_use_six_decimals():
+    for amount in ("5.000000", "10.000000", "20.000000", "50.000000"):
+        assert f">{amount} Credits</span>" in APP_HTML
+    assert "$1 = 1.000000 Credits" in APP_HTML
+```
+
+Extend the existing frontend contracts to require:
+
+```python
+def test_activity_renders_one_backtest_usage_summary_with_safe_context():
+    source = CREDITS_JS_PATH.read_text(encoding="utf-8")
+    assert "entry.entry_type === 'backtest_usage'" in source
+    assert "'Backtest usage'" in source
+    assert "entry.model_call_count" in source
+    assert "'Multiple providers'" in source
+    assert "'Multiple models'" in source
+    assert "String(entry.run_id).slice(0, 12)" in source
+    assert "entry.call_index" not in source
+```
+
+- [ ] **Step 2: Run frontend tests and verify the formatter and run title are absent**
+
+Run:
+
+```bash
+pytest dashboard/backend/tests/test_credit_format_frontend.py dashboard/backend/tests/test_credits_frontend.py dashboard/backend/tests/test_admin_credits_frontend.py dashboard/backend/tests/test_admin_analytics_frontend.py dashboard/backend/tests/test_frontend_fast_boot.py -q
+```
+
+Expected: FAIL because the shared formatter does not exist, package values use
+integer copy, and Credits Activity recognizes only `llm_usage`.
+
+- [ ] **Step 3: Implement the shared string/integer formatter**
+
+Create `dashboard/frontend/js/credit-format.js`:
+
+```javascript
+/** Exact ATL Credit formatting. One Credit is 1,000,000 micro-Credits. */
+(function () {
+  'use strict';
+
+  const UNAVAILABLE = '—';
+
+  function groupWhole(value) {
+    return value.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  }
+
+  function formatCredits(value) {
+    const text = value == null ? '' : String(value);
+    const match = /^(-?)(\d+)(?:\.(\d{1,6}))?$/.exec(text);
+    if (!match) return UNAVAILABLE;
+    const fraction = (match[3] || '').padEnd(6, '0');
+    const isZero = /^0+$/.test(match[2]) && !/[1-9]/.test(fraction);
+    const sign = match[1] && !isZero ? '-' : '';
+    return `${sign}${groupWhole(match[2])}.${fraction}`;
+  }
+
+  function formatCreditsMicro(value) {
+    const text = typeof value === 'number' && Number.isSafeInteger(value)
+      ? String(value)
+      : (typeof value === 'string' && /^-?\d+$/.test(value) ? value : '');
+    if (!text) return UNAVAILABLE;
+    const micro = BigInt(text);
+    const sign = micro < 0n ? '-' : '';
+    const absolute = micro < 0n ? -micro : micro;
+    const whole = groupWhole(String(absolute / 1000000n));
+    const fraction = String(absolute % 1000000n).padStart(6, '0');
+    return `${sign}${whole}.${fraction}`;
+  }
+
+  window.CreditFormat = Object.freeze({ formatCredits, formatCreditsMicro });
+})();
+```
+
+Load `js/credit-format.js?v=1` before `credits.js`, `admin-credits.js`, and
+`admin-analytics.js`. Change the static package copy to:
+
+```html
+<span class="credits-rate">$1 = 1.000000 Credits</span>
+```
+
+and use `5.000000`, `10.000000`, `20.000000`, and `50.000000 Credits` in the
+four package buttons.
+
+- [ ] **Step 4: Use the formatter in all billing and analytics consumers**
+
+In `credits.js`, bind the helper once and remove the local truncating
+`formatCreditDisplay`:
+
+```javascript
+const { formatCredits } = window.CreditFormat;
+```
+
+Use `formatCredits(balance.display_credits)` for the balance and
+`formatCredits(entry.display_credits)` for Activity.
+
+In `admin-credits.js`, bind both functions:
+
+```javascript
+const { formatCredits, formatCreditsMicro } = window.CreditFormat;
+```
+
+Use authoritative integer fields for the Grant Pool total and ring inputs:
+
+```javascript
+const availableMicro = pool.pool_available_micro;
+const allocatedMicro = pool.allocated_to_users_micro;
+const validAvailable = Number.isSafeInteger(availableMicro);
+const validAllocated = Number.isSafeInteger(allocatedMicro);
+const totalMicro = validAvailable && validAllocated
+  && Number.isSafeInteger(availableMicro + allocatedMicro)
+  ? availableMicro + allocatedMicro
+  : null;
+const availableText = formatCreditsMicro(availableMicro);
+const allocatedText = formatCreditsMicro(allocatedMicro);
+const totalText = formatCreditsMicro(totalMicro);
+const chartAvailable = validAvailable && availableMicro > 0 ? availableMicro : 0;
+const chartAllocated = validAllocated && allocatedMicro > 0 ? allocatedMicro : 0;
+const chartTotal = chartAvailable + chartAllocated;
+const availableRatio = chartTotal > 0 ? chartAvailable / chartTotal : 0;
+const allocatedRatio = chartTotal > 0 ? chartAllocated / chartTotal : 0;
+```
+
+Render the assign confirmation with
+`formatCreditsMicro(amountMicro)` instead of echoing the raw input. Keep API
+`display_credits` values formatted through `formatCredits` for user balance and
+Grant Activity tables.
+
+In `admin-analytics.js`, replace the floating point division formatter with:
+
+```javascript
+function formatCreditsMicro(value) {
+  return window.CreditFormat.formatCreditsMicro(value) === '—'
+    ? '—'
+    : `${window.CreditFormat.formatCreditsMicro(value)} Credits`;
+}
+```
+
+- [ ] **Step 5: Render one Backtest usage row with call count and mixed context**
+
+Replace the usage branch in `credits.js` with:
+
+```javascript
+const isUsage = entry.entry_type === 'backtest_usage';
+const isNegative = isUsage || entry.entry_type === 'refund';
+const title = isUsage
+  ? 'Backtest usage'
+  : (entry.entry_type === 'refund' ? 'Refund' : 'Credit purchase');
+const callCount = Number.isSafeInteger(entry.model_call_count)
+  && entry.model_call_count > 0
+  ? `${entry.model_call_count} model call${entry.model_call_count === 1 ? '' : 's'}`
+  : null;
+const usageDetail = isUsage
+  ? [
+      entry.provider_mixed ? 'Multiple providers' : entry.provider_id,
+      entry.model_mixed ? 'Multiple models' : entry.model_id,
+      callCount,
+      entry.run_id ? `run ${String(entry.run_id).slice(0, 12)}` : null,
+    ].filter(Boolean).join(' · ')
+  : null;
+```
+
+Continue building nodes with `textContent`; do not introduce HTML interpolation
+for provider, model, or run identifiers.
+
+- [ ] **Step 6: Bump changed asset versions and update the single-owner cache contract**
+
+Set the asset references in `app.html` to:
+
+```html
+<script src="js/credit-format.js?v=1" defer></script>
+<script src="js/credits.js?v=5" defer></script>
+<script src="js/admin-credits.js?v=6" defer></script>
+<script src="js/admin-analytics.js?v=2" defer></script>
+```
+
+Update existing exact-version assertions that reference the changed assets and
+add `credit-format.js?v=1` to
+`test_frontend_fast_boot.py::test_cache_busters_bumped`.
+
+- [ ] **Step 7: Run the behavioral and static frontend contracts**
+
+Run:
+
+```bash
+pytest dashboard/backend/tests/test_credit_format_frontend.py dashboard/backend/tests/test_credits_frontend.py dashboard/backend/tests/test_admin_credits_frontend.py dashboard/backend/tests/test_admin_analytics_frontend.py dashboard/backend/tests/test_frontend_fast_boot.py -q
+```
+
+Expected: PASS. Node verifies exact large/small/negative formatting; static
+contracts verify deferred load order, cache versions, and run-level copy.
+
+- [ ] **Step 8: Perform safe browser visual verification**
+
+Start the dashboard against a new temporary SQLite path:
+
+```bash
+ui_check_dir=$(mktemp -d /tmp/atl-credit-ui.XXXXXX)
+DATABASE_PATH="$ui_check_dir/ui-check.db" python -m uvicorn dashboard.backend.app:app --host 127.0.0.1 --port 8770
+```
+
+Use browser request interception for `/api/auth/me`, `/api/credits/balance`,
+and `/api/credits/ledger`. Return these synthetic bodies:
+
+```json
+{"user":{"id":1,"email":"ui-check@example.test","display_name":"UI Check","role":"admin"}}
+```
+
+```json
+{"balance":{"balance_micro":4790000,"display_credits":"4.790000","account_status":"active","billing_available":true},"test_mode":true}
+```
+
+```json
+{"items":[{"id":42,"source_kind":"llm_usage","bucket":null,"entry_type":"backtest_usage","amount_micro":-1284,"display_credits":"-0.001284","source":"llm_execution","reason":"Backtest usage.","payment_order_id":null,"created_at":"2026-08-27T15:44:00+00:00","run_id":"run_visual_check_001","model_call_count":12,"provider_id":"openrouter","model_id":"anthropic/claude-haiku-4-5","provider_mixed":false,"model_mixed":false,"billing_source":"platform_credits"}],"next_cursor":null}
+```
+
+Mock `/api/credits/model-providers` as `{"providers":[]}`,
+`/api/credits/api-keys` as `{"items":[]}`, and
+`/api/credits/execution-options` as `{"providers":[]}`. Then open
+`http://127.0.0.1:8770/app?view=credits`, select Credits and Activity, and
+verify at desktop and 390px viewport widths:
+
+1. Balance reads `4.790000 Credits`.
+2. Package cards and `$1` rate use six decimals without overflow.
+3. One run with twelve calls shows one `Backtest usage` row.
+4. The row reads `12 model calls` and `-0.001284`.
+5. Mixed provider/model copy wraps without covering the amount.
+6. Keyboard tab navigation and existing ARIA live regions still work.
+
+Do not use a production database, real provider key, or real Stripe credential.
+
+- [ ] **Step 9: Commit the frontend behavior**
+
+```bash
+git add dashboard/frontend/js/credit-format.js dashboard/frontend/app.html dashboard/frontend/js/credits.js dashboard/frontend/js/admin-credits.js dashboard/frontend/js/admin-analytics.js dashboard/backend/tests/test_credit_format_frontend.py dashboard/backend/tests/test_credits_frontend.py dashboard/backend/tests/test_admin_credits_frontend.py dashboard/backend/tests/test_admin_analytics_frontend.py dashboard/backend/tests/test_frontend_fast_boot.py
+git commit -m "fix(ui): show exact run-level Credit activity"
+```
+
+---
+
+### Task 5: Full Regression Verification and Pull Request
+
+**Files:**
+- Verify only: all files changed in Tasks 1-4
+- Verify only: `docs/superpowers/specs/2026-08-28-backtest-credit-activity-design.md`
+- Verify only: `docs/superpowers/plans/2026-08-28-backtest-credit-activity.md`
+
+**Interfaces:**
+- Consumes: all repository, API, and frontend contracts from Tasks 1-4.
+- Produces: a reviewable GitHub pull request targeting `main` with no unrelated files or secrets.
+
+- [ ] **Step 1: Run the complete focused regression set**
+
+Run:
+
+```bash
+pytest dashboard/backend/tests/domain/credits/test_repository.py dashboard/backend/tests/domain/credits/test_repository_postgres.py dashboard/backend/tests/test_store_twin_parity.py dashboard/backend/tests/domain/credits/test_service.py dashboard/backend/tests/test_credits_api.py dashboard/backend/tests/test_credits_api_review_fixes.py dashboard/backend/tests/test_credit_format_frontend.py dashboard/backend/tests/test_credits_frontend.py dashboard/backend/tests/test_admin_credits_frontend.py dashboard/backend/tests/test_admin_analytics_frontend.py dashboard/backend/tests/test_frontend_fast_boot.py -q
+```
+
+Expected: all non-Postgres tests PASS; live Postgres tests PASS when
+`TEST_POSTGRES_URL` is set and otherwise report only their declared skips.
+
+- [ ] **Step 2: Run the full backend suite**
+
+Run:
+
+```bash
+pytest dashboard/backend/tests/ --timeout=180 -p no:cacheprovider
+```
+
+Expected: no new failures. If the known marketplace-card baseline test remains
+red, run the same test against `origin/main` and record both identical results
+in the PR; do not alter unrelated marketplace code in this branch.
+
+- [ ] **Step 3: Audit the diff and repository contents**
+
+Run:
+
+```bash
+git diff --check origin/main...HEAD
+git status --short
+git diff --stat origin/main...HEAD
+git log --oneline origin/main..HEAD
+git diff --name-only origin/main...HEAD
+```
+
+Expected: only the approved spec, plan, Credits repositories/API/tests, exact
+Credit frontend files/tests, and cache-version HTML are present. No database,
+secret, `.superpowers/`, or nested `work/` path appears.
+
+- [ ] **Step 4: Push the branch and create the pull request**
+
+```bash
+git push -u origin fix/backtest-credit-activity
+gh pr create --base main --head fix/backtest-credit-activity --title "Fix backtest Credit activity precision" --body "## Summary
+- display ATL Credit values with exact fixed six-decimal precision
+- aggregate settled model-call debits into one Activity row per backtest run
+- keep SQLite and PostgreSQL pagination, evidence safety, and account isolation aligned
+
+## Tests
+- focused Credits repository, API, frontend, and parity tests
+- full dashboard backend test suite
+- safe desktop and mobile browser verification"
+```
+
+Expected: GitHub returns a PR URL whose base is `main` and whose file list
+matches Step 3.
+
+- [ ] **Step 5: Inspect the remote PR checks and final diff**
+
+Run:
+
+```bash
+gh pr view --json number,url,baseRefName,headRefName,files,statusCheckRollup
+```
+
+Expected: `baseRefName` is `main`, `headRefName` is
+`fix/backtest-credit-activity`, checks are passing or in progress, and no
+unrelated file is present.

--- a/docs/superpowers/plans/2026-08-29-pr411-main-sync.md
+++ b/docs/superpowers/plans/2026-08-29-pr411-main-sync.md
@@ -1,0 +1,286 @@
+# PR 411 Main Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update PR #411 onto the latest `main`, resolve its three Credits frontend conflicts, and produce a fresh green GitHub Actions run without including unrelated local benchmark commits.
+
+**Architecture:** Merge `origin/main` into an isolated repair branch created from `origin/fix/backtest-credit-activity`. Compose PR #410's checkout and welcome-grant behavior with PR #411's shared fixed-six-decimal formatter and run-level Activity presentation, then push the tested merge commit explicitly to the PR head branch.
+
+**Tech Stack:** Git, Python 3.13, pytest, vanilla JavaScript, HTML, GitHub Actions, SQLite locally, PostgreSQL 18 in CI.
+
+**Spec:** `docs/superpowers/specs/2026-08-29-pr411-main-sync-design.md`
+
+## Global Constraints
+
+- Work only in the isolated `repair/pr411-main-sync` worktree based on `origin/fix/backtest-credit-activity`.
+- Do not include the unrelated local benchmark commits that follow `e33df7c` on the local `fix/backtest-credit-activity` branch.
+- Preserve integer micro-Credit arithmetic and exact six-decimal public display strings.
+- Preserve PR #410's `$0.50`, `$1`, `$2`, and `$5` packages, `$1` default, `$0.50` through `$5.00` custom range, and `Welcome Credits` Activity row.
+- Preserve PR #411's one-row-per-backtest Activity contract and safe aggregated provider, model, call-count, and run context.
+- Do not commit secrets, API keys, database files, `.superpowers/`, or `work/` artifacts.
+- Push without force to `origin/fix/backtest-credit-activity` only after local verification passes.
+
+---
+
+### Task 1: Merge Current Main And Resolve Credits Frontend Contracts
+
+**Files:**
+- Modify: `dashboard/frontend/app.html:1890-1910`
+- Modify: `dashboard/frontend/app.html:2402-2410`
+- Modify: `dashboard/frontend/js/credits.js:1-55`
+- Modify: `dashboard/frontend/js/credits.js:440-485`
+- Modify: `dashboard/frontend/js/credits.js:518-528`
+- Modify: `dashboard/backend/tests/test_frontend_fast_boot.py:190-205`
+- Modify: `dashboard/backend/tests/test_credit_format_frontend.py:74-82`
+- Verify: `dashboard/backend/tests/test_credits_frontend.py`
+
+**Interfaces:**
+- Consumes: `window.CreditFormat.formatCredits(value)` from `dashboard/frontend/js/credit-format.js`, which returns a fixed-six-decimal string or an em dash for an invalid value.
+- Consumes: public Activity entries with `entry_type`, `display_credits`, `provider_id`, `model_id`, `provider_mixed`, `model_mixed`, `model_call_count`, `run_id`, and `created_at`.
+- Produces: checkout markup with small packages and exact display labels, plus Activity rows that distinguish `backtest_usage`, `system_promotion_grant`, refunds, and purchases.
+
+- [ ] **Step 1: Merge latest main and record the expected conflicts**
+
+  Run:
+
+  ```bash
+  git fetch origin main fix/backtest-credit-activity
+  git merge --no-ff origin/main
+  ```
+
+  Expected: Git stops with content conflicts only in:
+
+  ```text
+  dashboard/backend/tests/test_frontend_fast_boot.py
+  dashboard/frontend/app.html
+  dashboard/frontend/js/credits.js
+  ```
+
+- [ ] **Step 2: Compose checkout markup and asset versions**
+
+  Resolve `dashboard/frontend/app.html` with these checkout contracts:
+
+  ```html
+  <span class="credits-rate">$1 = 1.000000 Credits</span>
+  <div id="creditsPackageGrid" class="credits-package-grid" role="radiogroup" aria-label="Credit package">
+      <button class="credits-package-btn" type="button" role="radio" aria-checked="false" data-credit-package="usd_0_50" data-credit-cents="50"><strong>$0.50</strong><span>0.500000 Credits</span></button>
+      <button class="credits-package-btn is-selected" type="button" role="radio" aria-checked="true" data-credit-package="usd_1" data-credit-cents="100"><strong>$1</strong><span>1.000000 Credits</span></button>
+      <button class="credits-package-btn" type="button" role="radio" aria-checked="false" data-credit-package="usd_2" data-credit-cents="200"><strong>$2</strong><span>2.000000 Credits</span></button>
+      <button class="credits-package-btn" type="button" role="radio" aria-checked="false" data-credit-package="usd_5" data-credit-cents="500"><strong>$5</strong><span>5.000000 Credits</span></button>
+  </div>
+  ```
+
+  Keep the `type="number" min="0.50" max="5.00" step="0.01"` custom input and its `Minimum $0.50, maximum $5.00.` hint from `main`.
+
+  Resolve the asset block as:
+
+  ```html
+  <script src="js/credit-format.js?v=1" defer></script>
+  <script src="js/credits.js?v=7" defer></script>
+  <script src="js/admin-model-providers.js?v=1" defer></script>
+  <script src="js/admin-credits.js?v=6" defer></script>
+  <script src="js/admin-analytics.js?v=2" defer></script>
+  ```
+
+  Version `7` is newer than `main`'s `credits.js?v=6` and PR #411's `credits.js?v=5`, so browsers cannot retain either parent implementation.
+
+- [ ] **Step 3: Compose the Credits client behavior**
+
+  Resolve `dashboard/frontend/js/credits.js` so its header uses the shared formatter and the small default package:
+
+  ```javascript
+  /** Credits & Billing page. Server ledgers remain the only source of balance changes. */
+  (function () {
+    'use strict';
+
+    const { formatCredits } = window.CreditFormat;
+  ```
+
+  Keep:
+
+  ```javascript
+  selection: { kind: 'package', value: 'usd_1' },
+  ```
+
+  Remove `formatCreditDisplay`; balance and Activity amounts must call the shared `formatCredits` helper.
+
+  Compose the Activity branch as:
+
+  ```javascript
+  const isUsage = entry.entry_type === 'backtest_usage';
+  const isWelcomeGrant = entry.entry_type === 'system_promotion_grant';
+  const isNegative = isUsage || entry.entry_type === 'refund';
+  const title = isUsage
+    ? 'Backtest usage'
+    : (entry.entry_type === 'refund'
+      ? 'Refund'
+      : (isWelcomeGrant ? 'Welcome Credits' : 'Credit purchase'));
+  const callCount = Number.isSafeInteger(entry.model_call_count)
+    && entry.model_call_count > 0
+    ? `${entry.model_call_count} model call${entry.model_call_count === 1 ? '' : 's'}`
+    : null;
+  const usageDetail = isUsage
+    ? [
+      entry.provider_mixed ? 'Multiple providers' : entry.provider_id,
+      entry.model_mixed ? 'Multiple models' : entry.model_id,
+      callCount,
+      entry.run_id ? `run ${String(entry.run_id).slice(0, 12)}` : null,
+    ]
+      .filter(Boolean)
+      .join(' · ')
+    : null;
+  ```
+
+  Keep PR #410's custom checkout validation:
+
+  ```javascript
+  if (cents === null || cents < 50 || cents > 500) {
+    throw new Error('Enter a custom amount from $0.50 through $5.00.');
+  }
+  ```
+
+- [ ] **Step 4: Update asset contract tests**
+
+  Resolve `test_cache_busters_bumped` in `dashboard/backend/tests/test_frontend_fast_boot.py` with:
+
+  ```python
+  assert "js/credit-format.js?v=1" in APP_HTML
+  assert "js/credits.js?v=7" in APP_HTML
+  assert "js/admin-credits.js?v=6" in APP_HTML
+  assert "js/admin-analytics.js?v=2" in APP_HTML
+  ```
+
+  Update `test_credit_formatter_loads_before_every_consumer` in `dashboard/backend/tests/test_credit_format_frontend.py` so its consumer list expects `src="js/credits.js?v=7"` while leaving the admin asset versions unchanged.
+
+- [ ] **Step 5: Verify no unresolved markers or unintended files**
+
+  Run:
+
+  ```bash
+  git diff --check
+  git diff --name-only --diff-filter=U
+  rg -n '^(<<<<<<<|=======|>>>>>>>)' dashboard docs
+  git status --short
+  ```
+
+  Expected: no unmerged paths and no conflict markers. Stage the resolved files and finish the merge commit:
+
+  ```bash
+  git add dashboard/frontend/app.html \
+    dashboard/frontend/js/credits.js \
+    dashboard/backend/tests/test_frontend_fast_boot.py \
+    dashboard/backend/tests/test_credit_format_frontend.py
+  git commit
+  ```
+
+  Expected merge subject: `Merge remote-tracking branch 'origin/main' into repair/pr411-main-sync`.
+
+### Task 2: Verify Combined Credits And Repository Behavior
+
+**Files:**
+- Test: `dashboard/backend/tests/test_credit_format_frontend.py`
+- Test: `dashboard/backend/tests/test_credits_frontend.py`
+- Test: `dashboard/backend/tests/test_admin_credits_frontend.py`
+- Test: `dashboard/backend/tests/test_admin_analytics_frontend.py`
+- Test: `dashboard/backend/tests/test_frontend_fast_boot.py`
+- Test: `dashboard/backend/tests/test_frontend_model_facets.py`
+- Test: `dashboard/backend/tests/test_credits_api.py`
+- Test: `dashboard/backend/tests/domain/credits/test_repository.py`
+- Test: `dashboard/backend/tests/domain/credits/test_repository_postgres.py`
+
+**Interfaces:**
+- Consumes: the resolved frontend asset graph and the auto-merged SQLite/PostgreSQL Credit repositories.
+- Produces: evidence that fixed precision, Welcome Credits, small checkout packages, run-level aggregation, safe API output, and the Marketplace baseline all coexist.
+
+- [ ] **Step 1: Run focused frontend and API tests**
+
+  Run:
+
+  ```bash
+  python -m pytest \
+    dashboard/backend/tests/test_credit_format_frontend.py \
+    dashboard/backend/tests/test_credits_frontend.py \
+    dashboard/backend/tests/test_admin_credits_frontend.py \
+    dashboard/backend/tests/test_admin_analytics_frontend.py \
+    dashboard/backend/tests/test_frontend_fast_boot.py \
+    dashboard/backend/tests/test_frontend_model_facets.py \
+    dashboard/backend/tests/test_credits_api.py -q
+  ```
+
+  Expected: all tests pass, including the Marketplace provider-label regression from PR #413.
+
+- [ ] **Step 2: Run focused repository tests without forcing a missing PostgreSQL service**
+
+  Run:
+
+  ```bash
+  env -u TEST_POSTGRES_URL python -m pytest \
+    dashboard/backend/tests/domain/credits/test_repository.py \
+    dashboard/backend/tests/domain/credits/test_repository_postgres.py -q
+  ```
+
+  Expected: SQLite tests pass and PostgreSQL-only cases skip locally.
+
+- [ ] **Step 3: Run the complete local backend suite**
+
+  Run:
+
+  ```bash
+  env -u TEST_POSTGRES_URL \
+    DATABASE_PATH=/tmp/atl-pr411-main-sync.db \
+    pytest dashboard/backend/tests/ -p no:cacheprovider
+  ```
+
+  Expected: all non-PostgreSQL tests pass; PostgreSQL-only tests skip. GitHub Actions will run those tests against PostgreSQL 18.
+
+- [ ] **Step 4: Verify branch scope**
+
+  Run:
+
+  ```bash
+  git log --oneline origin/fix/backtest-credit-activity..HEAD
+  git diff --check origin/main...HEAD
+  git status --short --branch
+  ```
+
+  Expected: the new history contains only the PR 411 sync design, implementation plan, and merge commit. None of the local benchmark commits `3b728fd` through `6dc71e0` appear.
+
+### Task 3: Update PR 411 And Validate GitHub Actions
+
+**Files:**
+- No additional source changes expected.
+
+**Interfaces:**
+- Consumes: locally verified `repair/pr411-main-sync` HEAD.
+- Produces: updated remote branch `fix/backtest-credit-activity`, a conflict-free PR, and a fresh CI run against current `main`.
+
+- [ ] **Step 1: Push explicitly without force**
+
+  Run:
+
+  ```bash
+  git push origin HEAD:fix/backtest-credit-activity
+  ```
+
+  Expected: a normal fast-forward push from `e33df7c`; no `--force` or `--force-with-lease`.
+
+- [ ] **Step 2: Confirm PR metadata**
+
+  Run:
+
+  ```bash
+  gh pr view 411 -R Open-Finance-Lab/AgenticTrading \
+    --json headRefOid,baseRefOid,mergeable,mergeStateStatus,statusCheckRollup,url
+  ```
+
+  Expected: GitHub no longer reports `CONFLICTING` or `DIRTY`, and new checks reference the updated head SHA.
+
+- [ ] **Step 3: Wait for checks and inspect any real failure**
+
+  Run:
+
+  ```bash
+  gh pr checks 411 -R Open-Finance-Lab/AgenticTrading --watch
+  ```
+
+  Expected: Backend tests, Packaging tests, CodeQL, and Vercel checks pass. The Render production deploy remains skipped for a pull request by workflow design.

--- a/docs/superpowers/specs/2026-08-28-backtest-credit-activity-design.md
+++ b/docs/superpowers/specs/2026-08-28-backtest-credit-activity-design.md
@@ -1,7 +1,8 @@
 # Backtest Credit Activity Precision and Aggregation Design
 
-**Date:** 2026-08-28  
-**Status:** Approved  
+**Date:** 2026-08-28
+
+**Status:** Approved
 **Scope:** Exact ATL Credit display and run-level Credits activity
 
 ## Goal

--- a/docs/superpowers/specs/2026-08-28-backtest-credit-activity-design.md
+++ b/docs/superpowers/specs/2026-08-28-backtest-credit-activity-design.md
@@ -1,0 +1,234 @@
+# Backtest Credit Activity Precision and Aggregation Design
+
+**Date:** 2026-08-28  
+**Status:** Approved  
+**Scope:** Exact ATL Credit display and run-level Credits activity
+
+## Goal
+
+Make ATL Credit balances and debits auditable at the platform's authoritative
+micro-Credit precision, and show one settled debit per backtest instead of one
+row per model call.
+
+The Credits ledger already stores integer micro-Credits, where one Credit is
+`1,000,000` micro-Credits. This change preserves that accounting model. It
+fixes presentation and activity projection only; it does not recalculate,
+round, or migrate stored charges.
+
+## Current problem
+
+The Credits & Billing frontend truncates `display_credits` to two decimal
+places. A valid debit smaller than `0.01` Credits therefore appears as
+`-0.00`, even though the API and ledger contain an exact six-decimal value.
+The balance has the same two-decimal limitation.
+
+The Activity query currently groups settled usage by reservation and
+`call_index`. A single backtest can make many model calls, so one backtest
+produces many nearly identical `Model usage` rows. This makes it difficult to
+answer the user-level question: how many ATL Credits did this backtest cost?
+
+## Product decisions
+
+1. Every displayed ATL Credit amount uses exactly six decimal places.
+2. Activity groups settled model usage by account and `run_id`.
+3. A run appears once when it has at least one settled debit, whether the
+   backtest ultimately succeeded or failed.
+4. A failed or cancelled run with no settled debit does not create a zero-cost
+   Activity row.
+5. Per-call usage remains in the append-only accounting tables and analytics
+   evidence. Activity is a read projection, not a replacement ledger.
+
+## Exact amount display
+
+All ATL Credit amounts rendered in the dashboard's billing and analytics
+surfaces use a fixed six-decimal representation:
+
+- `4.79` becomes `4.790000 Credits`;
+- `-0.000137` remains `-0.000137 Credits`;
+- `10` becomes `10.000000 Credits`.
+
+Formatting must start from the authoritative integer `amount_micro` or the
+server-provided six-decimal string. It must not round through a binary floating
+point value. Thousands separators may be added to the integer portion, but the
+fractional portion must contain exactly six digits. Invalid or missing amounts
+render as the existing unavailable marker instead of a fabricated zero.
+
+This fixed-precision contract applies to:
+
+- the Credits & Billing balance;
+- Credits & Billing Activity amounts;
+- Admin Grant Credits balances and activity; and
+- Admin Analytics ATL Credit amounts.
+
+USD checkout and refund amounts remain currency values with two decimal
+places. Token counts, ratios, and non-Credit quotas keep their existing
+formatting.
+
+## Run-level activity projection
+
+### Aggregation identity
+
+SQLite and PostgreSQL must produce the same projection. Settled rows from
+`credit_llm_usage_entries` are grouped by `user_id` and `run_id`.
+
+For each run-level group:
+
+- `amount_micro` is the exact integer sum of all Grant and Purchased bucket
+  usage rows for every settled model call in the run;
+- `model_call_count` is the number of distinct settled `call_index` values;
+- `created_at` is the latest settlement timestamp in the run;
+- the stable activity identifier is derived from the greatest usage-entry id
+  in the group; and
+- the public `entry_type` is `backtest_usage`.
+
+The amount remains negative because Activity represents a debit. Grant and
+Purchased rows for the same call are combined before the user sees the result.
+The underlying bucket allocation is not exposed by this summary.
+
+### Provider and model context
+
+Safe pricing evidence is used only to summarize provider and model identity.
+The API returns a provider or model id only when all settled calls in the run
+agree on that value.
+
+- One provider and one model: return both ids.
+- Multiple providers: return no single provider id and mark the provider
+  summary as mixed.
+- Multiple models: return no single model id and mark the model summary as
+  mixed.
+- Missing or malformed historical evidence: return unknown context without
+  failing or dropping the exact debit.
+
+Raw `evidence_json`, provider response bodies, credential identifiers, and API
+keys never enter the public response.
+
+### Ordering and pagination
+
+Run summaries and purchase, refund, and Admin Grant ledger entries continue to
+share one reverse-chronological Activity feed. A run summary is ordered by its
+latest settlement timestamp, with its greatest underlying usage-entry id as
+the deterministic tie-breaker.
+
+The opaque cursor continues to encode the projected row's timestamp, source
+kind, and stable identifier. Aggregation happens before the page limit is
+applied, so a backtest cannot be split across pages and a page cannot show a
+partial run total. Existing decimal legacy cursors for historical ledger rows
+remain accepted.
+
+A running backtest can acquire additional settled calls after an Activity
+response. A later refresh shows the new exact total and latest settlement
+time. The endpoint does not promise snapshot isolation across separate page
+requests.
+
+## API response
+
+`GET /api/credits/ledger` remains the authenticated endpoint. Purchase,
+refund, and Admin Grant rows retain their current public shape. A run-level
+usage item contains the existing safe fields plus:
+
+```json
+{
+  "source_kind": "llm_usage",
+  "entry_type": "backtest_usage",
+  "amount_micro": -1284,
+  "display_credits": "-0.001284",
+  "run_id": "run_example",
+  "model_call_count": 12,
+  "provider_id": "openrouter",
+  "model_id": "anthropic/claude-haiku-4-5",
+  "provider_mixed": false,
+  "model_mixed": false,
+  "created_at": "2026-08-27T15:44:00+00:00"
+}
+```
+
+`source_kind` stays `llm_usage` so the existing opaque cursor domain remains
+compatible. `call_index` and `reservation_id` are omitted from run-level public
+items because they describe an individual model call rather than a backtest.
+
+## Frontend behavior
+
+Credits & Billing renders one `Backtest usage` row per run. Its secondary text
+contains:
+
+- the safe provider/model summary when available;
+- `1 model call` or `<N> model calls`;
+- the existing shortened run id; and
+- the latest settlement time.
+
+Mixed provider/model runs use explicit `Multiple providers` or `Multiple
+models` copy. Unknown historical context is omitted rather than guessed. The
+amount uses the server's exact signed six-decimal Credit string.
+
+No disclosure control for per-call details is added in this change. Per-call
+inspection remains an Admin Analytics or backend audit concern.
+
+## Failure and compatibility behavior
+
+- A malformed amount from the API renders as unavailable and does not crash
+  the Activity list.
+- Malformed historical evidence cannot prevent the exact run debit from being
+  returned.
+- A run with settled debits is visible even if its backtest status is failed.
+- Released reservations and failed calls with no usage entry contribute zero
+  rows and zero debit.
+- Existing ledger data needs no schema migration or backfill.
+- SQLite and PostgreSQL repository contracts must remain behaviorally
+  equivalent.
+
+## Security and privacy
+
+The existing append-only ledger and authenticated account boundary remain
+unchanged. Aggregation is always scoped by `user_id`; equal `run_id` values
+from different accounts must never be combined. The public serializer keeps
+its allowlist and never returns raw billing evidence, credential material, or
+provider payloads.
+
+Tests use synthetic micro-Credit amounts, safe mock pricing evidence, and fake
+run ids. Real API keys, local databases, `.superpowers/`, and `work/` are not
+committed.
+
+## Test coverage
+
+Focused regression tests cover:
+
+- fixed six-decimal formatting for whole, two-decimal, sub-cent, negative,
+  large, invalid, and missing Credit values without floating point rounding;
+- one run-level row for multiple calls and two bucket rows per call;
+- exact summed `amount_micro` and distinct `model_call_count`;
+- failed-run settled usage remaining visible and zero-debit failures remaining
+  absent by construction;
+- single, mixed, unknown, and malformed provider/model evidence;
+- aggregation before pagination, deterministic ordering, and legacy cursor
+  compatibility;
+- account isolation for repeated `run_id` values;
+- identical SQLite and PostgreSQL public behavior;
+- the API allowlist omitting call-level and secret evidence; and
+- frontend title, metadata, pluralization, and exact balance/Activity display.
+
+## Non-goals
+
+- Changing reservation, settlement, Grant-first allocation, pricing, or
+  provider cost calculation.
+- Adding a new database table or rewriting historical ledger rows.
+- Showing unreserved BYOK provider charges as ATL Credit debits.
+- Adding per-call expansion to the Credits & Billing page.
+- Changing backtest execution or failure-state rules.
+- Changing Stripe Test Mode purchase or refund behavior.
+
+## Acceptance criteria
+
+1. A balance of `4,790,000` micro-Credits displays as `4.790000 Credits`.
+2. A settled debit of `137` micro-Credits displays as `-0.000137`, never
+   `-0.00`.
+3. Twelve settled model calls for one `run_id` appear as one `Backtest usage`
+   row whose amount equals the exact sum of all twelve calls.
+4. The row states `12 model calls` and contains safe provider/model context or
+   an explicit mixed summary.
+5. A charged failed backtest remains in Activity; an uncharged failure does
+   not create a usage row.
+6. One run is never split across Activity pages.
+7. Purchase, refund, Admin Grant, balance accounting, and BYOK behavior remain
+   unchanged apart from fixed six-decimal ATL Credit presentation.
+8. No public response, test fixture, commit, or PR exposes a real secret or
+   local database.

--- a/docs/superpowers/specs/2026-08-29-pr411-main-sync-design.md
+++ b/docs/superpowers/specs/2026-08-29-pr411-main-sync-design.md
@@ -1,0 +1,57 @@
+# PR 411 Main Sync Design
+
+## Goal
+
+Make PR #411 mergeable against the latest `main` while preserving both the merged default-Credits behavior and PR #411's exact run-level Credit activity behavior.
+
+## Context
+
+PR #411 was created before PR #413 fixed the Marketplace provider-label test and before PR #410 added automatic welcome Credits and smaller checkout amounts. Re-running the old workflow reused the old pull-request merge snapshot, so it continued to report the already-fixed Marketplace failure. After PR #410 merged, GitHub also reported PR #411 as conflicting.
+
+The textual conflicts are limited to:
+
+- `dashboard/frontend/app.html`
+- `dashboard/frontend/js/credits.js`
+- `dashboard/backend/tests/test_frontend_fast_boot.py`
+
+The local branch named `fix/backtest-credit-activity` contains unrelated, unpushed benchmark commits. The repair must therefore run from an isolated worktree based on `origin/fix/backtest-credit-activity` and push explicitly to the remote PR branch.
+
+## Merge Strategy
+
+Merge `origin/main` into an isolated repair branch. Use a merge commit instead of rebasing so the existing PR history is preserved and no force push is required.
+
+Resolve the conflicts by composing the two behaviors rather than choosing one side wholesale:
+
+- Keep `main`'s checkout packages (`$0.50`, `$1`, `$2`, `$5`), `$1` default selection, and `$0.50` through `$5.00` custom range.
+- Render all package Credit quantities with the shared fixed-six-decimal formatter contract introduced by PR #411.
+- Keep `main`'s `system_promotion_grant` Activity title, `Welcome Credits`.
+- Keep PR #411's `backtest_usage` Activity title, run-level provider/model context, model-call count, and mixed-provider/model labels.
+- Keep the shared `credit-format.js` helper before every consumer.
+- Bump the combined `credits.js` asset version beyond both parents and retain the PR #411 asset versions for `admin-credits.js` and `admin-analytics.js`.
+- Update the frontend fast-boot assertions to match the final asset graph.
+
+## Data And Behavior Contracts
+
+The merge must not change backend Credit arithmetic or introduce floating-point calculations. Public amounts remain display strings backed by integer micro-Credits.
+
+Activity rendering must distinguish:
+
+- `backtest_usage`: one aggregated row per backtest run, negative amount, safe provider/model/call-count/run context.
+- `system_promotion_grant`: one positive `Welcome Credits` row.
+- `refund`: negative `Refund` row.
+- Other positive entries: `Credit purchase`.
+
+No reservation IDs, call indexes, raw evidence JSON, secrets, or database artifacts may enter the frontend or commit.
+
+## Verification
+
+Run focused tests for the three resolved frontend files, exact Credit formatting, Credits API behavior, SQLite and PostgreSQL repository contracts, and the Marketplace regression fixed by PR #413. Then run the complete backend suite without a local PostgreSQL URL and let GitHub Actions execute the PostgreSQL tier with its service container.
+
+The final PR must be conflict-free, contain no unrelated benchmark commits, and receive a fresh GitHub Actions run based on the updated head commit and current `main`.
+
+## Out Of Scope
+
+- Changing the Welcome Credit amount or promotion-ledger semantics from PR #410.
+- Changing checkout package limits from PR #410.
+- Changing PR #411's run-level aggregation or precision contract.
+- Modifying benchmark comparison work that exists only on the separate local branch.


### PR DESCRIPTION
## Summary
- display ATL Credit values with exact fixed six-decimal precision across Credits, Admin Credits, and Admin Analytics
- aggregate settled model-call debits into one Activity row per user and backtest run before pagination
- expose only safe run-level provider/model context while keeping SQLite and PostgreSQL behavior aligned

## Tests
- focused Credits repository, API, frontend, and parity suite: 195 passed, 21 skipped (live PostgreSQL not configured locally)
- full dashboard backend suite: 3745 passed, 147 skipped, with one pre-existing marketplace-card failure reproduced unchanged on `origin/main`
- desktop and 390px browser verification with a temporary SQLite database and synthetic account/run data
- `git diff --check origin/main...HEAD` and secret/path audit