### PR TITLE
fix: shorten admin credits user pages

### DIFF
--- a/dashboard/backend/api/routers/admin_credits.py
+++ b/dashboard/backend/api/routers/admin_credits.py
@@ -178,7 +178,7 @@ def reduce_grant_pool(
 @router.get("/users")
 def list_grant_users(
     query: str | None = Query(default=None, max_length=120),
-    limit: int = Query(default=100, ge=1, le=500),
+    limit: int = Query(default=25, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
     _admin: dict = Depends(require_admin),
 ):

--- a/dashboard/backend/tests/test_admin_credits_api.py
+++ b/dashboard/backend/tests/test_admin_credits_api.py
@@ -203,3 +203,20 @@ def test_admin_user_search_composes_identity_with_bucket_projection(
             },
         }
     ]
+
+
+def test_admin_user_list_defaults_to_25_accounts_per_page(live_admin_credits_api):
+    admin = _signup(live_admin_credits_api.client, "page-admin@example.com")
+    for index in range(25):
+        _signup(live_admin_credits_api.client, f"page-user-{index}@example.com")
+    live_admin_credits_api.users.apply_admin_patch(admin["id"], role="admin")
+    _login(live_admin_credits_api.client, "page-admin@example.com")
+
+    response = live_admin_credits_api.client.get("/api/admin/credits/users")
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["limit"] == 25
+    assert payload["offset"] == 0
+    assert payload["total"] == 26
+    assert len(payload["users"]) == 25

--- a/dashboard/backend/tests/test_admin_credits_frontend.py
+++ b/dashboard/backend/tests/test_admin_credits_frontend.py
@@ -75,6 +75,11 @@ def test_admin_grant_client_uses_server_api_and_never_persists_secrets():
     assert "innerHTML" not in ADMIN_JS
 
 
+def test_admin_grant_client_defaults_to_short_user_pages():
+    assert "ADMIN_CREDITS_USERS_PAGE_SIZE = 25" in ADMIN_JS
+    assert "usersLimit: ADMIN_CREDITS_USERS_PAGE_SIZE" in ADMIN_JS
+
+
 def test_admin_grant_console_is_wired_to_auth_navigation_and_refresh():
     assert "window.AdminCredits.syncAuth(user)" in APP_JS
     assert APP_JS.count("window.AdminCredits.onEnter()") >= 2

--- a/dashboard/frontend/js/admin-credits.js
+++ b/dashboard/frontend/js/admin-credits.js
@@ -2,12 +2,14 @@
 (function () {
   'use strict';
 
+  const ADMIN_CREDITS_USERS_PAGE_SIZE = 25;
+
   const state = {
     initialized: false,
     users: [],
     usersOffset: 0,
     usersTotal: 0,
-    usersLimit: 100,
+    usersLimit: ADMIN_CREDITS_USERS_PAGE_SIZE,
     usersRequestSeq: 0,
     activityCursor: null,
     activityItems: [],

--- a/docs/superpowers/plans/2026-08-28-admin-credits-pagination.md
+++ b/docs/superpowers/plans/2026-08-28-admin-credits-pagination.md
@@ -1,0 +1,68 @@
+# Admin Credits Pagination Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce the Admin Credits Account Management page size from 100 to 25 accounts while preserving existing pagination and search behavior.
+
+**Architecture:** Keep offset pagination in the existing Admin Credits browser state. Change the shared frontend request default and the FastAPI endpoint default together, while retaining response metadata as the source of truth for rendering the range and navigation state.
+
+**Tech Stack:** Vanilla JavaScript, FastAPI/Pydantic, pytest, static frontend contract tests.
+
+**Spec:** `docs/superpowers/specs/2026-08-28-admin-credits-pagination-design.md`
+
+## Global Constraints
+
+- Only the Admin Credits `Account Management` list changes; the legacy Admin Users table remains untouched.
+- The page size is exactly 25 accounts by default.
+- Existing `Previous`, `Next`, search reset, and out-of-range fallback behavior remains intact.
+- No new dependencies or API fields are introduced.
+
+### Task 1: Align the pagination defaults
+
+**Files:**
+- Modify: `dashboard/frontend/js/admin-credits.js:5-16`
+- Modify: `dashboard/backend/api/routers/admin_credits.py:181-182`
+- Test: `dashboard/backend/tests/test_admin_credits_frontend.py`
+- Test: `dashboard/backend/tests/test_admin_credits_api.py`
+
+**Interfaces:**
+- Consumes: existing `state.usersLimit`, `loadUsers()`, and `list_grant_users()` response metadata.
+- Produces: a default request/response limit of `25` with unchanged `users`, `total`, `limit`, and `offset` fields.
+
+- [ ] **Step 1: Add failing contract assertions**
+
+  Assert the frontend state initializes `usersLimit: 25`, and exercise the API endpoint without a `limit` query parameter to assert `limit == 25` and that the first page contains at most 25 users.
+
+- [ ] **Step 2: Run the focused tests and verify they fail**
+
+  Run:
+
+  ```bash
+  pytest -q dashboard/backend/tests/test_admin_credits_frontend.py dashboard/backend/tests/test_admin_credits_api.py
+  ```
+
+  Expected: the new assertions fail because both current defaults are 100.
+
+- [ ] **Step 3: Change both defaults to 25**
+
+  In `admin-credits.js`, change `usersLimit: 100` to `usersLimit: 25`. In `admin_credits.py`, change `limit: int = Query(default=100, ge=1, le=500)` to `limit: int = Query(default=25, ge=1, le=500)`. Do not change the maximum or offset logic.
+
+- [ ] **Step 4: Run the focused tests and verify they pass**
+
+  Run:
+
+  ```bash
+  pytest -q dashboard/backend/tests/test_admin_credits_frontend.py dashboard/backend/tests/test_admin_credits_api.py
+  ```
+
+  Expected: all Admin Credits tests pass.
+
+- [ ] **Step 5: Verify the patch and commit**
+
+  Run:
+
+  ```bash
+  git diff --check
+  git add dashboard/frontend/js/admin-credits.js dashboard/backend/api/routers/admin_credits.py dashboard/backend/tests/test_admin_credits_frontend.py dashboard/backend/tests/test_admin_credits_api.py docs/superpowers/specs/2026-08-28-admin-credits-pagination-design.md docs/superpowers/plans/2026-08-28-admin-credits-pagination.md
+  git commit -m "fix: shorten admin credits user pages"
+  ```

--- a/docs/superpowers/specs/2026-08-28-admin-credits-pagination-design.md
+++ b/docs/superpowers/specs/2026-08-28-admin-credits-pagination-design.md
@@ -1,0 +1,24 @@
+# Admin Credits Pagination Design
+
+## Goal
+
+Make the Admin Credits `Account Management` table easier to scan by showing 25 accounts per page instead of 100.
+
+## Scope
+
+- Change only the Admin Credits account-management list (`/api/admin/credits/users` and its `admin-credits.js` consumer).
+- Keep the existing offset pagination, search reset, range text, and Previous/Next controls.
+- Leave the legacy Admin Users table and all other list sizes unchanged.
+
+## Behavior
+
+- The browser requests 25 accounts by default.
+- The API defaults to 25 when callers omit `limit`; its existing validation range remains unchanged.
+- The response `limit`, `offset`, and `total` remain authoritative.
+- If accounts disappear and the current offset becomes empty, the client falls back to the last valid page.
+
+## Verification
+
+- Add a frontend contract assertion for the 25-account default.
+- Add an API test proving the omitted-limit default is 25 and the returned range metadata matches.
+- Run the Admin Credits frontend/API tests and `git diff --check`.


### PR DESCRIPTION
## Summary

- Reduce the Admin Credits Account Management page size from 100 to 25 users.
- Keep the existing Previous/Next controls, range text, search reset, and out-of-range fallback behavior.
- Align the FastAPI default for `/api/admin/credits/users` with the frontend default.
- Add frontend and API coverage for the 25-user default.

## Verification

- `pytest -q dashboard/backend/tests/test_admin_credits_api.py dashboard/backend/tests/test_admin_credits_frontend.py dashboard/backend/tests/test_admin_console_frontend.py`
- Result: 25 passed, 3 warnings.
- `git diff --check` passed.