### PR TITLE
feat: redesign account settings layout

### DIFF
--- a/dashboard/backend/tests/test_frontend_account_page.py
+++ b/dashboard/backend/tests/test_frontend_account_page.py
@@ -20,17 +20,21 @@ def _account_card() -> str:
     return html[start:end]
 
 
-def test_logout_button_is_last_in_the_account_card():
+def test_logout_button_is_last_in_the_account_identity_region():
     card = _account_card()
-    logout_at = card.index('id="authLogoutBtn"')
+    identity_start = card.index('class="account-identity"')
+    identity_end = card.index("</aside>", identity_start)
+    identity = card[identity_start:identity_end]
+    logout_at = identity.index('id="authLogoutBtn"')
 
-    for marker in ("id=\"avatarUploadBtn\"", "id=\"changePasswordForm\""):
-        assert card.index(marker) < logout_at, f"{marker} must come before Log out"
+    for marker in ('id="accountDisplayName"', 'id="accountEmail"', 'id="accountRole"'):
+        assert identity.index(marker) < logout_at, f"{marker} must come before Log out"
 
-    # "after those two" is not "last" -- a section appended later would keep the
-    # assertions above green. Nothing else in the card may carry an id.
-    tail = card[logout_at + len('id="authLogoutBtn"'):]
+    # Logout is the final interactive item in the identity panel. The editable
+    # settings intentionally follow in their own sibling region.
+    tail = identity[logout_at + len('id="authLogoutBtn"'):]
     assert 'id="' not in tail, f"something with an id follows Log out: {tail!r}"
+    assert card.index('class="account-settings-grid"') > identity_end
 
 
 def test_logout_button_carries_the_danger_class():
@@ -68,16 +72,51 @@ def test_auth_btn_danger_is_declared_after_the_generic_hover():
 def test_account_card_section_order():
     card = _account_card()
     order = [
-        'id="accountDisplayName"',      # read-only summary row
-        'id="accountEmail"',            # read-only summary row
-        'id="accountDisplayNameForm"',  # editor
-        'id="accountEmailForm"',        # editor
-        'id="avatarUploadBtn"',
-        'id="changePasswordForm"',
+        'id="accountDisplayName"',
+        'id="accountEmail"',
         'id="authLogoutBtn"',
+        'id="accountDisplayNameForm"',
+        'id="avatarUploadBtn"',
+        'id="accountEmailForm"',
+        'id="changePasswordForm"',
     ]
     positions = [card.index(marker) for marker in order]
     assert positions == sorted(positions), "account card sections are out of order"
+
+
+def test_account_layout_has_identity_and_settings_regions():
+    card = _account_card()
+
+    assert 'class="account-workspace"' in card
+    assert 'class="account-identity"' in card
+    assert 'class="account-settings-grid"' in card
+    identity_start = card.index('class="account-identity"')
+    settings_start = card.index('class="account-settings-grid"')
+    assert identity_start < settings_start
+    assert card.index('id="accountDisplayName"') < settings_start
+    assert card.index('id="accountEmail"') < settings_start
+    for marker in (
+        'id="accountDisplayNameForm"',
+        'id="accountEmailForm"',
+        'id="avatarUploadBtn"',
+        'id="changePasswordForm"',
+    ):
+        assert settings_start < card.index(marker)
+
+
+def test_account_redesign_selectors_are_scoped_to_account_view():
+    css = _STYLES_CSS.read_text(encoding="utf-8")
+
+    for selector in (
+        ".account-view {",
+        ".account-view .account-workspace",
+        ".account-view .account-identity",
+        ".account-view .account-settings-grid",
+    ):
+        assert selector in css
+    assert "\n.account-workspace" not in css
+    assert "\n.account-identity" not in css
+    assert "\n.account-settings-grid" not in css
 
 
 def test_email_change_copy_mentions_the_spam_folder():

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -1751,90 +1751,109 @@
             </div>
         </div>
         <div id="accountSignedIn" class="account-card" hidden>
-            <div class="account-row">
-                <span class="account-label">Display name</span>
-                <span id="accountDisplayName" class="account-value">—</span>
-            </div>
-            <div class="account-row">
-                <span class="account-label">Email</span>
-                <span id="accountEmail" class="account-value">—</span>
-            </div>
-            <div class="account-section">
-                <h3 class="account-section-title">Display name</h3>
-                <form id="accountDisplayNameForm" class="auth-form account-password-form">
-                    <label class="auth-field">
-                        <span>Display name</span>
-                        <input id="displayNameInput" type="text" maxlength="100" autocomplete="nickname" required>
-                    </label>
-                    <p id="displayNameError" class="auth-error" hidden></p>
-                    <p id="displayNameSuccess" class="account-success" hidden>Display name updated.</p>
-                    <button class="auth-btn auth-btn-primary" type="submit">Save name</button>
-                </form>
-            </div>
-            <div class="account-section">
-                <h3 class="account-section-title">Change email address</h3>
-                <form id="accountEmailForm" class="auth-form account-password-form">
-                    <div id="emailChangeIdle">
-                        <label class="auth-field">
-                            <span>New email address</span>
-                            <input id="newEmailInput" type="email" maxlength="254" autocomplete="email">
-                        </label>
-                        <label class="auth-field">
-                            <span>Current password</span>
-                            <input id="emailChangePasswordInput" type="password" autocomplete="current-password">
-                        </label>
-                        <p class="account-hint">You can change your email address once every 7 days.</p>
+            <div class="account-workspace">
+                <aside class="account-identity" aria-labelledby="accountIdentityHeading">
+                    <div class="account-identity-avatar-wrap">
+                        <span id="accountAvatarPreview" class="auth-avatar auth-avatar--large" aria-hidden="true"></span>
+                        <span id="accountProfileStatus" class="account-profile-status" role="status">Signed in</span>
                     </div>
-                    <div id="emailChangeCodeStep" hidden>
-                        <p id="emailChangeStepCopy" class="account-hint"></p>
-                        <label class="auth-field">
-                            <span>Confirmation code</span>
-                            <input id="emailChangeCodeInput" type="text" maxlength="6" autocomplete="one-time-code">
-                        </label>
+                    <p class="account-section-kicker">Account identity</p>
+                    <h3 id="accountIdentityHeading" class="account-identity-name">—</h3>
+                    <p id="accountIdentityEmail" class="account-identity-email">—</p>
+                    <dl class="account-identity-facts">
+                        <div>
+                            <dt>Display name</dt>
+                            <dd id="accountDisplayName">—</dd>
+                        </div>
+                        <div>
+                            <dt>Email</dt>
+                            <dd id="accountEmail">—</dd>
+                        </div>
+                        <div>
+                            <dt>Role</dt>
+                            <dd id="accountRole">Member</dd>
+                        </div>
+                    </dl>
+                    <div class="account-identity-actions">
+                        <button id="authLogoutBtn" class="auth-btn auth-btn-danger" type="button">Log out</button>
                     </div>
-                    <p id="emailChangeError" class="auth-error" hidden></p>
-                    <p id="emailChangeSuccess" class="account-success" hidden>Email address updated. Other devices were signed out.</p>
-                    <div class="account-email-actions">
-                        <button id="emailChangeSubmitBtn" class="auth-btn auth-btn-primary" type="submit">Send code</button>
-                        <button id="emailChangeCancelBtn" class="auth-btn auth-btn-secondary" type="button" hidden>Cancel</button>
-                    </div>
-                </form>
-            </div>
-            <div class="account-section">
-                <h3 class="account-section-title">Profile photo</h3>
-                <div class="account-avatar-row">
-                    <span id="accountAvatarPreview" class="auth-avatar auth-avatar--large" aria-hidden="true"></span>
-                    <div class="account-avatar-actions">
-                        <input id="avatarFileInput" type="file" accept="image/jpeg,image/png,image/webp" hidden>
-                        <button id="avatarUploadBtn" class="auth-btn auth-btn-secondary" type="button">Upload photo</button>
-                        <button id="avatarRemoveBtn" class="auth-btn auth-btn-secondary" type="button" hidden>Remove</button>
-                    </div>
+                </aside>
+
+                <div class="account-settings-grid">
+                    <section class="account-section" aria-labelledby="accountDisplayNameHeading">
+                        <h3 id="accountDisplayNameHeading" class="account-section-title">Display name</h3>
+                        <form id="accountDisplayNameForm" class="auth-form account-password-form">
+                            <label class="auth-field">
+                                <span>Display name</span>
+                                <input id="displayNameInput" type="text" maxlength="100" autocomplete="nickname" required>
+                            </label>
+                            <p id="displayNameError" class="auth-error" hidden></p>
+                            <p id="displayNameSuccess" class="account-success" hidden>Display name updated.</p>
+                            <button class="auth-btn auth-btn-primary" type="submit">Save name</button>
+                        </form>
+                    </section>
+                    <section class="account-section" aria-labelledby="accountPhotoHeading">
+                        <h3 id="accountPhotoHeading" class="account-section-title">Profile photo</h3>
+                        <div class="account-avatar-row">
+                            <div class="account-avatar-actions">
+                                <input id="avatarFileInput" type="file" accept="image/jpeg,image/png,image/webp" hidden>
+                                <button id="avatarUploadBtn" class="auth-btn auth-btn-secondary" type="button">Upload photo</button>
+                                <button id="avatarRemoveBtn" class="auth-btn auth-btn-secondary" type="button" hidden>Remove</button>
+                            </div>
+                        </div>
+                        <p id="avatarError" class="auth-error" hidden></p>
+                    </section>
+                    <section class="account-section" aria-labelledby="accountEmailHeading">
+                        <h3 id="accountEmailHeading" class="account-section-title">Change email address</h3>
+                        <form id="accountEmailForm" class="auth-form account-password-form">
+                            <div id="emailChangeIdle">
+                                <label class="auth-field">
+                                    <span>New email address</span>
+                                    <input id="newEmailInput" type="email" maxlength="254" autocomplete="email">
+                                </label>
+                                <label class="auth-field">
+                                    <span>Current password</span>
+                                    <input id="emailChangePasswordInput" type="password" autocomplete="current-password">
+                                </label>
+                                <p class="account-hint">You can change your email address once every 7 days.</p>
+                            </div>
+                            <div id="emailChangeCodeStep" hidden>
+                                <p id="emailChangeStepCopy" class="account-hint"></p>
+                                <label class="auth-field">
+                                    <span>Confirmation code</span>
+                                    <input id="emailChangeCodeInput" type="text" maxlength="6" autocomplete="one-time-code">
+                                </label>
+                            </div>
+                            <p id="emailChangeError" class="auth-error" hidden></p>
+                            <p id="emailChangeSuccess" class="account-success" hidden>Email address updated. Other devices were signed out.</p>
+                            <div class="account-email-actions">
+                                <button id="emailChangeSubmitBtn" class="auth-btn auth-btn-primary" type="submit">Send code</button>
+                                <button id="emailChangeCancelBtn" class="auth-btn auth-btn-secondary" type="button" hidden>Cancel</button>
+                            </div>
+                        </form>
+                    </section>
+                    <section class="account-section" aria-labelledby="accountPasswordHeading">
+                        <h3 id="accountPasswordHeading" class="account-section-title">Change password</h3>
+                        <form id="changePasswordForm" class="auth-form account-password-form">
+                            <label class="auth-field">
+                                <span>Current password</span>
+                                <input id="currentPasswordInput" type="password" autocomplete="current-password" required>
+                            </label>
+                            <label class="auth-field">
+                                <span>New password</span>
+                                <input id="newPasswordInput" type="password" autocomplete="new-password" required>
+                            </label>
+                            <label class="auth-field">
+                                <span>Confirm new password</span>
+                                <input id="confirmPasswordInput" type="password" autocomplete="new-password" required>
+                            </label>
+                            <ul id="passwordPolicyHints" class="password-policy-hints" hidden></ul>
+                            <p id="changePasswordError" class="auth-error" hidden></p>
+                            <p id="changePasswordSuccess" class="account-success" hidden>Password updated. Other devices were signed out.</p>
+                            <button class="auth-btn auth-btn-primary" type="submit">Update password</button>
+                        </form>
+                    </section>
                 </div>
-                <p id="avatarError" class="auth-error" hidden></p>
-            </div>
-            <div class="account-section">
-                <h3 class="account-section-title">Change password</h3>
-                <form id="changePasswordForm" class="auth-form account-password-form">
-                    <label class="auth-field">
-                        <span>Current password</span>
-                        <input id="currentPasswordInput" type="password" autocomplete="current-password" required>
-                    </label>
-                    <label class="auth-field">
-                        <span>New password</span>
-                        <input id="newPasswordInput" type="password" autocomplete="new-password" required>
-                    </label>
-                    <label class="auth-field">
-                        <span>Confirm new password</span>
-                        <input id="confirmPasswordInput" type="password" autocomplete="new-password" required>
-                    </label>
-                    <ul id="passwordPolicyHints" class="password-policy-hints" hidden></ul>
-                    <p id="changePasswordError" class="auth-error" hidden></p>
-                    <p id="changePasswordSuccess" class="account-success" hidden>Password updated. Other devices were signed out.</p>
-                    <button class="auth-btn auth-btn-primary" type="submit">Update password</button>
-                </form>
-            </div>
-            <div class="account-section account-actions">
-                <button id="authLogoutBtn" class="auth-btn auth-btn-danger" type="button">Log out</button>
             </div>
         </div>
         <div id="accountSignedOut" class="account-card account-card--empty" hidden>

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -3237,6 +3237,9 @@ function updateAccountPage() {
   const signedOut = document.getElementById('accountSignedOut');
   const nameEl = document.getElementById('accountDisplayName');
   const emailEl = document.getElementById('accountEmail');
+  const identityName = document.getElementById('accountIdentityHeading');
+  const identityEmail = document.getElementById('accountIdentityEmail');
+  const roleEl = document.getElementById('accountRole');
   if (!signedIn || !signedOut) return;
 
   if (user) {
@@ -3244,6 +3247,9 @@ function updateAccountPage() {
     signedOut.hidden = true;
     if (nameEl) nameEl.textContent = user.display_name || '—';
     if (emailEl) emailEl.textContent = user.email || '—';
+    if (identityName) identityName.textContent = user.display_name || '—';
+    if (identityEmail) identityEmail.textContent = user.email || '—';
+    if (roleEl) roleEl.textContent = user.role === 'admin' ? 'Administrator' : 'Member';
     const nameInput = document.getElementById('displayNameInput');
     // Skip while focused so a re-render mid-edit does not stomp what is typed.
     if (nameInput && document.activeElement !== nameInput) {

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -5290,7 +5290,7 @@ a.header-brand:hover .title-section h1 {
 }
 
 .account-view {
-    max-width: 560px;
+    max-width: 1180px;
 }
 
 .account-card {
@@ -9943,7 +9943,180 @@ body.agent-editor-open {
     color: #f87171;
 }
 
-/* Account page — password + avatar sections */
+/* Account page — identity summary + settings workspace */
+.account-view #accountSignedIn {
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+}
+
+.account-view .account-workspace {
+    display: grid;
+    grid-template-columns: minmax(220px, 0.72fr) minmax(0, 1.7fr);
+    gap: 20px;
+    align-items: start;
+}
+
+.account-view .account-identity {
+    position: sticky;
+    top: 88px;
+    min-width: 0;
+    padding: 24px;
+    border: 1px solid rgba(103, 232, 249, 0.22);
+    border-radius: 12px;
+    background: linear-gradient(145deg, rgba(18, 33, 62, 0.98), rgba(11, 20, 40, 0.98));
+    box-shadow: 0 18px 38px rgba(2, 8, 23, 0.22);
+}
+
+.account-view .account-identity-avatar-wrap {
+    display: flex;
+    align-items: flex-end;
+    gap: 12px;
+    margin-bottom: 24px;
+}
+
+.account-view .auth-avatar--large {
+    width: 72px;
+    height: 72px;
+    border: 2px solid rgba(103, 232, 249, 0.45);
+    font-size: 26px;
+    box-shadow: 0 0 0 5px rgba(34, 211, 238, 0.06);
+}
+
+.account-view .account-profile-status {
+    display: inline-flex;
+    align-items: center;
+    min-height: 24px;
+    padding: 3px 9px;
+    border: 1px solid rgba(52, 211, 153, 0.28);
+    border-radius: 999px;
+    background: rgba(16, 185, 129, 0.08);
+    color: #6ee7b7;
+    font-size: 11px;
+    font-weight: 700;
+}
+
+.account-view .account-profile-status::before {
+    width: 6px;
+    height: 6px;
+    margin-right: 6px;
+    border-radius: 50%;
+    background: #34d399;
+    content: "";
+}
+
+.account-view .account-section-kicker {
+    margin: 0 0 7px;
+    color: #67e8f9;
+    font-size: 10px;
+    font-weight: 800;
+    text-transform: uppercase;
+}
+
+.account-view .account-identity-name {
+    margin: 0;
+    color: var(--text-primary);
+    font-size: 24px;
+    font-weight: 750;
+    line-height: 1.2;
+    overflow-wrap: anywhere;
+}
+
+.account-view .account-identity-email {
+    margin: 6px 0 22px;
+    color: var(--text-secondary);
+    font-size: 13px;
+    overflow-wrap: anywhere;
+}
+
+.account-view .account-identity-facts {
+    margin: 0;
+    border-top: 1px solid rgba(148, 163, 184, 0.14);
+}
+
+.account-view .account-identity-facts > div {
+    display: grid;
+    grid-template-columns: minmax(88px, 0.8fr) minmax(0, 1.2fr);
+    gap: 12px;
+    padding: 12px 0;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.14);
+}
+
+.account-view .account-identity-facts dt,
+.account-view .account-identity-facts dd {
+    margin: 0;
+    font-size: 12px;
+    line-height: 1.45;
+}
+
+.account-view .account-identity-facts dt {
+    color: var(--text-secondary);
+    font-weight: 600;
+}
+
+.account-view .account-identity-facts dd {
+    color: var(--text-primary);
+    font-weight: 700;
+    text-align: right;
+    overflow-wrap: anywhere;
+}
+
+.account-view .account-identity-actions {
+    margin-top: 20px;
+}
+
+.account-view .account-identity-actions .auth-btn {
+    width: 100%;
+}
+
+.account-view .account-settings-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 14px;
+    min-width: 0;
+}
+
+.account-view .account-settings-grid > .account-section {
+    min-width: 0;
+    margin-top: 0;
+    padding: 18px;
+    border: 1px solid rgba(148, 163, 184, 0.16);
+    border-radius: 10px;
+    background: rgba(17, 29, 54, 0.82);
+}
+
+.account-view .account-settings-grid > .account-section:nth-child(3),
+.account-view .account-settings-grid > .account-section:nth-child(4) {
+    grid-column: span 2;
+}
+
+.account-view .account-section-title {
+    margin-bottom: 14px;
+    padding-bottom: 11px;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.13);
+    font-size: 14px;
+}
+
+.account-view .account-password-form {
+    max-width: none;
+}
+
+.account-view .account-avatar-row,
+.account-view .account-avatar-actions {
+    width: 100%;
+}
+
+.account-view .account-avatar-actions .auth-btn:first-of-type {
+    flex: 1;
+}
+
+.account-view .auth-field input:focus-visible,
+.account-view .auth-btn:focus-visible {
+    outline: 2px solid #67e8f9;
+    outline-offset: 2px;
+}
+
 .account-section {
     margin-top: 16px;
     padding-top: 14px;
@@ -10018,6 +10191,45 @@ body.agent-editor-open {
 .account-avatar-actions {
     display: flex;
     gap: 8px;
+}
+
+@media (max-width: 860px) {
+    .account-view .account-workspace,
+    .account-view .account-settings-grid {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .account-view .account-identity {
+        position: static;
+    }
+
+    .account-view .account-settings-grid > .account-section:nth-child(3),
+    .account-view .account-settings-grid > .account-section:nth-child(4) {
+        grid-column: auto;
+    }
+}
+
+@media (max-width: 540px) {
+    .account-view .account-identity,
+    .account-view .account-settings-grid > .account-section {
+        padding: 16px;
+    }
+
+    .account-view .account-identity-avatar-wrap {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+
+    .account-view .account-avatar-actions,
+    .account-view .account-email-actions {
+        grid-template-columns: minmax(0, 1fr);
+        flex-direction: column;
+    }
+
+    .account-view .account-avatar-actions .auth-btn,
+    .account-view .account-email-actions .auth-btn {
+        width: 100%;
+    }
 }
 
 /* My Agents — asset-class shelves. A real panel, not loose prose: these sections

--- a/docs/superpowers/plans/2026-08-28-account-page-layout-redesign.md
+++ b/docs/superpowers/plans/2026-08-28-account-page-layout-redesign.md
@@ -1,0 +1,286 @@
+# Account Page Layout Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Reorganize only the signed-in Account page into a balanced identity-summary and settings workspace while preserving all existing account behavior and leaving every other route unchanged.
+
+**Architecture:** Keep the existing single-page HTML shell and all current account form IDs. Add a presentational `.account-workspace` wrapper with an identity column and a settings grid, then apply Account-scoped CSS in the existing account style section. A small `updateAccountPage()` presentation update may populate the identity role/status label; no API or workflow changes are needed.
+
+**Tech Stack:** Static HTML, vanilla JavaScript, existing `styles.css`, pytest source-contract tests, and the current local frontend server.
+
+**Spec:** `docs/superpowers/specs/2026-08-28-account-page-layout-redesign.md`
+
+## Global Constraints
+
+- Redesign only the signed-in Account page content rendered by `#accountView`.
+- Do not change the global header, brand bar, market ticker, primary navigation, shared page shell, or other page views.
+- Preserve existing account form IDs, event listeners, API calls, email-code stages, password policy hints, avatar behavior, and status/error semantics.
+- Add or adjust CSS only with `.account-view`-scoped selectors; do not alter shared `.page-view`, `.page-header`, `.auth-form`, or global button behavior.
+- Do not change backend files, API contracts, or unrelated frontend assets.
+- Do not add `.superpowers/`, real secrets, database connections, or `work/` files to the commit.
+
+### Task 1: Lock the Account DOM and CSS Contracts
+
+**Files:**
+- Modify: `dashboard/backend/tests/test_frontend_account_page.py`
+- Test: `dashboard/backend/tests/test_frontend_account_page.py`
+
+**Interfaces:**
+- Consumes: the existing `#accountView`, `#accountSignedIn`, account form IDs, and shipped `styles.css` source.
+- Produces: source contracts that require the new identity/settings wrappers and prevent unscoped layout changes.
+
+- [ ] **Step 1: Add a failing wrapper contract**
+
+Add a test that extracts the signed-in card and asserts the new wrappers and required IDs:
+
+```python
+def test_account_layout_has_identity_and_settings_regions():
+    card = _account_card()
+    assert 'class="account-workspace"' in card
+    assert 'class="account-identity"' in card
+    assert 'class="account-settings-grid"' in card
+    identity_start = card.index('class="account-identity"')
+    settings_start = card.index('class="account-settings-grid"')
+    assert identity_start < settings_start
+    assert card.index('id="accountDisplayName"') < settings_start
+    assert card.index('id="accountEmail"') < settings_start
+    for marker in (
+        'id="accountDisplayNameForm"',
+        'id="accountEmailForm"',
+        'id="avatarUploadBtn"',
+        'id="changePasswordForm"',
+    ):
+        assert settings_start < card.index(marker)
+```
+
+- [ ] **Step 2: Add a failing CSS scope contract**
+
+Add a test that requires the new layout selectors to be rooted under `.account-view` and rejects bare global layout selectors:
+
+```python
+def test_account_redesign_selectors_are_scoped_to_account_view():
+    css = _STYLES_CSS.read_text(encoding="utf-8")
+    for selector in (
+        ".account-view {",
+        ".account-view .account-workspace",
+        ".account-view .account-identity",
+        ".account-view .account-settings-grid",
+    ):
+        assert selector in css
+    assert "\n.account-workspace" not in css
+    assert "\n.account-identity" not in css
+    assert "\n.account-settings-grid" not in css
+```
+
+- [ ] **Step 3: Run the new tests and verify they fail**
+
+Run:
+
+```bash
+pytest -q dashboard/backend/tests/test_frontend_account_page.py
+```
+
+Expected: the two new tests fail because the wrappers and scoped selectors do not exist yet; all existing account contracts should continue to pass.
+
+### Task 2: Restructure Only the Account Markup
+
+**Files:**
+- Modify: `dashboard/frontend/app.html:1746-1845`
+- Modify: `dashboard/frontend/app.js:3234-3258` (presentation-only role/status text, if needed)
+- Test: `dashboard/backend/tests/test_frontend_account_page.py`
+
+**Interfaces:**
+- Consumes: all current account element IDs and `updateAccountPage()` behavior.
+- Produces: a `.account-workspace` containing `.account-identity` and `.account-settings-grid` while preserving every existing form and control contract.
+
+- [ ] **Step 1: Move the existing summary rows into the identity column**
+
+Inside `#accountSignedIn`, remove the two top-level `.account-row` elements and replace them with:
+
+```html
+<div class="account-workspace">
+    <aside class="account-identity" aria-labelledby="accountIdentityHeading">
+        <div class="account-identity-avatar-wrap">
+            <span id="accountAvatarPreview" class="auth-avatar auth-avatar--large" aria-hidden="true"></span>
+            <span id="accountProfileStatus" class="account-profile-status">Signed in</span>
+        </div>
+        <p class="account-section-kicker">Account identity</p>
+        <h3 id="accountIdentityHeading" class="account-identity-name">—</h3>
+        <p id="accountIdentityEmail" class="account-identity-email">—</p>
+        <dl class="account-identity-facts">
+            <div><dt>Display name</dt><dd id="accountDisplayName">—</dd></div>
+            <div><dt>Email</dt><dd id="accountEmail">—</dd></div>
+            <div><dt>Role</dt><dd id="accountRole">Member</dd></div>
+        </dl>
+        <div class="account-identity-actions">
+            <button id="authLogoutBtn" class="auth-btn auth-btn-danger" type="button">Log out</button>
+        </div>
+    </aside>
+
+    <div class="account-settings-grid">
+        <!-- existing Display name, email, avatar, and password sections stay here unchanged -->
+    </div>
+</div>
+```
+
+Keep the existing `#accountDisplayName` and `#accountEmail` IDs in the identity facts; do not duplicate those IDs elsewhere. The existing `#accountAvatarPreview` moves into the identity column, while the Profile photo section keeps its upload/remove controls and no longer renders a second avatar preview.
+
+- [ ] **Step 2: Keep all existing editable sections and controls intact**
+
+Place the current `accountDisplayNameForm`, `accountEmailForm`, profile photo controls, and `changePasswordForm` inside `.account-settings-grid` in this order:
+
+1. Display name
+2. Profile photo
+3. Change email address
+4. Change password
+
+Keep `emailChangeIdle`, `emailChangeCodeStep`, `emailChangeStepCopy`, `emailChangeSubmitBtn`, `emailChangeCancelBtn`, password policy hints, success/error elements, and avatar file input IDs unchanged.
+
+- [ ] **Step 3: Update only presentation fields in `updateAccountPage()`**
+
+After the existing `nameEl` and `emailEl` updates, populate the new identity presentation nodes without changing any API calls:
+
+```javascript
+const identityName = document.getElementById('accountIdentityHeading');
+const identityEmail = document.getElementById('accountIdentityEmail');
+const roleEl = document.getElementById('accountRole');
+if (identityName) identityName.textContent = user.display_name || '—';
+if (identityEmail) identityEmail.textContent = user.email || '—';
+if (roleEl) roleEl.textContent = user.role === 'admin' ? 'Administrator' : 'Member';
+```
+
+Do not change the existing focused-input guard, avatar rendering, remove-button state, signed-out state, or form event handlers.
+
+- [ ] **Step 4: Run the structural tests**
+
+Run:
+
+```bash
+pytest -q dashboard/backend/tests/test_frontend_account_page.py
+```
+
+Expected: all Account source contracts pass.
+
+### Task 3: Add the Account-Scoped Two-Column Visual System
+
+**Files:**
+- Modify: `dashboard/frontend/styles.css` in the existing Account section near `.account-section`
+- Test: `dashboard/backend/tests/test_frontend_account_page.py`
+
+**Interfaces:**
+- Consumes: `.account-workspace`, `.account-identity`, `.account-settings-grid`, and existing account form classes.
+- Produces: desktop two-column layout and mobile single-column fallback without changing shared styles.
+
+- [ ] **Step 1: Add scoped desktop layout rules**
+
+Add rules under the existing account section:
+
+```css
+.account-view {
+    max-width: 1180px;
+}
+
+.account-view .account-workspace {
+    display: grid;
+    grid-template-columns: minmax(220px, 0.72fr) minmax(0, 1.7fr);
+    gap: 20px;
+    align-items: start;
+}
+
+.account-view .account-identity {
+    position: sticky;
+    top: 88px;
+    min-width: 0;
+    padding: 24px;
+    border: 1px solid rgba(103, 232, 249, 0.22);
+    border-radius: 12px;
+    background: linear-gradient(145deg, rgba(18, 33, 62, 0.98), rgba(11, 20, 40, 0.98));
+}
+
+.account-view .account-settings-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 14px;
+    min-width: 0;
+}
+```
+
+Use Account-only selectors for identity typography, fact rows, panel surfaces, form spacing, focus-visible states, and the logout placement. Do not rewrite shared `.auth-btn`, `.auth-field`, `.page-header`, or `.page-view` declarations.
+
+- [ ] **Step 2: Normalize the four setting panels**
+
+Style `.account-view .account-settings-grid > .account-section` as equal visual panels with consistent padding, border, radius, and `min-width: 0`. Keep the email and password forms readable by allowing them to span both columns when required:
+
+```css
+.account-view .account-settings-grid > .account-section {
+    margin-top: 0;
+    min-width: 0;
+    padding: 18px;
+    border: 1px solid rgba(148, 163, 184, 0.16);
+    border-radius: 10px;
+    background: rgba(17, 29, 54, 0.82);
+}
+
+.account-view .account-settings-grid > .account-section:nth-child(3),
+.account-view .account-settings-grid > .account-section:nth-child(4) {
+    grid-column: span 2;
+}
+```
+
+Ensure inputs and button rows use `width: 100%` only inside `.account-view`; preserve the existing email `1fr auto` action layout and password policy hint behavior.
+
+- [ ] **Step 3: Add responsive and reduced-motion-safe behavior**
+
+At `max-width: 860px`, collapse both grids to one column, remove sticky positioning, and make the identity panel full width. At `max-width: 540px`, stack avatar actions and let email action buttons wrap without horizontal overflow. Use existing transition conventions and do not add animation that affects other routes.
+
+- [ ] **Step 4: Run source and lint checks**
+
+Run:
+
+```bash
+git diff --check
+pytest -q dashboard/backend/tests/test_frontend_account_page.py dashboard/backend/tests/test_frontend_fast_boot.py
+```
+
+Expected: no whitespace errors and all Account/fast-boot contracts pass.
+
+### Task 4: Visual QA and Regression Verification
+
+**Files:**
+- Modify: none unless QA finds an Account-only issue
+- Test: `dashboard/backend/tests/test_frontend_account_page.py`, `dashboard/backend/tests/test_frontend_fast_boot.py`
+
+**Interfaces:**
+- Consumes: the completed Account markup and scoped CSS.
+- Produces: verified desktop/mobile rendering and a clean, focused diff.
+
+- [ ] **Step 1: Start the local frontend server**
+
+Use the repository's existing frontend start command or static server from the repository root. Open the Account route with a signed-in test session and verify the page title, identity panel, four setting panels, logout placement, and all focus states.
+
+- [ ] **Step 2: Check desktop and mobile widths**
+
+Inspect at approximately 1440px and 390px wide. Confirm the desktop view fills the content area without the screenshot's large unused right side, while the mobile view is a single readable column with no horizontal scroll.
+
+- [ ] **Step 3: Check non-Account routes for selector leakage**
+
+Open Home, Community, Competition, Credits, and Admin. Confirm their layout is unchanged; the final CSS diff must contain only `.account-view`-scoped redesign selectors plus the existing account rules that are intentionally adjusted.
+
+- [ ] **Step 4: Run the focused regression suite**
+
+Run:
+
+```bash
+pytest -q dashboard/backend/tests/test_frontend_account_page.py dashboard/backend/tests/test_frontend_fast_boot.py dashboard/backend/tests/test_credits_frontend.py
+git diff --check
+git status --short
+```
+
+Expected: all focused tests pass, no diff-check errors, and no `.superpowers/` files are staged.
+
+- [ ] **Step 5: Commit the implementation**
+
+```bash
+git add dashboard/frontend/app.html dashboard/frontend/app.js dashboard/frontend/styles.css dashboard/backend/tests/test_frontend_account_page.py
+git commit -m "feat: redesign account settings layout"
+```

--- a/docs/superpowers/specs/2026-08-28-account-page-layout-redesign.md
+++ b/docs/superpowers/specs/2026-08-28-account-page-layout-redesign.md
@@ -1,0 +1,88 @@
+# Account Page Layout Redesign
+
+## Scope
+
+Redesign only the signed-in Account page content rendered by `#accountView` in
+`dashboard/frontend/app.html`. The global header, brand bar, market ticker,
+primary navigation, other page views, shared page shell, and backend behavior
+are explicitly out of scope.
+
+## Goals
+
+- Use the available desktop width instead of leaving most of the viewport empty.
+- Give the account identity a clear visual home before the editable settings.
+- Keep all existing account capabilities and JavaScript contracts intact.
+- Preserve the site's dark trading-lab visual language while improving hierarchy,
+  scanning, focus states, and responsive behavior.
+
+## Layout
+
+The Account page keeps its existing page title and description, followed by a
+responsive two-column workspace:
+
+- **Identity column:** a compact profile summary containing the existing avatar
+  preview, display name, email, and account role/status information. The logout
+  action remains in this column as the destructive account action.
+- **Settings column:** a two-column grid of the existing settings sections:
+  display name, profile photo, change email address, and change password.
+  Existing forms, field IDs, error containers, success containers, and submit
+  buttons remain available so current JavaScript behavior does not change.
+
+The workspace uses a scoped max width of approximately 1180px. On narrow
+viewports the columns collapse to one column in a predictable order: identity,
+display name, profile photo, email, password, logout.
+
+## Visual Language
+
+- Keep the existing dark background and typography foundation used by the app.
+- Add Account-scoped surface, border, spacing, and heading rules rather than
+  changing global selectors.
+- Use a restrained cyan accent for primary actions and focus indicators,
+  neutral slate borders for secondary controls, and red only for logout/error
+  states.
+- Remove the repeated summary rows currently shown above the editable display
+  name form; the identity column becomes the single source of summary content.
+- Use consistent panel padding, field heights, button alignment, and section
+  headings so each setting reads as a deliberate unit.
+
+## Behavior and Accessibility
+
+- Do not add new account workflows, API calls, or navigation states.
+- Keep all existing form submission, email-code stages, password policy hints,
+  avatar upload/remove behavior, status announcements, and error handling.
+- Preserve existing element IDs and event listeners in `app.js`.
+- Keep visible labels associated with inputs and retain `role="status"`,
+  `role="alert"`, and keyboard-submit behavior already present.
+- Ensure focus-visible styles remain obvious against the dark surfaces and that
+  buttons and inputs maintain comfortable touch targets on mobile.
+
+## Implementation Boundaries
+
+- Edit the Account markup only when needed to group the existing elements into
+  the new identity/settings layout.
+- Add or adjust CSS only with `.account-view`-scoped selectors. Do not alter
+  shared `.page-view`, `.page-header`, `.auth-form`, or global button rules in
+  ways that affect other routes.
+- Do not change `dashboard/frontend/app.js` unless a purely presentational DOM
+  grouping requires a selector update; existing IDs must remain stable.
+- Do not change backend files, API contracts, or unrelated frontend assets.
+
+## Verification
+
+- Run the Account-related frontend contract tests and the existing fast-boot
+  tests.
+- Run `git diff --check` and verify the diff contains only Account markup/CSS
+  plus any focused tests.
+- Start the local frontend and inspect Account at desktop and mobile widths.
+- Confirm Home, Community, Competition, Credits, and Admin views retain their
+  existing layout by checking that no global selector was changed.
+
+## Acceptance Criteria
+
+1. Account desktop view presents the identity summary and settings in a balanced
+   two-column workspace with no large unused right-side void.
+2. All existing account actions still work without changing their API or event
+   contracts.
+3. Account mobile view is a readable single column with no horizontal overflow.
+4. Other routes and the global navigation/header/ticker are unchanged.
+5. Existing Account accessibility semantics and keyboard paths remain intact.


### PR DESCRIPTION
## Summary
- Redesign the signed-in Account page into an identity summary and responsive settings workspace.
- Preserve existing account IDs, forms, API calls, auth behavior, and global navigation.
- Add Account-scoped desktop/mobile styles with visible focus states and no horizontal overflow.

## Verification
- `pytest -q dashboard/backend/tests/test_frontend_account_page.py dashboard/backend/tests/test_frontend_fast_boot.py dashboard/backend/tests/test_credits_frontend.py`
- Result: 42 passed
- `node --check dashboard/frontend/app.js`
- `git diff --check`
- Visual QA at 1440px and 390px using synthetic local preview data.