### PR TITLE
Add backtest benchmark comparison and right-rail trading log

### DIFF
--- a/dashboard/backend/api/routers/backtests.py
+++ b/dashboard/backend/api/routers/backtests.py
@@ -2170,7 +2170,8 @@ def get_backtest_chart_data(run_id: str, request: Request):
     """Chart-ready equity series for the Playground backtest page.
 
     Uses the same DJIA index + Nasdaq-100 baselines and gapless market-hour
-    x-axis as ``/runs/{run_id}/plot.png`` (Discord chart).
+    x-axis as ``/runs/{run_id}/plot.png`` (Discord chart), plus the paired
+    stored Buy & Hold curve when one exists.
     """
     session_id = get_session_id_from_request(request)
     run = db.get_run_with_session(run_id, session_id)
@@ -2198,11 +2199,7 @@ def get_backtest_chart_data(run_id: str, request: Request):
             initial_capital=initial_capital,
             agent_curve=agent_curve,
             card_name=card_name,
-            stored_baselines=(
-                _stored_buyhold_baseline(run)
-                if not profile.index_baseline_enabled
-                else []
-            ),
+            stored_baselines=_stored_buyhold_baseline(run),
             include_market_indexes=profile.index_baseline_enabled,
             market_timezone=profile.timezone,
         )

--- a/dashboard/backend/chart_style.py
+++ b/dashboard/backend/chart_style.py
@@ -17,7 +17,7 @@ PLAYGROUND_SERIES_COLORS = {
     "djia": "#F5C04A",
     "djia-index": "#F5C04A",
     "nasdaq-100": "#9AA4B2",
-    "buy-and-hold": "#9AA4B2",
+    "buy-and-hold": "#34D399",
 }
 
 PLAYGROUND_THEME = {

--- a/dashboard/backend/tests/fixtures/backtest-comparison.json
+++ b/dashboard/backend/tests/fixtures/backtest-comparison.json
@@ -1,0 +1,64 @@
+{
+  "run": {
+    "run_id": "agent-fixture",
+    "data_source": "alpaca",
+    "baseline_buyhold_run_id": "buyhold-fixture",
+    "reporting_currency": "USD"
+  },
+  "chart": {
+    "agent_run_id": "agent-fixture",
+    "timestamps": [
+      "2026-05-04T14:30:00Z",
+      "2026-05-04T15:30:00Z",
+      "2026-05-04T16:30:00Z",
+      "2026-05-04T17:30:00Z"
+    ],
+    "x_labels": ["2026-05-04", "", "", ""],
+    "index_baselines_ok": true,
+    "series": [
+      {
+        "run_id": "index:^NDX",
+        "label": "Nasdaq-100",
+        "values": [1000, 1020, 1010, 1060],
+        "color": "#9AA4B2",
+        "dashed": true
+      },
+      {
+        "run_id": "buyhold-fixture",
+        "label": "buy-and-hold",
+        "values": [1000, 1008, 1014, 1024],
+        "color": "#34D399",
+        "dashed": true
+      },
+      {
+        "run_id": "agent-fixture",
+        "label": "Agent 33",
+        "values": [1000, 1010, 995, 1017.4],
+        "color": "#4FC3F7",
+        "dashed": false
+      },
+      {
+        "run_id": "index:^DJI",
+        "label": "DJIA index",
+        "values": [1000, 1005, 1002, 1011.1],
+        "color": "#F5C04A",
+        "dashed": true
+      }
+    ]
+  },
+  "trades": {
+    "trades": [
+      {
+        "timestamp": "2026-05-04T15:30:00Z",
+        "symbol": "AAPL",
+        "side": "BUY",
+        "quantity": 1,
+        "price": 277.33,
+        "value": 277.33,
+        "reason": "Momentum entry"
+      }
+    ],
+    "order_events": [],
+    "order_events_truncated": 0
+  }
+}

--- a/dashboard/backend/tests/integrations/test_frontend_home_friction.py
+++ b/dashboard/backend/tests/integrations/test_frontend_home_friction.py
@@ -25,8 +25,9 @@ def test_backtest_result_has_no_fabricated_performance_drivers():
     assert "view-more-btn" not in html
 
 
-def test_real_result_metrics_are_preserved():
+def test_real_result_comparison_is_preserved():
     html = _APP_HTML.read_text(encoding="utf-8")
-    # The genuine, data-driven metrics must survive the cleanup.
-    for metric in ("max-drawdown", "sharpe"):
-        assert f'data-metric="{metric}"' in html
+    # The genuine, data-driven result surface must survive the cleanup.
+    assert 'id="performanceComparison"' in html
+    assert 'id="performanceComparisonBody"' in html
+    assert 'src="js/backtest-comparison.js?v=1"' in html

--- a/dashboard/backend/tests/test_admin_analytics_frontend.py
+++ b/dashboard/backend/tests/test_admin_analytics_frontend.py
@@ -190,9 +190,9 @@ def test_app_lifecycle_and_cache_versions_are_wired():
     assert "window.AdminAnalytics.syncAuth(user)" in APP_JS
     assert "window.AdminAnalytics.onEnter()" in APP_JS
     assert "window.AdminAnalytics.refresh()" in APP_JS
-    assert 'styles.css?v=125' in APP_HTML
-    assert 'app.js?v=116' in APP_HTML
     assert 'js/admin-analytics.js?v=2' in APP_HTML
+    assert 'styles.css?v=126' in APP_HTML
+    assert 'app.js?v=117' in APP_HTML
     assert 'js/admin-tabs.js?v=3' in APP_HTML
 
 

--- a/dashboard/backend/tests/test_analytics_frontend.py
+++ b/dashboard/backend/tests/test_analytics_frontend.py
@@ -41,7 +41,7 @@ def _function_body(source: str, signature: str) -> str:
 
 
 def test_analytics_script_loads_between_app_and_page_scripts():
-    app_at = APP_HTML.index('<script src="app.js?v=116" defer></script>')
+    app_at = APP_HTML.index('<script src="app.js?v=117" defer></script>')
     analytics_at = APP_HTML.index(
         '<script src="js/analytics.js?v=1" defer></script>'
     )

--- a/dashboard/backend/tests/test_backtest_chart_data.py
+++ b/dashboard/backend/tests/test_backtest_chart_data.py
@@ -1,0 +1,110 @@
+"""Focused contracts for the run-scoped Backtest chart-data route."""
+
+import dashboard.backend.api.routers.backtests as bt
+import pytest
+from fastapi import HTTPException
+
+
+def _curve():
+    return [
+        {"timestamp": "2026-05-04T14:30:00", "equity": 1_000.0},
+        {"timestamp": "2026-05-04T15:30:00", "equity": 1_010.0},
+    ]
+
+
+def _install_route_fakes(monkeypatch, *, buyhold_curve, index_ok=True):
+    run = {
+        "run_id": "agent-1",
+        "agent_name": "Agent",
+        "start_date": "2026-05-04",
+        "end_date": "2026-05-04",
+        "initial_equity": 1_000.0,
+        "baseline_buyhold_run_id": "buyhold-1",
+        "metadata": {"data_source": "alpaca"},
+    }
+    monkeypatch.setattr(
+        bt, "get_session_id_from_request", lambda _request: "session-1"
+    )
+    monkeypatch.setattr(
+        bt.db,
+        "get_run_with_session",
+        lambda run_id, session_id: run
+        if (run_id, session_id) == ("agent-1", "session-1")
+        else None,
+    )
+    monkeypatch.setattr(
+        bt.db,
+        "get_run",
+        lambda run_id: {"run_id": run_id, "agent_name": "buy-and-hold"}
+        if run_id == "buyhold-1"
+        else None,
+    )
+    monkeypatch.setattr(
+        bt.db,
+        "get_equity_curve",
+        lambda run_id: _curve() if run_id == "agent-1" else buyhold_curve,
+    )
+    monkeypatch.setattr(bt, "_filter_equity_for_run", lambda _run, curve: curve)
+    monkeypatch.setattr(
+        bt.agent_service.agents,
+        "get_agent_by_session",
+        lambda _session_id: None,
+    )
+
+    def fake_indexes(timestamps, *_args, **_kwargs):
+        indexes = [
+            ("DJIA index", "index:^DJI", [1_000.0, 1_005.0]),
+            ("Nasdaq-100", "index:^NDX", [1_000.0, 1_015.0]),
+        ]
+        return (indexes if index_ok else [], index_ok)
+
+    monkeypatch.setattr(
+        "dashboard.backend.equity_plot.market_index_baselines_with_status",
+        fake_indexes,
+    )
+
+
+def test_us_chart_data_includes_buyhold_and_market_indexes(monkeypatch):
+    _install_route_fakes(monkeypatch, buyhold_curve=_curve())
+
+    response = bt.get_backtest_chart_data("agent-1", object())
+
+    assert [series.run_id for series in response.series] == [
+        "agent-1",
+        "buyhold-1",
+        "index:^DJI",
+        "index:^NDX",
+    ]
+
+
+def test_missing_buyhold_curve_does_not_substitute_another_run(monkeypatch):
+    _install_route_fakes(monkeypatch, buyhold_curve=[])
+
+    response = bt.get_backtest_chart_data("agent-1", object())
+
+    assert "buyhold-1" not in [series.run_id for series in response.series]
+    assert response.index_baselines_ok is True
+
+
+def test_index_failure_retains_agent_and_buyhold(monkeypatch):
+    _install_route_fakes(monkeypatch, buyhold_curve=_curve(), index_ok=False)
+
+    response = bt.get_backtest_chart_data("agent-1", object())
+
+    assert [series.run_id for series in response.series] == [
+        "agent-1",
+        "buyhold-1",
+    ]
+    assert response.index_baselines_ok is False
+
+
+def test_chart_data_keeps_selected_run_session_scoped(monkeypatch):
+    _install_route_fakes(monkeypatch, buyhold_curve=_curve())
+    monkeypatch.setattr(
+        bt, "get_session_id_from_request", lambda _request: "other-session"
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        bt.get_backtest_chart_data("agent-1", object())
+
+    assert exc_info.value.status_code == 404

--- a/dashboard/backend/tests/test_backtest_comparison_frontend.py
+++ b/dashboard/backend/tests/test_backtest_comparison_frontend.py
@@ -50,6 +50,40 @@ def run_helper(expression):
     return json.loads(result.stdout)
 
 
+def extract_app_function(source, name):
+    for marker in (f"async function {name}(", f"function {name}("):
+        start = source.find(marker)
+        if start != -1:
+            break
+    else:
+        raise AssertionError(f"{name} not found in app.js")
+    depth = 0
+    index = source.index("{", start)
+    while index < len(source):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start:index + 1]
+        index += 1
+    raise AssertionError(f"unterminated function {name}")
+
+
+def run_app_functions(source, names, harness_lines):
+    script = "\n".join(
+        [*(extract_app_function(source, name) for name in names), *harness_lines]
+    )
+    result = subprocess.run(
+        ["node", "-e", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
 def test_model_canonicalizes_shuffled_series_and_calculates_deltas():
     model = run_helper("BacktestComparison.buildModel(fixture.chart, fixture.run)")
     assert [column["key"] for column in model["columns"]] == [
@@ -205,3 +239,32 @@ def test_comparison_states_and_focus_styles_ship():
         "displayNoMetrics",
     ):
         assert removed not in APP_JS
+
+
+def test_request_token_rejects_previous_run_after_selection_changes():
+    result = run_app_functions(
+        APP_JS,
+        ["beginBacktestSurfaceRequest", "isCurrentBacktestSurfaceRequest"],
+        [
+            "global.window = { SELECTED_RUN: { run_id: 'run-a' } };",
+            "let liveBacktestChartActive = false;",
+            "let backtestSurfaceRequestSeq = 0;",
+            "const first = beginBacktestSurfaceRequest('run-a');",
+            "window.SELECTED_RUN = { run_id: 'run-b' };",
+            "const second = beginBacktestSurfaceRequest('run-b');",
+            "console.log(JSON.stringify({",
+            "  first: isCurrentBacktestSurfaceRequest(first),",
+            "  second: isCurrentBacktestSurfaceRequest(second),",
+            "}));",
+        ],
+    )
+    assert result == {"first": False, "second": True}
+
+
+def test_historical_surfaces_settle_independently():
+    body = fn_body("async function loadHistoricalBacktestSurfaces(")
+    assert "Promise.allSettled" in body
+    assert "setPerformanceComparisonState(" in body
+    assert "'error'" in body
+    assert "loadTradingLogForRun" in body
+    assert "isCurrentBacktestSurfaceRequest" in body

--- a/dashboard/backend/tests/test_backtest_comparison_frontend.py
+++ b/dashboard/backend/tests/test_backtest_comparison_frontend.py
@@ -1,0 +1,148 @@
+"""Browser-runtime contracts for Backtest benchmark comparison."""
+
+import json
+import math
+import shutil
+import statistics
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "frontend" / "js" / "backtest-comparison.js"
+FIXTURE = Path(__file__).parent / "fixtures" / "backtest-comparison.json"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("node") is None, reason="node is not installed"
+)
+
+
+def run_helper(expression):
+    fixture = FIXTURE.read_text(encoding="utf-8")
+    source = SCRIPT.read_text(encoding="utf-8")
+    result = subprocess.run(
+        [
+            "node",
+            "-e",
+            "\n".join(
+                [
+                    "global.window = global;",
+                    source,
+                    f"const fixture = {fixture};",
+                    f"console.log(JSON.stringify({expression}));",
+                ]
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def test_model_canonicalizes_shuffled_series_and_calculates_deltas():
+    model = run_helper("BacktestComparison.buildModel(fixture.chart, fixture.run)")
+    assert [column["key"] for column in model["columns"]] == [
+        "agent",
+        "djia",
+        "nasdaq",
+        "buyhold",
+    ]
+    assert [column["label"] for column in model["columns"]] == [
+        "Your Agent",
+        "DJIA",
+        "Nasdaq-100",
+        "Buy & Hold",
+    ]
+    assert model["agentDeltas"]["djia"] == pytest.approx(0.63)
+    assert model["agentDeltas"]["nasdaq"] == pytest.approx(-4.26)
+    assert model["agentDeltas"]["buyhold"] == pytest.approx(-0.66)
+    assert model["bestByMetric"]["totalReturn"] == ["nasdaq"]
+
+
+def test_metrics_use_population_stddev_and_hourly_annualization():
+    metrics = run_helper(
+        "BacktestComparison.calculateMetrics([100, 110, 99, 120])"
+    )
+    returns = [0.1, -0.1, 120 / 99 - 1]
+    expected_sharpe = (
+        statistics.fmean(returns)
+        / statistics.pstdev(returns)
+        * math.sqrt(252 * 6.5)
+    )
+    assert metrics["finalValue"] == pytest.approx(120.0)
+    assert metrics["totalReturn"] == pytest.approx(20.0)
+    assert metrics["maxDrawdown"] == pytest.approx(-10.0)
+    assert metrics["sharpe"] == pytest.approx(expected_sharpe)
+
+
+def test_invalid_and_flat_series_are_unavailable_not_zero():
+    result = run_helper(
+        "({"
+        "short: BacktestComparison.calculateMetrics([100]),"
+        "flat: BacktestComparison.calculateMetrics([100, 100, 100]),"
+        "zeroStart: BacktestComparison.calculateMetrics([0, 10, 12]),"
+        "missing: BacktestComparison.calculateMetrics([null, undefined]),"
+        "gapped: BacktestComparison.calculateMetrics([100, null, 110]),"
+        "nonFinite: BacktestComparison.calculateMetrics([100, Number.NaN, 110])"
+        "})"
+    )
+    assert result["short"] == {
+        "finalValue": 100,
+        "totalReturn": None,
+        "maxDrawdown": None,
+        "sharpe": None,
+    }
+    assert result["flat"]["sharpe"] is None
+    assert result["zeroStart"]["totalReturn"] is None
+    assert result["missing"] == {
+        "finalValue": None,
+        "totalReturn": None,
+        "maxDrawdown": None,
+        "sharpe": None,
+    }
+    assert result["gapped"]["totalReturn"] == pytest.approx(10.0)
+    assert result["nonFinite"]["totalReturn"] == pytest.approx(10.0)
+
+
+def test_ifind_model_omits_inapplicable_us_indexes():
+    keys = run_helper(
+        "BacktestComparison.buildModel(fixture.chart, "
+        "{...fixture.run, data_source: 'ifind_ashare'}).columns.map(c => c.key)"
+    )
+    assert keys == ["agent", "buyhold"]
+
+
+def test_degraded_indexes_and_missing_buyhold_stay_explicitly_unavailable():
+    model = run_helper(
+        "BacktestComparison.buildModel("
+        "{...fixture.chart, index_baselines_ok: false, "
+        "series: fixture.chart.series.filter(s => s.run_id !== 'buyhold-fixture')}, "
+        "fixture.run)"
+    )
+    columns = {column["key"]: column for column in model["columns"]}
+    assert columns["agent"]["available"] is True
+    assert columns["djia"]["available"] is False
+    assert columns["nasdaq"]["available"] is False
+    assert columns["buyhold"]["available"] is False
+    assert model["agentDeltas"] == {
+        "djia": None,
+        "nasdaq": None,
+        "buyhold": None,
+    }
+
+
+def test_exact_raw_ties_mark_every_tied_series_best():
+    best = run_helper(
+        "(() => { const agent = fixture.chart.series.find("
+        "s => s.run_id === fixture.chart.agent_run_id); "
+        "const chart = {...fixture.chart, series: fixture.chart.series"
+        ".filter(s => ['agent-fixture', 'index:^DJI'].includes(s.run_id))"
+        ".map(s => s.run_id === 'index:^DJI' ? {...s, values: agent.values} : s)}; "
+        "return BacktestComparison.buildModel(chart, fixture.run).bestByMetric; })()"
+    )
+    assert best["totalReturn"] == ["agent", "djia"]
+    assert best["maxDrawdown"] == ["agent", "djia"]

--- a/dashboard/backend/tests/test_backtest_comparison_frontend.py
+++ b/dashboard/backend/tests/test_backtest_comparison_frontend.py
@@ -9,6 +9,13 @@ from pathlib import Path
 
 import pytest
 
+from dashboard.backend.tests._frontend_source import (
+    APP_HTML,
+    APP_JS,
+    STYLES,
+    fn_body,
+)
+
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "frontend" / "js" / "backtest-comparison.js"
@@ -146,3 +153,55 @@ def test_exact_raw_ties_mark_every_tied_series_best():
     )
     assert best["totalReturn"] == ["agent", "djia"]
     assert best["maxDrawdown"] == ["agent", "djia"]
+
+
+def test_comparison_script_and_semantic_table_ship_before_app():
+    helper = '<script src="js/backtest-comparison.js?v=1" defer></script>'
+    app = '<script src="app.js?v=117" defer></script>'
+    assert 'href="styles.css?v=126"' in APP_HTML
+    assert APP_HTML.index(helper) < APP_HTML.index(app)
+    for element_id in (
+        "performanceLegend",
+        "performanceComparison",
+        "performanceComparisonHead",
+        "performanceComparisonBody",
+        "performanceComparisonStatus",
+    ):
+        assert f'id="{element_id}"' in APP_HTML
+    assert 'aria-describedby="performanceComparisonCaption"' in APP_HTML
+    assert 'aria-details="performanceComparison"' in APP_HTML
+    assert 'role="img"' in APP_HTML
+
+
+def test_chart_uses_canonical_model_and_dom_legend():
+    body = fn_body("function initializeCharts()")
+    assert "BacktestComparison.buildModel" in body
+    assert "renderPerformanceComparison" in body
+    assert "renderPerformanceLegend" in body
+    assert "comparisonKey" in body
+    assert "display: false" in body
+
+
+def test_renderers_create_semantic_headers_and_native_legend_buttons():
+    comparison = fn_body("function renderPerformanceComparison(")
+    legend = fn_body("function renderPerformanceLegend(")
+    assert ".scope = 'col'" in comparison
+    assert ".scope = 'row'" in comparison
+    assert "Best" in comparison
+    assert "document.createElement('button')" in legend
+    assert "button.type = 'button'" in legend
+    assert "aria-pressed" in legend
+    assert "setDatasetVisibility" in legend
+
+
+def test_comparison_states_and_focus_styles_ship():
+    assert ".performance-comparison" in STYLES
+    assert ".performance-legend-button:focus-visible" in STYLES
+    assert ".performance-comparison-scroll:focus-visible" in STYLES
+    assert 'data-metric="final-value"' not in APP_HTML
+    for removed in (
+        "loadPerformanceMetrics",
+        "displayPerformanceMetrics",
+        "displayNoMetrics",
+    ):
+        assert removed not in APP_JS

--- a/dashboard/backend/tests/test_chart_baseline_notice_frontend.py
+++ b/dashboard/backend/tests/test_chart_baseline_notice_frontend.py
@@ -24,6 +24,7 @@ def test_initialize_charts_reads_the_flag_and_toggles_the_notice():
     body = fn_body("function initializeCharts()")
     assert "chartBaselineNotice" in body
     assert "index_baselines_ok" in body
+    assert "renderPerformanceComparison" in body
     # `!== false`, not falsy: a payload from an older backend omits the key
     # entirely, and `!payload.index_baselines_ok` would show the warning on
     # every healthy chart served during a frontend/backend deploy skew.

--- a/dashboard/backend/tests/test_chart_style.py
+++ b/dashboard/backend/tests/test_chart_style.py
@@ -23,6 +23,10 @@ def test_series_kind_and_colors_match_playground():
     assert series_color("agent_123", "Agent") == PLAYGROUND_SERIES_COLORS["agent"]
     assert series_color("idx1", "DJIA index") == "#F5C04A"
     assert series_color("idx2", "Nasdaq-100") == "#9AA4B2"
+    assert series_color("buyhold_1", "buy-and-hold") == "#34D399"
+    assert series_color("buyhold_1", "buy-and-hold") != series_color(
+        "idx2", "Nasdaq-100"
+    )
 
 
 def test_format_playground_timestamp():

--- a/dashboard/backend/tests/test_frontend_fast_boot.py
+++ b/dashboard/backend/tests/test_frontend_fast_boot.py
@@ -190,9 +190,9 @@ def test_cache_busters_bumped():
     # the next bump, so the exact one looks like the broken guard and gets
     # "fixed" by loosening it. That collision has already cost this repo one
     # round of follow-ups (#347/#348).
-    assert "app.js?v=116" in APP_HTML
+    assert "app.js?v=117" in APP_HTML
     assert "js/agent-editor.js?v=28" in APP_HTML
-    assert "styles.css?v=125" in APP_HTML
+    assert "styles.css?v=126" in APP_HTML
     assert "js/leaderboard.js?v=32" in APP_HTML
     assert "home-page.js?v=50" in APP_HTML
     assert "js/credit-format.js?v=1" in APP_HTML

--- a/dashboard/backend/tests/test_ifind_ashare_frontend.py
+++ b/dashboard/backend/tests/test_ifind_ashare_frontend.py
@@ -306,6 +306,7 @@ def test_historical_run_config_reads_delay_summary_from_linked_buyhold(js):
 
 
 def test_ifind_chart_does_not_render_us_index_series(js):
+    assert "BacktestComparison.buildModel" in js
     assert re.search(r"filterIfindChartSeries\s*\(", js)
     assert "DJIA index" in js
     assert "Nasdaq-100" in js

--- a/dashboard/backend/tests/test_trading_log_order_events_ui.py
+++ b/dashboard/backend/tests/test_trading_log_order_events_ui.py
@@ -58,14 +58,23 @@ def _run_node(lines):
     return json.loads(result.stdout)
 
 
-def test_trading_log_markup_uses_order_language_and_eight_columns():
+def test_trading_log_markup_is_an_accessible_right_rail_feed():
     html = _APP_HTML.read_text(encoding="utf-8")
 
     assert "All Orders" in html
     assert "All Trades" not in html
-    assert "<th>Status</th>" in html
-    assert "<th>Reason</th>" in html
-    assert 'colspan="8"' in html
+    assert 'id="tradingLogFeed"' in html
+    assert 'role="list"' in html
+    assert 'tabindex="0"' in html
+    assert 'aria-label="Trading Log orders"' in html
+    assert 'id="tradingLogCount"' in html
+    assert 'id="tradingLogStatusSummary"' in html
+    assert 'class="trading-log-table"' not in html
+    center_end = html.index('</section>', html.index('class="center-panel"'))
+    log_at = html.index('id="tradingLogFeed"')
+    right_at = html.index('class="right-panel"')
+    assert right_at < log_at
+    assert log_at > center_end
 
 
 def _merge_harness(source: str):
@@ -161,7 +170,11 @@ def test_truncation_is_derived_from_either_signal():
 def _render_harness(source: str):
     return [
         "const tbody = { innerHTML: '' };",
-        "const document = { getElementById: () => tbody };",
+        "const tradingLogCount = { textContent: '' };",
+        "const tradingLogStatusSummary = { textContent: '' };",
+        "const document = { getElementById: (id) => ({",
+        "  tradingLogFeed: tbody, tradingLogCount, tradingLogStatusSummary,",
+        "}[id] || tbody) };",
         "const IFIND_ASHARE_UNIVERSES = { demo: { assets: [",
         "  { symbol: '600519.SH', name: 'Kweichow Moutai' },",
         "] } };",
@@ -178,6 +191,7 @@ def _render_harness(source: str):
         _extract_function(source, "renderOrderCostAudit"),
         _extract_function(source, "renderMarketRuleAudit"),
         _extract_function(source, "formatTradeTimestamp"),
+        _extract_function(source, "renderTradingLogSummary"),
         _extract_function(source, "paintTradingLog"),
         _extract_function(source, "renderTradingLog"),
     ]
@@ -203,7 +217,7 @@ def test_rendered_rejection_has_safe_reason_zero_fill_and_english_company():
     assert "0 / 50 shares" in known
     assert "REJECTED" in known
     assert "Invalid lot size" in known
-    assert ">$250.00<" in known
+    assert "$250.00" in known
     assert ">--<" in known
     assert "<img" not in result["unknown"]
     assert "Order not executed" in result["unknown"]
@@ -249,6 +263,23 @@ def test_rendered_partial_uses_actual_value_and_side_filter():
     assert "$2,000.00" in result
     assert "T+1 frozen" in result
     assert "Apple Inc." not in result
+
+
+def test_rendering_updates_order_count_and_status_summary():
+    source = _APP_JS.read_text(encoding="utf-8")
+    result = _run_node(_render_harness(source) + [
+        "renderTradingLog([",
+        " { symbol: 'AAPL', side: 'BUY', requested_shares: 1, executed_shares: 1,",
+        "   price: 10, executed_value: 10, status: 'filled', reason: '' },",
+        " { symbol: 'MSFT', side: 'BUY', requested_shares: 2, executed_shares: 1,",
+        "   price: 20, executed_value: 20, status: 'partial', reason: '' },",
+        " { symbol: '600519.SH', side: 'SELL', requested_shares: 100, executed_shares: 0,",
+        "   price: 200, executed_value: 0, status: 'rejected', reason: 'invalid_lot_size' },",
+        "]);",
+        "console.log(JSON.stringify({ count: tradingLogCount.textContent, summary: tradingLogStatusSummary.textContent }));",
+    ])
+
+    assert result == {"count": "3 orders", "summary": "1 filled · 1 partial · 1 rejected"}
 
 
 def test_capped_sample_says_so_instead_of_ending_early():

--- a/dashboard/backend/tests/test_trading_log_order_events_ui.py
+++ b/dashboard/backend/tests/test_trading_log_order_events_ui.py
@@ -24,8 +24,18 @@ def _extract_function(source: str, name: str) -> str:
             break
     else:
         raise AssertionError(f"{name} not found in {_APP_JS.name}")
+    paren_depth = 0
+    paren_index = source.index("(", start)
+    while paren_index < len(source):
+        if source[paren_index] == "(":
+            paren_depth += 1
+        elif source[paren_index] == ")":
+            paren_depth -= 1
+            if paren_depth == 0:
+                break
+        paren_index += 1
     depth = 0
-    index = source.index("{", start)
+    index = source.index("{", paren_index)
     while index < len(source):
         if source[index] == "{":
             depth += 1
@@ -369,3 +379,25 @@ def test_ordinary_a_share_fill_carries_no_market_rule_audit_line():
     assert "¥13.00" not in result
     assert "Official close" not in result
     assert "Official status" not in result
+
+
+def test_late_trading_log_response_cannot_repaint_a_newer_run():
+    source = _APP_JS.read_text(encoding="utf-8")
+    function_source = _extract_function(source, "loadTradingLogForRun")
+    body = function_source[function_source.index("{") :]
+    assert body.count("if (!isCurrent()) return") >= 2
+    result = _run_node([
+        "const API_BASE = '';",
+        "const paints = [];",
+        "const API = { get: async () => ({ trades: [{ symbol: 'AAPL' }] }) };",
+        "const resolveTradingLogRecords = (payload) => payload.trades;",
+        "const resolveTradingLogTruncation = () => 0;",
+        "const renderTradingLog = () => paints.push('render');",
+        "const clearTradingLog = () => paints.push('clear');",
+        function_source,
+        "(async () => {",
+        "  await loadTradingLogForRun('run-a', { isCurrent: () => false });",
+        "  console.log(JSON.stringify(paints));",
+        "})();",
+    ])
+    assert result == []

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -1274,11 +1274,21 @@
                 </section>
             </div>
 
-            <!-- Trading Log Section -->
-            <div class="section-card">
-                <div class="section-header">
-                    <h2>Trading Log</h2>
+        </section>
+
+        <!-- Right Panel: run-scoped Trading Log -->
+        <aside class="right-panel">
+            <section class="section-card trading-log-card" aria-labelledby="tradingLogTitle">
+                <div class="section-header trading-log-header">
+                    <div>
+                        <h2 id="tradingLogTitle">Trading Log</h2>
+                        <p class="trading-log-summary">
+                            <span id="tradingLogCount">0 orders</span>
+                            <span id="tradingLogStatusSummary"></span>
+                        </p>
+                    </div>
                     <div class="log-controls">
+                        <label class="sr-only" for="tradingLogFilter">Filter Trading Log orders</label>
                         <select class="filter-select" id="tradingLogFilter">
                             <option value="all">All Orders</option>
                             <option value="buy">Buys Only</option>
@@ -1287,32 +1297,11 @@
                     </div>
                 </div>
 
-                <div class="trading-log-scroll">
-                    <table class="decision-table trading-log-table">
-                        <thead>
-                            <tr>
-                                <th>Time</th>
-                                <th>Action</th>
-                                <th>Company / Asset</th>
-                                <th>Quantity</th>
-                                <th>Price</th>
-                                <th>Total Value</th>
-                                <th>Status</th>
-                                <th>Reason</th>
-                            </tr>
-                        </thead>
-                        <tbody id="tradingLogBody">
-                            <tr>
-                                <td colspan="8" class="trading-log-empty">Run a backtest to see orders here.</td>
-                            </tr>
-                        </tbody>
-                    </table>
+                <div id="tradingLogFeed" class="trading-log-scroll" role="list" tabindex="0" aria-label="Trading Log orders">
+                    <p class="trading-log-empty">Run a backtest to see orders here.</p>
                 </div>
-            </div>
-        </section>
-
-        <!-- Right rail is populated by the run-scoped Trading Log. -->
-        <aside class="right-panel"></aside>
+            </section>
+        </aside>
     </div>
 
     <!-- Paper Trading View (Playground / Paper Trading) -->

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -13,7 +13,7 @@
          because every API call is a CORS request. -->
     <link rel="preconnect" href="https://agentictrading.onrender.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css?v=125">
+    <link rel="stylesheet" href="styles.css?v=126">
     <!-- defer: ~200KB that was render-blocking. Deferred scripts execute in
          document order (this one first, the body-end ones after), all before
          DOMContentLoaded, so Chart is defined before any chart renders. -->
@@ -1253,11 +1253,25 @@
                     reached. Your agent's curve is complete; reload to retry the benchmarks.
                 </p>
 
-                <!-- Chart with integrated legend -->
+                <div id="performanceLegend" class="performance-legend" role="group" aria-label="Chart series visibility"></div>
+
                 <div class="chart-container">
-                    <canvas id="performanceChart"></canvas>
+                    <canvas id="performanceChart" role="img" aria-label="Portfolio value comparison chart" aria-describedby="performanceComparisonCaption" aria-details="performanceComparison"></canvas>
                 </div>
 
+                <section id="performanceComparison" class="performance-comparison" aria-labelledby="performanceComparisonTitle">
+                    <div class="performance-comparison-header">
+                        <h3 id="performanceComparisonTitle">Performance comparison</h3>
+                        <p id="performanceComparisonCaption">Same capital, date range, and sampling interval.</p>
+                    </div>
+                    <div class="performance-comparison-scroll" tabindex="0" aria-label="Performance comparison table">
+                        <table>
+                            <thead id="performanceComparisonHead"></thead>
+                            <tbody id="performanceComparisonBody"></tbody>
+                        </table>
+                    </div>
+                    <p id="performanceComparisonStatus" class="performance-comparison-status" role="status" aria-live="polite"></p>
+                </section>
             </div>
 
             <!-- Trading Log Section -->
@@ -1297,34 +1311,8 @@
             </div>
         </section>
 
-        <!-- Right Panel: Metrics -->
-        <aside class="right-panel">
-            <!-- Trading Performance Summary -->
-            <div class="section-card compact">
-                <h3 class="section-title">Trading Performance Summary</h3>
-                
-                <div class="metric-row">
-                    <span class="metric-label">Final Value</span>
-                    <span class="metric-value" data-metric="final-value">--</span>
-                </div>
-                <div class="metric-row">
-                    <span class="metric-label">Cumulative Return</span>
-                    <span class="metric-value" data-metric="total-return">--</span>
-                </div>
-                <div class="metric-row">
-                    <span class="metric-label">Max Drawdown</span>
-                    <span class="metric-value" data-metric="max-drawdown">--</span>
-                </div>
-                <div class="metric-row">
-                    <span class="metric-label">Sharpe Ratio</span>
-                    <span class="metric-value" data-metric="sharpe" title="Risk-adjusted return, annualized from hourly results.">--</span>
-                </div>
-                
-            </div>
-
-
-
-        </aside>
+        <!-- Right rail is populated by the run-scoped Trading Log. -->
+        <aside class="right-panel"></aside>
     </div>
 
     <!-- Paper Trading View (Playground / Paper Trading) -->
@@ -2418,7 +2406,8 @@
     <script src="market-events/MarketEventCard.js" defer></script>
     <script src="market-events/MarketEventFeed.js" defer></script>
     <script src="js/portfolio.js?v=17" defer></script>
-    <script src="app.js?v=116" defer></script>
+    <script src="js/backtest-comparison.js?v=1" defer></script>
+    <script src="app.js?v=117" defer></script>
     <script src="js/analytics.js?v=1" defer></script>
     <script src="js/agent-editor.js?v=28" defer></script>
     <script src="js/credit-format.js?v=1" defer></script>

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -7204,8 +7204,8 @@ function formatTradeTimestamp(ts) {
  * every quantity and dropping the currency audit the moment a user filters.
  */
 function paintTradingLog(normalizedRecords, options) {
-    const tbody = document.getElementById('tradingLogBody');
-    if (!tbody) return;
+    const feed = document.getElementById('tradingLogFeed');
+    if (!feed) return;
     options = options || {};
     const emptyMessage = options.emptyMessage || 'No orders yet.';
 
@@ -7216,12 +7216,14 @@ function paintTradingLog(normalizedRecords, options) {
         filtered = normalizedRecords.filter((trade) => trade.side === 'SELL');
     }
 
+    renderTradingLogSummary(filtered);
+
     if (filtered.length === 0) {
-        tbody.innerHTML = `<tr><td colspan="8" class="trading-log-empty">${escapeHtml(emptyMessage)}</td></tr>`;
+        feed.innerHTML = `<p class="trading-log-empty">${escapeHtml(emptyMessage)}</p>`;
         return;
     }
 
-    tbody.innerHTML = filtered.map((order) => {
+    feed.innerHTML = filtered.map((order) => {
         const actionClass = order.side === 'SELL' ? 'action-sell' : 'action-buy';
         const actionLabel = order.side === 'SELL' ? 'SELL' : 'BUY';
         const statusLabel = order.status.toUpperCase();
@@ -7245,16 +7247,24 @@ function paintTradingLog(normalizedRecords, options) {
         const repeatNote = order.repeatCount > 1
             ? `<div class="trading-log-native">×${order.repeatCount} that day</div>`
             : '';
-        return `<tr>
-            <td>${escapeHtml(formatTradeTimestamp(order.timestamp))}</td>
-            <td><span class="${actionClass}">${actionLabel}</span></td>
-            <td><div class="trading-log-asset"><strong>${escapeHtml(order.symbol)}</strong>${assetName ? `<small>${escapeHtml(assetName)}</small>` : ''}</div></td>
-            <td class="trading-log-quantity">${escapeHtml(quantity)}</td>
-            <td>$${order.price.toFixed(2)}${priceAudit}</td>
-            <td class="trading-log-value">${order.executedShares > 0 ? `${formatTradingMoney(order.value, '$')}${valueAudit}${costAudit}` : '--'}</td>
-            <td><span class="order-status order-status-${order.status}" title="Order status: ${statusLabel}" aria-label="Order status: ${statusLabel}">${statusLabel}</span></td>
-            <td class="trading-log-reason">${escapeHtml(reason)}${marketRuleAudit}${repeatNote}</td>
-        </tr>`;
+        return `<article class="trading-log-event" role="listitem">
+            <div class="trading-log-event-head">
+                <span class="trading-log-action ${actionClass}">${actionLabel}</span>
+                <div class="trading-log-asset">
+                    <strong>${escapeHtml(order.symbol)}</strong>
+                    ${assetName ? `<small>${escapeHtml(assetName)}</small>` : ''}
+                    <time datetime="${escapeHtml(order.timestamp || '')}">${escapeHtml(formatTradeTimestamp(order.timestamp))}</time>
+                </div>
+                <span class="order-status order-status-${order.status}" aria-label="Order status: ${statusLabel}">${statusLabel}</span>
+            </div>
+            <div class="trading-log-event-meta">
+                <span><small>Filled / requested</small>${escapeHtml(quantity)}</span>
+                <span><small>Execution price</small>$${order.price.toFixed(2)}${priceAudit}</span>
+                <span><small>Filled value</small>${order.executedShares > 0 ? `${formatTradingMoney(order.value, '$')}${valueAudit}` : '--'}</span>
+            </div>
+            ${costAudit}
+            <p class="trading-log-reason"><span class="trading-log-reason-label">Reason</span>${escapeHtml(reason)}${marketRuleAudit}${repeatNote}</p>
+        </article>`;
     }).join('');
 
     // Never let a capped list read like a complete one. The server bounds the
@@ -7265,7 +7275,24 @@ function paintTradingLog(normalizedRecords, options) {
         const note = `${truncated.toLocaleString('en-US')} more unfilled `
             + `${truncated === 1 ? 'order is' : 'orders are'} not shown `
             + '(audit sample capped).';
-        tbody.innerHTML += `<tr><td colspan="8" class="trading-log-empty">${escapeHtml(note)}</td></tr>`;
+        feed.innerHTML += `<p class="trading-log-empty trading-log-truncation">${escapeHtml(note)}</p>`;
+    }
+}
+
+function renderTradingLogSummary(filtered) {
+    const countEl = document.getElementById('tradingLogCount');
+    const summaryEl = document.getElementById('tradingLogStatusSummary');
+    const records = Array.isArray(filtered) ? filtered : [];
+    const count = records.length;
+    if (countEl) countEl.textContent = `${count.toLocaleString('en-US')} ${count === 1 ? 'order' : 'orders'}`;
+    if (summaryEl) {
+        const counts = records.reduce((summary, order) => {
+            if (order.status === 'filled') summary.filled += 1;
+            else if (order.status === 'partial') summary.partial += 1;
+            else if (order.status === 'rejected') summary.rejected += 1;
+            return summary;
+        }, { filled: 0, partial: 0, rejected: 0 });
+        summaryEl.textContent = `${counts.filled} filled · ${counts.partial} partial · ${counts.rejected} rejected`;
     }
 }
 

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -1888,7 +1888,6 @@ async function onBacktestAgentSelectChange() {
   localStorage.removeItem(SELECTED_BACKTEST_RUN_KEY);
   if (currentMode === 'backtest') {
     await loadData();
-    loadPerformanceMetrics();
   }
 }
 
@@ -5209,135 +5208,151 @@ function updateMarketsOpenStatus() {
 window.updateMarketsOpenStatus = updateMarketsOpenStatus;
 window.isUsEquityMarketOpen = isUsEquityMarketOpen;
 
-/**
- * Load performance metrics from latest backtest run
- */
-async function loadPerformanceMetrics() {
-    try {
-        if (liveBacktestChartActive) {
-            displayNoMetrics();
-            return;
-        }
-        // Mirror the chart: show metrics for the selected run. window.SELECTED_RUN
-        // is set by loadData; resolve from session runs when called standalone.
-        let metrics = window.SELECTED_RUN || null;
+function formatComparisonMetric(metric, value, currency = 'USD') {
+    if (!Number.isFinite(value)) return '—';
+    if (metric.kind === 'currency') {
+        return new Intl.NumberFormat('en-US', {
+            style: 'currency',
+            currency,
+            maximumFractionDigits: 0,
+        }).format(value);
+    }
+    if (metric.kind === 'percent') {
+        return `${value >= 0 ? '+' : ''}${value.toFixed(2)}%`;
+    }
+    return value.toFixed(2);
+}
 
-        if (!metrics) {
-            try {
-                const sessionRuns = await API.get(`${API_BASE}/api/backtest/runs?t=${Date.now()}`);
-                metrics = resolveSelectedRun(sessionRuns);
-            } catch (e) {
-                console.warn('Could not load session runs for metrics');
+function createComparisonDelta(value, label) {
+    if (!Number.isFinite(value)) return null;
+    const delta = document.createElement('span');
+    const state = value > 0 ? 'is-positive' : value < 0 ? 'is-negative' : 'is-neutral';
+    const sign = value > 0 ? '+' : value < 0 ? '-' : '';
+    delta.className = `performance-delta ${state}`;
+    delta.textContent = `${label} ${sign}${Math.abs(value).toFixed(2)}pp`;
+    return delta;
+}
+
+function setPerformanceComparisonState(state, message = '') {
+    const region = document.getElementById('performanceComparison');
+    const status = document.getElementById('performanceComparisonStatus');
+    if (!region || !status) return;
+    region.dataset.state = state;
+    status.textContent = message;
+}
+
+function clearPerformanceComparison(state = 'empty', message = '') {
+    document.getElementById('performanceComparisonHead')?.replaceChildren();
+    document.getElementById('performanceComparisonBody')?.replaceChildren();
+    renderPerformanceLegend({ columns: [] });
+    setPerformanceComparisonState(state, message);
+}
+
+function renderPerformanceComparison(payload, run) {
+    const head = document.getElementById('performanceComparisonHead');
+    const body = document.getElementById('performanceComparisonBody');
+    if (!head || !body || !window.BacktestComparison) return;
+
+    const model = window.BacktestComparison.buildModel(payload, run);
+    const currency = run?.reporting_currency
+        || run?.metadata?.reporting_currency
+        || 'USD';
+    const headerRow = document.createElement('tr');
+    const metricHeader = document.createElement('th');
+    metricHeader.scope = 'col';
+    metricHeader.textContent = 'Metric';
+    headerRow.appendChild(metricHeader);
+
+    for (const column of model.columns) {
+        const header = document.createElement('th');
+        header.scope = 'col';
+        header.dataset.seriesKey = column.key;
+        const swatch = document.createElement('span');
+        swatch.className = 'performance-series-swatch';
+        swatch.style.backgroundColor = column.color;
+        swatch.setAttribute('aria-hidden', 'true');
+        header.append(swatch, document.createTextNode(column.label));
+        headerRow.appendChild(header);
+    }
+    head.replaceChildren(headerRow);
+
+    const rows = window.BacktestComparison.METRICS.map((metric) => {
+        const row = document.createElement('tr');
+        const rowHeader = document.createElement('th');
+        rowHeader.scope = 'row';
+        rowHeader.textContent = metric.label;
+        row.appendChild(rowHeader);
+
+        for (const column of model.columns) {
+            const cell = document.createElement('td');
+            const value = column.metrics[metric.key];
+            cell.dataset.seriesKey = column.key;
+            const formatted = document.createElement('span');
+            formatted.className = 'performance-metric-value';
+            formatted.textContent = formatComparisonMetric(metric, value, currency);
+            cell.appendChild(formatted);
+
+            if (model.bestByMetric[metric.key].includes(column.key)) {
+                cell.classList.add('performance-best');
+                const best = document.createElement('span');
+                best.className = 'performance-best-label';
+                best.textContent = 'Best';
+                cell.appendChild(best);
             }
-        }
 
-        if (!metrics) {
-            metrics = await API.get(`${API_BASE}/runs/latest/metrics?t=${Date.now()}`);
+            if (metric.key === 'totalReturn' && column.key === 'agent') {
+                const deltas = document.createElement('span');
+                deltas.className = 'performance-deltas';
+                for (const benchmark of model.columns.filter((item) => item.key !== 'agent')) {
+                    const delta = createComparisonDelta(
+                        model.agentDeltas[benchmark.key],
+                        benchmark.label,
+                    );
+                    if (delta) deltas.appendChild(delta);
+                }
+                cell.appendChild(deltas);
+            }
+            row.appendChild(cell);
         }
-
-        if (!metrics || !metrics.initial_equity) {
-            console.warn('Invalid metrics data:', metrics);
-            displayNoMetrics();
-            return;
-        }
-
-        displayPerformanceMetrics(metrics);
-        console.log('✅ Performance metrics loaded:', metrics);
-    } catch (error) {
-        console.warn('Error fetching performance metrics:', error.message);
-        displayNoMetrics();
-    }
-}
-
-/**
- * Display performance metrics in the summary panel
- */
-/**
- * Display performance metrics from backtest results.
- * 
- * Metric Formulas:
- * 1. Final Portfolio Value: last portfolio value in equity curve
- * 2. Cumulative Return: (final_value - initial_capital) / initial_capital * 100
- * 3. Max Drawdown: minimum drawdown = (value - running_peak) / running_peak * 100
- * 4. Sharpe Ratio: (mean(returns) / std(returns)) * sqrt(252*6.5)
- *    - Hourly data with 252 trading days/year and 6.5 hours/day
- */
-function displayPerformanceMetrics(metrics) {
-    console.log('displayPerformanceMetrics() called with:', metrics);
-    
-    // Calculate final value from initial equity and total return
-    const initialCapital = metrics.initial_equity || 1000;
-    let totalReturnPercent = metrics.total_return || 0;
-    if (Math.abs(totalReturnPercent) <= 1 && totalReturnPercent !== 0) {
-        totalReturnPercent = totalReturnPercent * 100;
-    }
-    const finalValue = metrics.final_equity || (initialCapital * (1 + totalReturnPercent / 100));
-    
-    // Update Final Value
-    const finalValueEl = document.querySelector('[data-metric="final-value"]');
-    if (finalValueEl) {
-        finalValueEl.textContent = '$' + finalValue.toLocaleString('en-US', {
-            minimumFractionDigits: 0,
-            maximumFractionDigits: 0
-        });
-        finalValueEl.className = 'metric-value ' + (totalReturnPercent >= 0 ? 'positive' : 'negative');
-        console.log(`  → Updated Final Value: $${finalValue.toFixed(0)}`);
-    }
-    
-    // Update Cumulative Return (renamed from Total Return)
-    const returnEl = document.querySelector('[data-metric="total-return"]');
-    if (returnEl) {
-        const returnSign = totalReturnPercent >= 0 ? '+' : '';
-        const returnText = returnSign + totalReturnPercent.toFixed(2) + '%';
-        returnEl.textContent = returnText;
-        returnEl.className = 'metric-value ' + (totalReturnPercent >= 0 ? 'positive' : 'negative');
-        console.log(`  → Updated Cumulative Return: ${returnText}`);
-    }
-    
-    // Update Max Drawdown
-    const drawdownEl = document.querySelector('[data-metric="max-drawdown"]');
-    if (drawdownEl) {
-        let maxDrawdown = metrics.max_drawdown || 0;
-        if (Math.abs(maxDrawdown) <= 1 && maxDrawdown !== 0) {
-            maxDrawdown = maxDrawdown * 100;
-        }
-        const drawdownText = maxDrawdown.toFixed(2) + '%';
-        drawdownEl.textContent = drawdownText;
-        drawdownEl.className = 'metric-value ' + (maxDrawdown >= 0 ? 'positive' : 'negative');
-        console.log(`  → Updated Max Drawdown: ${drawdownText}`);
-    }
-    
-    // Update Sharpe Ratio
-    // Note: Calculated using hourly data with annualization factor sqrt(252*6.5)
-    const sharpeEl = document.querySelector('[data-metric="sharpe"]');
-    if (sharpeEl) {
-        const sharpe = metrics.sharpe_ratio || 0;
-        const sharpeText = sharpe.toFixed(2);
-        sharpeEl.textContent = sharpeText;
-        sharpeEl.className = 'metric-value';
-        console.log(`  → Updated Sharpe Ratio: ${sharpeText}`);
-        // Tooltip already set in HTML with title attribute
-    }
-}
-
-/**
- * Display placeholder when no metrics available
- */
-function displayNoMetrics() {
-    const elements = [
-        '[data-metric="final-value"]',
-        '[data-metric="total-return"]',
-        '[data-metric="max-drawdown"]',
-        '[data-metric="sharpe"]'
-    ];
-    
-    elements.forEach(selector => {
-        const el = document.querySelector(selector);
-        if (el) {
-            el.textContent = '--';
-            el.className = 'metric-value';
-        }
+        return row;
     });
+    body.replaceChildren(...rows);
+
+    const missing = model.columns.filter((column) => !column.available);
+    const message = missing.length
+        ? `${missing.map((column) => column.label).join(', ')} unavailable for this run.`
+        : '';
+    setPerformanceComparisonState(missing.length ? 'partial' : 'ready', message);
+    return model;
+}
+
+function renderPerformanceLegend(model, { disabled = false } = {}) {
+    const host = document.getElementById('performanceLegend');
+    if (!host) return;
+    const available = (model?.columns || []).filter((column) => column.available);
+    const buttons = available.map((column, index) => {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'performance-legend-button';
+        button.dataset.datasetIndex = String(index);
+        button.setAttribute('aria-pressed', 'true');
+        button.disabled = disabled;
+
+        const swatch = document.createElement('span');
+        swatch.className = 'performance-series-swatch';
+        swatch.style.backgroundColor = column.color;
+        swatch.setAttribute('aria-hidden', 'true');
+        button.append(swatch, document.createTextNode(column.label));
+        button.addEventListener('click', () => {
+            if (!chartInstance) return;
+            const visible = button.getAttribute('aria-pressed') === 'true';
+            chartInstance.setDatasetVisibility(index, !visible);
+            button.setAttribute('aria-pressed', String(!visible));
+            chartInstance.update();
+        });
+        return button;
+    });
+    host.replaceChildren(...buttons);
 }
 
 const MAG7_TICKER_SYMBOLS = ['AAPL', 'MSFT', 'GOOGL', 'AMZN', 'NVDA', 'TSLA', 'META'];
@@ -6427,16 +6442,7 @@ function getPerformanceChartOptions(timestampMeta) {
         },
         plugins: {
             legend: {
-                display: true,
-                labels: {
-                    color: '#e5e7eb',
-                    font: { size: 12, weight: '600' },
-                    padding: 15,
-                    usePointStyle: true,
-                    pointStyle: 'line',
-                    boxWidth: 12,
-                    boxHeight: 2,
-                }
+                display: false,
             },
             tooltip: {
                 enabled: true,
@@ -6532,6 +6538,18 @@ function initLiveBacktestChart() {
         },
         options: getPerformanceChartOptions(liveBacktestChartMeta),
     });
+    renderPerformanceLegend({
+        columns: [{
+            key: 'agent',
+            label: 'Your Agent',
+            color: '#4FC3F7',
+            available: true,
+        }],
+    }, { disabled: true });
+    setPerformanceComparisonState(
+        'live',
+        'Benchmark metrics will appear when this run finishes.',
+    );
 }
 
 /** Clear history chart/metrics/log and pin the view to a soon-to-start live run. */
@@ -6543,7 +6561,10 @@ function prepareLiveBacktestView(launchConfig = null) {
     localStorage.removeItem(SELECTED_BACKTEST_RUN_KEY);
     const runSelect = document.getElementById('backtestRunSelect');
     if (runSelect) runSelect.value = '';
-    displayNoMetrics();
+    clearPerformanceComparison(
+        'live',
+        'Benchmark metrics will appear when this run finishes.',
+    );
     clearTradingLog('Backtest running… orders will appear here.');
     initLiveBacktestChart();
     renderBacktestRunConfig(null, { running: true, launchConfig });
@@ -6578,7 +6599,10 @@ function attachToLiveBacktest(runId, progress = null, launchConfig = null) {
         runSelect.value = runId;
         runSelect.hidden = false;
     }
-    displayNoMetrics();
+    clearPerformanceComparison(
+        'live',
+        'Benchmark metrics will appear when this run finishes.',
+    );
     if (!alreadyLive) {
         initLiveBacktestChart();
     }
@@ -6625,7 +6649,7 @@ function showBacktestLaunchFailure(message, launchConfig, runKey = null) {
     liveBacktestLaunchPending = false;
     liveBacktestLaunchError = true;
     renderBacktestRunConfig(null, { launchConfig, statusLabel: 'Failed' });
-    displayNoMetrics();
+    clearPerformanceComparison('error', 'Backtest did not start.');
     clearTradingLog('Backtest did not start.');
     showBacktestRunProgress(true, { isError: true });
     updateBacktestRunProgress({ elapsedSeconds: 0, message });
@@ -6857,7 +6881,6 @@ function ensureBacktestPolling() {
                         localStorage.removeItem(SELECTED_BACKTEST_RUN_KEY);
                     }
                     await loadData();
-                    await loadPerformanceMetrics();
                     setTimeout(() => showBacktestRunProgress(false), 2500);
                 } else {
                     showBacktestRunProgress(false);
@@ -8654,7 +8677,6 @@ function showPlaygroundPanel(tab) {
         populateBacktestAgentSelect();
         if (!allAgents.length) loadAgents();
         loadData();
-        loadPerformanceMetrics();
     } else if (tab === 'paper') {
         currentMode = 'paper';
         loadPaperTradingData();
@@ -9345,7 +9367,12 @@ async function loadData() {
                 console.warn('No backtest runs for this session');
                 comparisonData = null;
                 backtestChartData = null;
-                displayNoMetrics();
+                clearPerformanceComparison(
+                    'empty',
+                    runningId
+                        ? 'Select the Running run to watch live progress.'
+                        : 'No completed backtests yet.',
+                );
                 clearTradingLog(
                     runningId
                         ? 'Select the Running run to watch live progress.'
@@ -9382,7 +9409,6 @@ async function loadData() {
             console.log('Loaded backtest chart data:', backtestChartData);
 
             initializeCharts();
-            displayPerformanceMetrics(selectedRun);
             await loadTradingLogForRun(selectedRun.run_id);
         }
         
@@ -9422,14 +9448,20 @@ function initializeCharts() {
         const ctx = perfCtx.getContext('2d');
         const { timestamps, x_labels: xLabels, series } = backtestChartData;
         const visibleSeries = filterIfindChartSeries(series);
-
-        const datasets = visibleSeries.map((entry) => ({
-            label: entry.label,
-            data: entry.values,
-            borderColor: entry.color,
+        const comparisonPayload = { ...backtestChartData, series: visibleSeries };
+        const model = window.BacktestComparison.buildModel(
+            comparisonPayload,
+            window.SELECTED_RUN,
+        );
+        const chartColumns = model.columns.filter((column) => column.available);
+        const datasets = chartColumns.map((column) => ({
+            label: column.label,
+            comparisonKey: column.key,
+            data: column.values,
+            borderColor: column.color,
             backgroundColor: 'transparent',
             borderWidth: 2.5,
-            borderDash: entry.dashed ? [6, 4] : [],
+            borderDash: column.dashed ? [6, 4] : [],
             tension: 0,
             fill: false,
             pointRadius: 0,
@@ -9451,16 +9483,7 @@ function initializeCharts() {
                 },
                 plugins: {
                     legend: {
-                        display: true,
-                        labels: {
-                            color: '#e5e7eb',
-                            font: { size: 12, weight: '600' },
-                            padding: 15,
-                            usePointStyle: true,
-                            pointStyle: 'line',
-                            boxWidth: 12,
-                            boxHeight: 2,
-                        }
+                        display: false,
                     },
                     tooltip: {
                         enabled: true,
@@ -9531,8 +9554,10 @@ function initializeCharts() {
             }
         });
 
+        renderPerformanceComparison(comparisonPayload, window.SELECTED_RUN);
+        renderPerformanceLegend(model);
         liveBacktestChartActive = false;
-        console.log('✅ Chart initialized -', series.map((s) => s.label).join(', '));
+        console.log('✅ Chart initialized -', chartColumns.map((column) => column.label).join(', '));
     }
 }
 

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -4918,6 +4918,7 @@ let userHasNavigated = false;
 let allRuns = [];
 let comparisonData = null;
 let backtestChartData = null;
+let backtestSurfaceRequestSeq = 0;
 let defaultConfig = null;
 
 // Initialize on page load
@@ -6554,6 +6555,7 @@ function initLiveBacktestChart() {
 
 /** Clear history chart/metrics/log and pin the view to a soon-to-start live run. */
 function prepareLiveBacktestView(launchConfig = null) {
+    backtestSurfaceRequestSeq += 1;
     liveBacktestChartActive = true;
     liveBacktestRunId = null;
     liveBacktestLaunchPending = true;
@@ -6574,6 +6576,7 @@ function prepareLiveBacktestView(launchConfig = null) {
 /** Switch the Backtest surface onto an in-flight run (chart + log + config). */
 function attachToLiveBacktest(runId, progress = null, launchConfig = null) {
     if (!runId) return;
+    backtestSurfaceRequestSeq += 1;
     liveBacktestLaunchPending = false;
     liveBacktestLaunchError = false;
     const alreadyLive =
@@ -6644,6 +6647,7 @@ function showBacktestLaunchFailure(message, launchConfig, runKey = null) {
         clearAgentBacktestRunning(runKey);
         applyAgentFilters(false);
     }
+    backtestSurfaceRequestSeq += 1;
     liveBacktestChartActive = false;
     liveBacktestRunId = null;
     liveBacktestLaunchPending = false;
@@ -7289,18 +7293,20 @@ function updateLiveTradingLog(progress) {
     });
 }
 
-async function loadTradingLogForRun(runId) {
+async function loadTradingLogForRun(runId, { isCurrent = () => true } = {}) {
     if (!runId) {
-        clearTradingLog('Run a backtest to see orders here.');
+        if (isCurrent()) clearTradingLog('Run a backtest to see orders here.');
         return;
     }
     try {
         const data = await API.get(`${API_BASE}/runs/${encodeURIComponent(runId)}/trades?t=${Date.now()}`);
+        if (!isCurrent()) return;
         renderTradingLog(resolveTradingLogRecords(data), {
             emptyMessage: 'No orders were submitted by the selected strategy.',
             truncatedCount: resolveTradingLogTruncation(data),
         });
     } catch (error) {
+        if (!isCurrent()) return;
         console.warn('Could not load orders:', error.message);
         clearTradingLog('Order log unavailable for this run.');
     }
@@ -9278,6 +9284,49 @@ function resolveSelectedRun(sessionRuns) {
     return latestRun(realRuns);
 }
 
+function beginBacktestSurfaceRequest(runId) {
+    return { seq: ++backtestSurfaceRequestSeq, runId };
+}
+
+function isCurrentBacktestSurfaceRequest(token) {
+    return token?.seq === backtestSurfaceRequestSeq
+        && token.runId === window.SELECTED_RUN?.run_id
+        && !liveBacktestChartActive;
+}
+
+async function loadHistoricalBacktestSurfaces(selectedRun) {
+    const token = beginBacktestSurfaceRequest(selectedRun.run_id);
+    clearPerformanceComparison('loading', 'Loading performance comparison...');
+    clearTradingLog('Loading orders...');
+    const chartUrl = `${API_BASE}/api/backtest/${encodeURIComponent(selectedRun.run_id)}/chart-data?t=${Date.now()}`;
+
+    const chartRequest = API.get(chartUrl).then((payload) => {
+        if (!isCurrentBacktestSurfaceRequest(token)) return;
+        backtestChartData = payload;
+        initializeCharts();
+    }).catch((error) => {
+        if (!isCurrentBacktestSurfaceRequest(token)) return;
+        backtestChartData = null;
+        if (chartInstance) {
+            chartInstance.destroy();
+            chartInstance = null;
+        }
+        const notice = document.getElementById('chartBaselineNotice');
+        if (notice) notice.hidden = true;
+        renderPerformanceLegend({ columns: [] });
+        setPerformanceComparisonState(
+            'error',
+            'Performance comparison is unavailable. Reload to retry.',
+        );
+        console.warn('Could not load performance comparison:', error.message);
+    });
+
+    const logRequest = loadTradingLogForRun(selectedRun.run_id, {
+        isCurrent: () => isCurrentBacktestSurfaceRequest(token),
+    });
+    await Promise.allSettled([chartRequest, logRequest]);
+}
+
 // Find the DJIA / buy-and-hold runs that belong to a given run: same session,
 // same date window, created closest in time to the run (baselines are written
 // seconds apart from the agent run).
@@ -9400,16 +9449,8 @@ async function loadData() {
                 baselineRun: selectedBuyholdRun,
             });
 
-            const chartUrl = `${API_BASE}/api/backtest/${encodeURIComponent(selectedRun.run_id)}/chart-data?t=${Date.now()}`;
-            backtestChartData = await API.get(chartUrl);
-            // Another click may have switched to the live run while we awaited.
-            if (liveBacktestChartActive || isViewingLiveBacktest(runningId)) {
-                return;
-            }
-            console.log('Loaded backtest chart data:', backtestChartData);
-
-            initializeCharts();
-            await loadTradingLogForRun(selectedRun.run_id);
+            if (isViewingLiveBacktest(runningId)) return;
+            await loadHistoricalBacktestSurfaces(selectedRun);
         }
         
     } catch (error) {

--- a/dashboard/frontend/js/backtest-comparison.js
+++ b/dashboard/frontend/js/backtest-comparison.js
@@ -1,0 +1,148 @@
+(function () {
+  'use strict';
+
+  const SERIES = Object.freeze({
+    agent: { label: 'Your Agent', color: '#4FC3F7' },
+    djia: { label: 'DJIA', color: '#F5C04A' },
+    nasdaq: { label: 'Nasdaq-100', color: '#9AA4B2' },
+    buyhold: { label: 'Buy & Hold', color: '#34D399' },
+  });
+  const METRICS = Object.freeze([
+    { key: 'finalValue', label: 'Final Value', kind: 'currency' },
+    { key: 'totalReturn', label: 'Total Return', kind: 'percent' },
+    { key: 'maxDrawdown', label: 'Max Drawdown', kind: 'percent' },
+    { key: 'sharpe', label: 'Sharpe Ratio', kind: 'ratio' },
+  ]);
+  const INDEX_IDS = Object.freeze({
+    'index:^DJI': 'djia',
+    'index:^NDX': 'nasdaq',
+  });
+
+  function finiteValues(values) {
+    if (!Array.isArray(values)) return [];
+    return values.reduce((clean, value) => {
+      if (value === null || value === undefined || value === '') return clean;
+      const numeric = Number(value);
+      if (Number.isFinite(numeric)) clean.push(numeric);
+      return clean;
+    }, []);
+  }
+
+  function calculateMetrics(values) {
+    const clean = finiteValues(values);
+    const result = {
+      finalValue: clean.length ? clean[clean.length - 1] : null,
+      totalReturn: null,
+      maxDrawdown: null,
+      sharpe: null,
+    };
+    if (clean.length < 2 || clean[0] <= 0) return result;
+
+    result.totalReturn = (clean[clean.length - 1] / clean[0] - 1) * 100;
+    let peak = clean[0];
+    let maxDrawdown = 0;
+    for (const value of clean) {
+      peak = Math.max(peak, value);
+      maxDrawdown = Math.min(maxDrawdown, value / peak - 1);
+    }
+    result.maxDrawdown = maxDrawdown * 100;
+
+    const returns = [];
+    for (let index = 1; index < clean.length; index += 1) {
+      if (clean[index - 1] !== 0) {
+        returns.push(clean[index] / clean[index - 1] - 1);
+      }
+    }
+    if (returns.length < 2) return result;
+
+    const mean = returns.reduce((sum, value) => sum + value, 0) / returns.length;
+    const variance = returns.reduce(
+      (sum, value) => sum + (value - mean) ** 2,
+      0,
+    ) / returns.length;
+    const deviation = Math.sqrt(variance);
+    if (deviation > 0) {
+      result.sharpe = mean / deviation * Math.sqrt(252 * 6.5);
+    }
+    return result;
+  }
+
+  function classify(entry, payload, run) {
+    if (entry?.run_id === payload?.agent_run_id) return 'agent';
+    if (INDEX_IDS[entry?.run_id]) return INDEX_IDS[entry.run_id];
+    if (entry?.run_id === run?.baseline_buyhold_run_id) return 'buyhold';
+
+    const label = String(entry?.label || '').toLowerCase();
+    if (label === 'djia index' || label === 'djia') return 'djia';
+    if (label === 'nasdaq-100' || label === 'nasdaq 100') return 'nasdaq';
+    if (label === 'buy-and-hold' || label === 'buy & hold') return 'buyhold';
+    return null;
+  }
+
+  function buildModel(payload, run) {
+    const desired = run?.data_source === 'ifind_ashare'
+      ? ['agent', 'buyhold']
+      : ['agent', 'djia', 'nasdaq', 'buyhold'];
+    const indexBaselinesOk = payload?.index_baselines_ok !== false;
+    const found = new Map();
+
+    for (const entry of payload?.series || []) {
+      const key = classify(entry, payload, run);
+      if (key && !found.has(key)) found.set(key, entry);
+    }
+
+    const columns = desired.map((key) => {
+      const candidate = found.get(key) || null;
+      const entry = !indexBaselinesOk && (key === 'djia' || key === 'nasdaq')
+        ? null
+        : candidate;
+      return {
+        key,
+        label: SERIES[key].label,
+        color: entry?.color || SERIES[key].color,
+        available: Boolean(entry),
+        runId: entry?.run_id || null,
+        values: entry?.values || [],
+        metrics: entry ? calculateMetrics(entry.values) : calculateMetrics([]),
+        dashed: Boolean(entry?.dashed),
+      };
+    });
+
+    const bestByMetric = Object.fromEntries(METRICS.map(({ key }) => {
+      const finite = columns.filter(
+        (column) => Number.isFinite(column.metrics[key]),
+      );
+      if (!finite.length) return [key, []];
+      const best = Math.max(...finite.map((column) => column.metrics[key]));
+      return [
+        key,
+        finite
+          .filter((column) => column.metrics[key] === best)
+          .map((column) => column.key),
+      ];
+    }));
+    const agent = columns.find((column) => column.key === 'agent');
+    const agentDeltas = Object.fromEntries(columns
+      .filter((column) => column.key !== 'agent')
+      .map((column) => [
+        column.key,
+        Number.isFinite(agent?.metrics.totalReturn)
+          && Number.isFinite(column.metrics.totalReturn)
+          ? agent.metrics.totalReturn - column.metrics.totalReturn
+          : null,
+      ]));
+
+    return {
+      columns,
+      bestByMetric,
+      agentDeltas,
+      indexBaselinesOk,
+    };
+  }
+
+  window.BacktestComparison = Object.freeze({
+    METRICS,
+    buildModel,
+    calculateMetrics,
+  });
+})();

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -1759,6 +1759,223 @@ a.header-brand:hover .title-section h1 {
     height: 380px;
 }
 
+.performance-legend {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 6px;
+    min-height: 32px;
+    margin-bottom: 4px;
+}
+
+.performance-legend-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    min-height: 32px;
+    padding: 4px 8px;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--text-primary);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0;
+    cursor: pointer;
+}
+
+.performance-legend-button:hover:not(:disabled) {
+    border-color: var(--border-color);
+    background: var(--bg-hover);
+}
+
+.performance-legend-button[aria-pressed="false"] {
+    color: var(--text-muted);
+    opacity: 0.72;
+}
+
+.performance-legend-button[aria-pressed="false"] .performance-series-swatch {
+    filter: grayscale(1);
+}
+
+.performance-legend-button:disabled {
+    cursor: default;
+}
+
+.performance-legend-button:focus-visible,
+.performance-comparison-scroll:focus-visible {
+    outline: 2px solid var(--info-color);
+    outline-offset: 2px;
+}
+
+.performance-series-swatch {
+    display: inline-block;
+    flex: 0 0 auto;
+    width: 14px;
+    height: 3px;
+    border-radius: 2px;
+}
+
+.performance-comparison {
+    margin: 10px -14px -14px;
+    border-top: 1px solid var(--border-color);
+    background: rgba(8, 18, 40, 0.28);
+}
+
+.performance-comparison-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 12px 14px 9px;
+}
+
+.section-card .performance-comparison-header h3 {
+    margin: 0;
+    color: var(--text-primary);
+    font-size: 12px;
+    letter-spacing: 0;
+}
+
+.performance-comparison-header p {
+    margin: 0;
+    color: var(--text-muted);
+    font-size: 10px;
+    line-height: 1.4;
+    text-align: right;
+}
+
+.performance-comparison-scroll {
+    max-width: 100%;
+    overflow-x: auto;
+    overscroll-behavior-inline: contain;
+}
+
+.performance-comparison table {
+    width: 100%;
+    min-width: 680px;
+    border-collapse: collapse;
+    table-layout: fixed;
+    font-variant-numeric: tabular-nums;
+}
+
+.performance-comparison th,
+.performance-comparison td {
+    padding: 10px 12px;
+    border-top: 1px solid var(--border-color);
+    text-align: right;
+    vertical-align: top;
+}
+
+.performance-comparison thead th {
+    color: var(--text-secondary);
+    font-size: 10px;
+    font-weight: 700;
+    white-space: nowrap;
+}
+
+.performance-comparison th:first-child {
+    width: 132px;
+    text-align: left;
+}
+
+.performance-comparison tbody th {
+    color: var(--text-secondary);
+    font-size: 10px;
+    font-weight: 600;
+}
+
+.performance-comparison td {
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 11px;
+}
+
+.performance-comparison [data-series-key="agent"] {
+    background: rgba(0, 191, 255, 0.06);
+}
+
+.performance-metric-value {
+    white-space: nowrap;
+}
+
+.performance-best {
+    color: var(--success-color);
+}
+
+.performance-best-label {
+    display: block;
+    margin-top: 3px;
+    color: var(--success-color);
+    font-family: var(--font-base);
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0;
+    text-transform: uppercase;
+}
+
+.performance-deltas {
+    display: flex;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    gap: 3px 6px;
+    margin-top: 5px;
+}
+
+.performance-delta {
+    font-family: var(--font-base);
+    font-size: 9px;
+    line-height: 1.35;
+    white-space: nowrap;
+}
+
+.performance-delta.is-positive {
+    color: var(--success-color);
+}
+
+.performance-delta.is-negative {
+    color: var(--danger-color);
+}
+
+.performance-delta.is-neutral {
+    color: var(--text-muted);
+}
+
+.performance-comparison-status {
+    margin: 0;
+    padding: 8px 14px 10px;
+    border-top: 1px solid var(--border-color);
+    color: var(--text-secondary);
+    font-size: 10px;
+    line-height: 1.4;
+}
+
+.performance-comparison-status:empty {
+    display: none;
+}
+
+.performance-comparison[data-state="partial"] .performance-comparison-status,
+.performance-comparison[data-state="error"] .performance-comparison-status {
+    color: var(--warning-color);
+}
+
+@media (max-width: 600px) {
+    .chart-container {
+        height: 320px;
+        min-height: 320px;
+    }
+
+    .performance-comparison-header {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 3px;
+    }
+
+    .performance-comparison-header p {
+        text-align: left;
+    }
+}
+
 .chart-legend {
     display: grid;
     grid-template-columns: repeat(2, 1fr);

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -1976,6 +1976,189 @@ a.header-brand:hover .title-section h1 {
     }
 }
 
+/* Backtest Trading Log: a dense, independently scrolling activity feed. */
+.playground-backtest-panel .right-panel {
+    min-width: 0;
+}
+
+.trading-log-card {
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr);
+    min-width: 0;
+    max-height: 720px;
+    padding: 0;
+    overflow: hidden;
+}
+
+.trading-log-header {
+    margin: 0;
+    padding: 14px;
+}
+
+.trading-log-header h2 {
+    margin-bottom: 0;
+}
+
+.trading-log-summary {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 10px;
+    margin-top: 5px;
+    color: var(--text-muted);
+    font-size: 10px;
+    line-height: 1.35;
+}
+
+.trading-log-scroll {
+    min-height: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+    border-top: 1px solid var(--border-color);
+    border-radius: 0;
+    background: rgba(8, 18, 40, 0.18);
+}
+
+.trading-log-scroll:focus-visible {
+    outline: 2px solid var(--info-color);
+    outline-offset: -2px;
+}
+
+.trading-log-event {
+    padding: 12px 14px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.trading-log-event:last-child {
+    border-bottom: 0;
+}
+
+.trading-log-event-head {
+    display: grid;
+    grid-template-columns: max-content minmax(0, 1fr) max-content;
+    gap: 8px;
+    align-items: start;
+}
+
+.trading-log-action {
+    display: inline-flex;
+    align-items: center;
+    min-height: 20px;
+    padding: 2px 6px;
+    border: 1px solid currentColor;
+    border-radius: 3px;
+    font-size: 9px;
+    font-weight: 800;
+    letter-spacing: 0.2px;
+    line-height: 1;
+}
+
+.trading-log-asset {
+    display: grid;
+    gap: 2px;
+    min-width: 0;
+}
+
+.trading-log-asset strong {
+    overflow-wrap: anywhere;
+    font-size: 11px;
+    line-height: 1.2;
+}
+
+.trading-log-asset small,
+.trading-log-asset time {
+    color: var(--text-secondary);
+    font-size: 10px;
+    line-height: 1.3;
+}
+
+.trading-log-event-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 12px;
+    margin: 9px 0 0;
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-variant-numeric: tabular-nums;
+}
+
+.trading-log-event-meta > span {
+    display: grid;
+    gap: 2px;
+    min-width: 78px;
+}
+
+.trading-log-event-meta small {
+    color: var(--text-muted);
+    font-family: var(--font-base);
+    font-size: 9px;
+}
+
+.trading-log-event .trading-log-reason {
+    margin: 9px 0 0;
+    color: var(--text-primary);
+    font-size: 10px;
+    line-height: 1.45;
+    overflow-wrap: anywhere;
+}
+
+.trading-log-reason-label {
+    display: block;
+    margin-bottom: 2px;
+    color: var(--text-muted);
+    font-size: 9px;
+    font-weight: 700;
+    text-transform: uppercase;
+}
+
+.trading-log-event .trading-log-costs,
+.trading-log-event .trading-log-native-costs {
+    margin-top: 8px;
+}
+
+.trading-log-empty {
+    margin: 0;
+    padding: 18px 14px;
+    color: var(--text-secondary);
+    font-size: 11px;
+    line-height: 1.45;
+    text-align: center;
+}
+
+@media (min-width: 1280px) {
+    .playground-backtest-panel.main-container {
+        grid-template-columns: minmax(220px, 250px) minmax(620px, 1fr) minmax(320px, 360px);
+    }
+}
+
+@media (max-width: 1279px) {
+    .playground-backtest-panel.main-container {
+        grid-template-columns: 1fr;
+    }
+
+    .playground-backtest-panel .right-panel {
+        display: flex;
+    }
+
+    .trading-log-card {
+        max-height: 560px;
+    }
+}
+
+@media (max-width: 600px) {
+    .trading-log-card {
+        max-height: none;
+    }
+
+    .trading-log-scroll {
+        overflow-y: visible;
+    }
+
+    .trading-log-event-meta {
+        gap: 8px;
+    }
+}
+
 .chart-legend {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
@@ -2583,6 +2766,51 @@ a.header-brand:hover .title-section h1 {
 @media (prefers-reduced-motion: reduce) {
     .market-event-card--fade-in {
         animation: none;
+    }
+}
+
+/* Final Backtest feed overrides stay scoped so legacy decision-table rules
+   cannot reintroduce a wide table or page-level overflow. */
+.playground-backtest-panel .trading-log-card {
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr);
+    min-width: 0;
+    max-height: 720px;
+    padding: 0;
+    overflow: hidden;
+}
+
+.playground-backtest-panel .trading-log-scroll {
+    min-height: 0;
+    max-height: none;
+    overflow-y: auto;
+    overflow-x: hidden;
+    border-top: 1px solid var(--border-color);
+    border-right: 0;
+    border-bottom: 0;
+    border-left: 0;
+    border-radius: 0;
+}
+
+.playground-backtest-panel .trading-log-empty {
+    margin: 0;
+    padding: 18px 14px;
+    text-align: center;
+}
+
+@media (max-width: 1279px) {
+    .playground-backtest-panel .trading-log-card {
+        max-height: 560px;
+    }
+}
+
+@media (max-width: 600px) {
+    .playground-backtest-panel .trading-log-card {
+        max-height: none;
+    }
+
+    .playground-backtest-panel .trading-log-scroll {
+        overflow-y: visible;
     }
 }
 

--- a/docs/superpowers/plans/2026-08-28-backtest-benchmark-comparison.md
+++ b/docs/superpowers/plans/2026-08-28-backtest-benchmark-comparison.md
@@ -1,0 +1,1310 @@
+# Backtest Benchmark Comparison Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show exact Agent, DJIA, Nasdaq-100, and Buy & Hold performance metrics below the Backtest chart while moving the complete Trading Log into an independently scrolling right rail.
+
+**Architecture:** Extend the existing chart-data route to include the stored Buy & Hold curve beside US index curves. Put benchmark classification, metric calculation, best-value selection, and percentage-point deltas in a small dependency-free browser helper; keep DOM rendering and Chart.js orchestration in `app.js`. Historical chart/comparison and Trading Log requests use one run-scoped request token but settle independently so either surface can fail without clearing the other.
+
+**Tech Stack:** FastAPI/Pydantic, vanilla JavaScript, Chart.js 4.4, HTML/CSS, pytest, Node.js runtime contract tests
+
+**Spec:** `docs/superpowers/specs/2026-08-28-backtest-benchmark-comparison-design.md`
+
+## Global Constraints
+
+- Supported US runs compare `Your Agent`, `DJIA`, `Nasdaq-100`, and `Buy & Hold` in that order.
+- Metrics are exactly Final Value, Total Return, Max Drawdown, and hourly annualized Sharpe Ratio; do not add Annualized Return, Annualized Volatility, alpha, beta, or tracking error.
+- Calculate every series from the aligned chart-data `values` arrays; do not mix stored Agent metrics with frontend-computed benchmark metrics.
+- Sharpe uses population standard deviation, zero risk-free rate, and `sqrt(252 * 6.5)`.
+- Non-US profiles show only applicable series; do not display DJIA or Nasdaq-100 for iFinD A-share runs.
+- Missing, flat, insufficient, or non-finite inputs render unavailable and never participate in `Best` selection.
+- Legend toggles affect chart-line visibility only; they never remove comparison-table columns.
+- Preserve every existing Trading Log field, filter, audit detail, empty state, error state, and truncation notice.
+- Keep the existing session/ownership boundary and escaping helpers. Do not add a database table, migration, dependency, or endpoint.
+- Use only synthetic fixture values. Never read, display, or commit a real API key, local database, `.superpowers/`, or `work/` content.
+
+## File Map
+
+- Create `dashboard/frontend/js/backtest-comparison.js`: pure series classification, metric calculation, comparison model, and formatting constants; no DOM or API access.
+- Create `dashboard/backend/tests/fixtures/backtest-comparison.json`: synthetic US run, four aligned series, and order records shared by Node/runtime and visual checks.
+- Create `dashboard/backend/tests/test_backtest_chart_data.py`: chart-data route contract for combined stored and index baselines.
+- Create `dashboard/backend/tests/test_backtest_comparison_frontend.py`: Node-executed pure helper tests plus shipped HTML/app.js contracts.
+- Modify `dashboard/backend/api/routers/backtests.py`: always offer the paired stored Buy & Hold curve to chart-data.
+- Modify `dashboard/backend/chart_style.py`: give Buy & Hold a color distinct from Nasdaq-100 once both appear together.
+- Modify `dashboard/backend/tests/test_chart_style.py`: pin the distinct Buy & Hold color.
+- Modify `dashboard/frontend/app.html`: semantic comparison markup, DOM legend host, right-rail Trading Log feed, and script/cache revisions.
+- Modify `dashboard/frontend/app.js`: comparison rendering, DOM legend behavior, independent loading, stale-response guard, and vertical log rendering.
+- Modify `dashboard/frontend/styles.css`: approved three-column layout, comparison table, log feed, focus, and responsive rules.
+- Modify `dashboard/backend/tests/test_trading_log_order_events_ui.py`: keep current behavioral coverage while asserting the vertical feed contract.
+- Modify `dashboard/backend/tests/test_chart_baseline_notice_frontend.py`, `dashboard/backend/tests/test_ifind_ashare_frontend.py`, `dashboard/backend/tests/test_frontend_fast_boot.py`, `dashboard/backend/tests/test_analytics_frontend.py`, and `dashboard/backend/tests/test_admin_analytics_frontend.py`: update integration, applicability, and asset-order/cache contracts.
+
+---
+
+### Task 1: Return Buy & Hold Beside US Index Baselines
+
+**Files:**
+- Create: `dashboard/backend/tests/test_backtest_chart_data.py`
+- Modify: `dashboard/backend/api/routers/backtests.py:208-219,2168-2208`
+- Modify: `dashboard/backend/chart_style.py:15-27`
+- Modify: `dashboard/backend/tests/test_chart_style.py:14-27`
+
+**Interfaces:**
+- Consumes: existing `run["baseline_buyhold_run_id"]`, `db.get_run()`, `db.get_equity_curve()`, and `build_backtest_chart_data(..., stored_baselines, include_market_indexes)`.
+- Produces: unchanged `GET /api/backtest/{run_id}/chart-data` schema whose US `series` contains Agent, stored Buy & Hold, `index:^DJI`, and `index:^NDX` when all sources are available.
+
+- [ ] **Step 1: Write failing route and color tests**
+
+Create `dashboard/backend/tests/test_backtest_chart_data.py` with a direct route-function test that avoids network and database state:
+
+```python
+import dashboard.backend.api.routers.backtests as bt
+import pytest
+from fastapi import HTTPException
+
+
+def _curve():
+    return [
+        {"timestamp": "2026-05-04T14:30:00", "equity": 1_000.0},
+        {"timestamp": "2026-05-04T15:30:00", "equity": 1_010.0},
+    ]
+
+
+def _install_route_fakes(monkeypatch, *, buyhold_curve, index_ok=True):
+    run = {
+        "run_id": "agent-1",
+        "agent_name": "Agent",
+        "start_date": "2026-05-04",
+        "end_date": "2026-05-04",
+        "initial_equity": 1_000.0,
+        "baseline_buyhold_run_id": "buyhold-1",
+        "metadata": {"data_source": "alpaca"},
+    }
+    monkeypatch.setattr(bt, "get_session_id_from_request", lambda _request: "session-1")
+    monkeypatch.setattr(
+        bt.db,
+        "get_run_with_session",
+        lambda run_id, session_id: run
+        if (run_id, session_id) == ("agent-1", "session-1")
+        else None,
+    )
+    monkeypatch.setattr(
+        bt.db,
+        "get_run",
+        lambda run_id: {"run_id": run_id, "agent_name": "buy-and-hold"}
+        if run_id == "buyhold-1"
+        else None,
+    )
+    monkeypatch.setattr(
+        bt.db,
+        "get_equity_curve",
+        lambda run_id: _curve() if run_id == "agent-1" else buyhold_curve,
+    )
+    monkeypatch.setattr(bt, "_filter_equity_for_run", lambda _run, curve: curve)
+    monkeypatch.setattr(
+        bt.agent_service.agents,
+        "get_agent_by_session",
+        lambda _session_id: None,
+    )
+
+    def fake_indexes(timestamps, *_args, **_kwargs):
+        indexes = [
+            ("DJIA index", "index:^DJI", [1_000.0, 1_005.0]),
+            ("Nasdaq-100", "index:^NDX", [1_000.0, 1_015.0]),
+        ]
+        return (indexes if index_ok else [], index_ok)
+
+    monkeypatch.setattr(
+        "dashboard.backend.equity_plot.market_index_baselines_with_status",
+        fake_indexes,
+    )
+
+
+def test_us_chart_data_includes_buyhold_and_market_indexes(monkeypatch):
+    _install_route_fakes(monkeypatch, buyhold_curve=_curve())
+    response = bt.get_backtest_chart_data("agent-1", object())
+    assert [series.run_id for series in response.series] == [
+        "agent-1",
+        "buyhold-1",
+        "index:^DJI",
+        "index:^NDX",
+    ]
+
+
+def test_missing_buyhold_curve_does_not_substitute_another_run(monkeypatch):
+    _install_route_fakes(monkeypatch, buyhold_curve=[])
+    response = bt.get_backtest_chart_data("agent-1", object())
+    assert "buyhold-1" not in [series.run_id for series in response.series]
+    assert response.index_baselines_ok is True
+
+
+def test_index_failure_retains_agent_and_buyhold(monkeypatch):
+    _install_route_fakes(monkeypatch, buyhold_curve=_curve(), index_ok=False)
+    response = bt.get_backtest_chart_data("agent-1", object())
+    assert [series.run_id for series in response.series] == [
+        "agent-1", "buyhold-1"
+    ]
+    assert response.index_baselines_ok is False
+
+
+def test_chart_data_keeps_selected_run_session_scoped(monkeypatch):
+    _install_route_fakes(monkeypatch, buyhold_curve=_curve())
+    monkeypatch.setattr(
+        bt, "get_session_id_from_request", lambda _request: "other-session"
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        bt.get_backtest_chart_data("agent-1", object())
+    assert exc_info.value.status_code == 404
+```
+
+Extend `test_series_kind_and_colors_match_playground()`:
+
+```python
+assert series_color("idx2", "Nasdaq-100") == "#9AA4B2"
+assert series_color("buyhold_1", "buy-and-hold") == "#34D399"
+assert series_color("buyhold_1", "buy-and-hold") != series_color(
+    "idx2", "Nasdaq-100"
+)
+```
+
+- [ ] **Step 2: Run the tests and verify the missing combined-baseline contract**
+
+Run:
+
+```bash
+python -m pytest dashboard/backend/tests/test_backtest_chart_data.py dashboard/backend/tests/test_chart_style.py -q
+```
+
+Expected: the US route test fails because `buyhold-1` is absent; the color test fails because Buy & Hold still uses `#9AA4B2`.
+
+- [ ] **Step 3: Make stored and index baselines coexist**
+
+Change the chart-data call to pass the stored curve for every profile. Keep `include_market_indexes` profile-controlled:
+
+```python
+payload = build_backtest_chart_data(
+    run_id=run_id,
+    agent_name=run.get("agent_name") or "Agent",
+    llm_model=run.get("llm_model"),
+    start_date=run.get("start_date") or "",
+    end_date=run.get("end_date") or "",
+    initial_capital=initial_capital,
+    agent_curve=agent_curve,
+    card_name=card_name,
+    stored_baselines=_stored_buyhold_baseline(run),
+    include_market_indexes=profile.index_baseline_enabled,
+    market_timezone=profile.timezone,
+)
+```
+
+Update the route docstring to say the dashboard response may include the paired stored Buy & Hold curve in addition to the Discord-compatible index baselines. Set the shared color map entry:
+
+```python
+"buy-and-hold": "#34D399",
+```
+
+- [ ] **Step 4: Run route, plot, and non-US regressions**
+
+Run:
+
+```bash
+python -m pytest dashboard/backend/tests/test_backtest_chart_data.py dashboard/backend/tests/test_chart_style.py dashboard/backend/tests/test_equity_plot.py dashboard/backend/tests/integration/test_ifind_ashare_backtest.py -q
+```
+
+Expected: PASS. The provider-failure route case retains Agent + Buy & Hold with `index_baselines_ok=false`; the ownership case remains 404; and the iFinD assertions remain Agent + Buy & Hold with no DJIA/Nasdaq series.
+
+- [ ] **Step 5: Commit the backend contract**
+
+```bash
+git add dashboard/backend/api/routers/backtests.py dashboard/backend/chart_style.py dashboard/backend/tests/test_backtest_chart_data.py dashboard/backend/tests/test_chart_style.py
+git commit -m "feat(backtest): include buy-and-hold chart baseline"
+```
+
+---
+
+### Task 2: Build the Pure Benchmark Comparison Model
+
+**Files:**
+- Create: `dashboard/frontend/js/backtest-comparison.js`
+- Create: `dashboard/backend/tests/fixtures/backtest-comparison.json`
+- Create: `dashboard/backend/tests/test_backtest_comparison_frontend.py`
+
+**Interfaces:**
+- Consumes: chart-data `{agent_run_id, series, index_baselines_ok}` and selected run `{data_source, baseline_buyhold_run_id, reporting_currency?}`.
+- Produces: `window.BacktestComparison.buildModel(payload, run)` returning `{columns, bestByMetric, agentDeltas, indexBaselinesOk}`, plus `calculateMetrics(values)` and immutable `METRICS` descriptors.
+
+- [ ] **Step 1: Add a synthetic shared fixture**
+
+Create `dashboard/backend/tests/fixtures/backtest-comparison.json` with no credential or database material:
+
+```json
+{
+  "run": {
+    "run_id": "agent-fixture",
+    "data_source": "alpaca",
+    "baseline_buyhold_run_id": "buyhold-fixture",
+    "reporting_currency": "USD"
+  },
+  "chart": {
+    "agent_run_id": "agent-fixture",
+    "timestamps": [
+      "2026-05-04T14:30:00Z",
+      "2026-05-04T15:30:00Z",
+      "2026-05-04T16:30:00Z",
+      "2026-05-04T17:30:00Z"
+    ],
+    "x_labels": ["2026-05-04", "", "", ""],
+    "index_baselines_ok": true,
+    "series": [
+      {"run_id": "index:^NDX", "label": "Nasdaq-100", "values": [1000, 1020, 1010, 1060], "color": "#9AA4B2", "dashed": true},
+      {"run_id": "buyhold-fixture", "label": "buy-and-hold", "values": [1000, 1008, 1014, 1024], "color": "#34D399", "dashed": true},
+      {"run_id": "agent-fixture", "label": "Agent 33", "values": [1000, 1010, 995, 1017.4], "color": "#4FC3F7", "dashed": false},
+      {"run_id": "index:^DJI", "label": "DJIA index", "values": [1000, 1005, 1002, 1011.1], "color": "#F5C04A", "dashed": true}
+    ]
+  },
+  "trades": {
+    "trades": [
+      {"timestamp": "2026-05-04T15:30:00Z", "symbol": "AAPL", "side": "BUY", "quantity": 1, "price": 277.33, "value": 277.33, "reason": "Momentum entry"}
+    ],
+    "order_events": [],
+    "order_events_truncated": 0
+  }
+}
+```
+
+- [ ] **Step 2: Write failing Node-executed model tests**
+
+In `test_backtest_comparison_frontend.py`, load and execute the future helper as a browser global:
+
+```python
+import json
+import math
+import shutil
+import statistics
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "frontend" / "js" / "backtest-comparison.js"
+FIXTURE = Path(__file__).parent / "fixtures" / "backtest-comparison.json"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("node") is None, reason="node is not installed"
+)
+
+
+def run_helper(expression):
+    fixture = FIXTURE.read_text(encoding="utf-8")
+    source = SCRIPT.read_text(encoding="utf-8")
+    result = subprocess.run(
+        [
+            "node",
+            "-e",
+            "\n".join(
+                [
+                    "global.window = global;",
+                    source,
+                    f"const fixture = {fixture};",
+                    f"console.log(JSON.stringify({expression}));",
+                ]
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def test_model_canonicalizes_shuffled_series_and_calculates_deltas():
+    model = run_helper("BacktestComparison.buildModel(fixture.chart, fixture.run)")
+    assert [column["key"] for column in model["columns"]] == [
+        "agent", "djia", "nasdaq", "buyhold"
+    ]
+    assert [column["label"] for column in model["columns"]] == [
+        "Your Agent", "DJIA", "Nasdaq-100", "Buy & Hold"
+    ]
+    assert model["agentDeltas"]["djia"] == pytest.approx(0.63)
+    assert model["agentDeltas"]["nasdaq"] == pytest.approx(-4.26)
+    assert model["agentDeltas"]["buyhold"] == pytest.approx(-0.66)
+    assert model["bestByMetric"]["totalReturn"] == ["nasdaq"]
+
+
+def test_metrics_use_population_stddev_and_hourly_annualization():
+    metrics = run_helper(
+        "BacktestComparison.calculateMetrics([100, 110, 99, 120])"
+    )
+    returns = [0.1, -0.1, 120 / 99 - 1]
+    expected_sharpe = (
+        statistics.fmean(returns)
+        / statistics.pstdev(returns)
+        * math.sqrt(252 * 6.5)
+    )
+    assert metrics["finalValue"] == pytest.approx(120.0)
+    assert metrics["totalReturn"] == pytest.approx(20.0)
+    assert metrics["maxDrawdown"] == pytest.approx(-10.0)
+    assert metrics["sharpe"] == pytest.approx(expected_sharpe)
+
+
+def test_invalid_and_flat_series_are_unavailable_not_zero():
+    result = run_helper(
+        "({"
+        "short: BacktestComparison.calculateMetrics([100]),"
+        "flat: BacktestComparison.calculateMetrics([100, 100, 100]),"
+        "zeroStart: BacktestComparison.calculateMetrics([0, 10, 12]),"
+        "missing: BacktestComparison.calculateMetrics([null, undefined]),"
+        "gapped: BacktestComparison.calculateMetrics([100, null, 110]),"
+        "nonFinite: BacktestComparison.calculateMetrics([100, Number.NaN, 110])"
+        "})"
+    )
+    assert result["short"] == {
+        "finalValue": 100,
+        "totalReturn": None,
+        "maxDrawdown": None,
+        "sharpe": None,
+    }
+    assert result["flat"]["sharpe"] is None
+    assert result["zeroStart"]["totalReturn"] is None
+    assert result["missing"] == {
+        "finalValue": None,
+        "totalReturn": None,
+        "maxDrawdown": None,
+        "sharpe": None,
+    }
+    assert result["gapped"]["totalReturn"] == pytest.approx(10.0)
+    assert result["nonFinite"]["totalReturn"] == pytest.approx(10.0)
+
+
+def test_ifind_model_omits_inapplicable_us_indexes():
+    keys = run_helper(
+        "BacktestComparison.buildModel(fixture.chart, "
+        "{...fixture.run, data_source: 'ifind_ashare'}).columns.map(c => c.key)"
+    )
+    assert keys == ["agent", "buyhold"]
+
+
+def test_degraded_indexes_and_missing_buyhold_stay_explicitly_unavailable():
+    model = run_helper(
+        "BacktestComparison.buildModel("
+        "{...fixture.chart, index_baselines_ok: false, "
+        "series: fixture.chart.series.filter(s => s.run_id !== 'buyhold-fixture')}, "
+        "fixture.run)"
+    )
+    columns = {column["key"]: column for column in model["columns"]}
+    assert columns["agent"]["available"] is True
+    assert columns["djia"]["available"] is False
+    assert columns["nasdaq"]["available"] is False
+    assert columns["buyhold"]["available"] is False
+    assert model["agentDeltas"] == {
+        "djia": None, "nasdaq": None, "buyhold": None
+    }
+
+
+def test_exact_raw_ties_mark_every_tied_series_best():
+    best = run_helper(
+        "(() => { const agent = fixture.chart.series.find("
+        "s => s.run_id === fixture.chart.agent_run_id); "
+        "const chart = {...fixture.chart, series: fixture.chart.series"
+        ".filter(s => ['agent-fixture', 'index:^DJI'].includes(s.run_id))"
+        ".map(s => s.run_id === 'index:^DJI' ? {...s, values: agent.values} : s)}; "
+        "return BacktestComparison.buildModel(chart, fixture.run).bestByMetric; })()"
+    )
+    assert best["totalReturn"] == ["agent", "djia"]
+    assert best["maxDrawdown"] == ["agent", "djia"]
+```
+
+- [ ] **Step 3: Run the model tests and verify the helper is absent**
+
+Run:
+
+```bash
+python -m pytest dashboard/backend/tests/test_backtest_comparison_frontend.py -q
+```
+
+Expected: FAIL because `dashboard/frontend/js/backtest-comparison.js` does not exist.
+
+- [ ] **Step 4: Implement the dependency-free helper**
+
+Create the helper as an IIFE. Use these stable public names and return shapes:
+
+```javascript
+(function () {
+  'use strict';
+
+  const SERIES = Object.freeze({
+    agent: { label: 'Your Agent', color: '#4FC3F7' },
+    djia: { label: 'DJIA', color: '#F5C04A' },
+    nasdaq: { label: 'Nasdaq-100', color: '#9AA4B2' },
+    buyhold: { label: 'Buy & Hold', color: '#34D399' },
+  });
+  const METRICS = Object.freeze([
+    { key: 'finalValue', label: 'Final Value', kind: 'currency' },
+    { key: 'totalReturn', label: 'Total Return', kind: 'percent' },
+    { key: 'maxDrawdown', label: 'Max Drawdown', kind: 'percent' },
+    { key: 'sharpe', label: 'Sharpe Ratio', kind: 'ratio' },
+  ]);
+  const INDEX_IDS = Object.freeze({ 'index:^DJI': 'djia', 'index:^NDX': 'nasdaq' });
+
+  function finiteValues(values) {
+    if (!Array.isArray(values)) return [];
+    return values.reduce((clean, value) => {
+      if (value === null || value === undefined || value === '') return clean;
+      const numeric = Number(value);
+      if (Number.isFinite(numeric)) clean.push(numeric);
+      return clean;
+    }, []);
+  }
+
+  function calculateMetrics(values) {
+    const clean = finiteValues(values);
+    const result = {
+      finalValue: clean.length ? clean[clean.length - 1] : null,
+      totalReturn: null,
+      maxDrawdown: null,
+      sharpe: null,
+    };
+    if (clean.length < 2 || clean[0] <= 0) return result;
+    result.totalReturn = (clean[clean.length - 1] / clean[0] - 1) * 100;
+    let peak = clean[0];
+    let maxDrawdown = 0;
+    for (const value of clean) {
+      peak = Math.max(peak, value);
+      maxDrawdown = Math.min(maxDrawdown, value / peak - 1);
+    }
+    result.maxDrawdown = maxDrawdown * 100;
+    const returns = [];
+    for (let index = 1; index < clean.length; index += 1) {
+      if (clean[index - 1] !== 0) returns.push(clean[index] / clean[index - 1] - 1);
+    }
+    if (returns.length < 2) return result;
+    const mean = returns.reduce((sum, value) => sum + value, 0) / returns.length;
+    const variance = returns.reduce(
+      (sum, value) => sum + (value - mean) ** 2,
+      0,
+    ) / returns.length;
+    const deviation = Math.sqrt(variance);
+    if (deviation > 0) result.sharpe = mean / deviation * Math.sqrt(252 * 6.5);
+    return result;
+  }
+
+  function classify(entry, payload, run) {
+    if (entry?.run_id === payload?.agent_run_id) return 'agent';
+    if (INDEX_IDS[entry?.run_id]) return INDEX_IDS[entry.run_id];
+    if (entry?.run_id === run?.baseline_buyhold_run_id) return 'buyhold';
+    const label = String(entry?.label || '').toLowerCase();
+    if (label === 'djia index' || label === 'djia') return 'djia';
+    if (label === 'nasdaq-100' || label === 'nasdaq 100') return 'nasdaq';
+    if (label === 'buy-and-hold' || label === 'buy & hold') return 'buyhold';
+    return null;
+  }
+
+  function buildModel(payload, run) {
+    const desired = run?.data_source === 'ifind_ashare'
+      ? ['agent', 'buyhold']
+      : ['agent', 'djia', 'nasdaq', 'buyhold'];
+    const indexBaselinesOk = payload?.index_baselines_ok !== false;
+    const found = new Map();
+    for (const entry of payload?.series || []) {
+      const key = classify(entry, payload, run);
+      if (key && !found.has(key)) found.set(key, entry);
+    }
+    const columns = desired.map((key) => {
+      const candidate = found.get(key) || null;
+      const entry = !indexBaselinesOk && (key === 'djia' || key === 'nasdaq')
+        ? null
+        : candidate;
+      return {
+        key,
+        label: SERIES[key].label,
+        color: entry?.color || SERIES[key].color,
+        available: Boolean(entry),
+        runId: entry?.run_id || null,
+        values: entry?.values || [],
+        metrics: entry ? calculateMetrics(entry.values) : calculateMetrics([]),
+        dashed: Boolean(entry?.dashed),
+      };
+    });
+    const bestByMetric = Object.fromEntries(METRICS.map(({ key }) => {
+      const finite = columns.filter((column) => Number.isFinite(column.metrics[key]));
+      if (!finite.length) return [key, []];
+      const best = Math.max(...finite.map((column) => column.metrics[key]));
+      return [key, finite.filter((column) => column.metrics[key] === best).map((column) => column.key)];
+    }));
+    const agent = columns.find((column) => column.key === 'agent');
+    const agentDeltas = Object.fromEntries(columns
+      .filter((column) => column.key !== 'agent')
+      .map((column) => [
+        column.key,
+        Number.isFinite(agent?.metrics.totalReturn)
+          && Number.isFinite(column.metrics.totalReturn)
+          ? agent.metrics.totalReturn - column.metrics.totalReturn
+          : null,
+      ]));
+    return {
+      columns,
+      bestByMetric,
+      agentDeltas,
+      indexBaselinesOk,
+    };
+  }
+
+  window.BacktestComparison = Object.freeze({ METRICS, buildModel, calculateMetrics });
+})();
+```
+
+Max Drawdown uses the numerically largest raw value for `Best`, which correctly selects the value closest to zero. Keep labels fixed and do not pass payload labels into visible headings.
+
+- [ ] **Step 5: Run the pure model tests**
+
+```bash
+python -m pytest dashboard/backend/tests/test_backtest_comparison_frontend.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the model and fixture**
+
+```bash
+git add dashboard/frontend/js/backtest-comparison.js dashboard/backend/tests/fixtures/backtest-comparison.json dashboard/backend/tests/test_backtest_comparison_frontend.py
+git commit -m "feat(backtest): calculate benchmark comparison metrics"
+```
+
+---
+
+### Task 3: Render the Comparison Table and Accessible Chart Legend
+
+**Files:**
+- Modify: `dashboard/frontend/app.html:1231-1261,1300-1327,2394-2403`
+- Modify: `dashboard/frontend/app.js:5206-5335,6413-6434,6531-6575,9099-9116,9392-9531`
+- Modify: `dashboard/frontend/styles.css:1753-1802`
+- Modify: `dashboard/backend/tests/test_backtest_comparison_frontend.py`
+- Modify: `dashboard/backend/tests/test_chart_baseline_notice_frontend.py`
+- Modify: `dashboard/backend/tests/test_ifind_ashare_frontend.py`
+- Modify: `dashboard/backend/tests/test_frontend_fast_boot.py`
+- Modify: `dashboard/backend/tests/test_analytics_frontend.py`
+- Modify: `dashboard/backend/tests/test_admin_analytics_frontend.py`
+
+**Interfaces:**
+- Consumes: `window.BacktestComparison.buildModel(backtestChartData, window.SELECTED_RUN)` from Task 2.
+- Produces: `renderPerformanceComparison(payload, run)`, `setPerformanceComparisonState(state, message)`, `renderPerformanceLegend(model)`, and Chart.js datasets carrying `comparisonKey`.
+
+- [ ] **Step 1: Add failing semantic markup and integration tests**
+
+Extend `test_backtest_comparison_frontend.py` using `_frontend_source`:
+
+```python
+from dashboard.backend.tests._frontend_source import APP_HTML, STYLES, fn_body
+
+
+def test_comparison_script_and_semantic_table_ship_before_app():
+    helper = '<script src="js/backtest-comparison.js?v=1" defer></script>'
+    app = '<script src="app.js?v=117" defer></script>'
+    assert 'href="styles.css?v=126"' in APP_HTML
+    assert APP_HTML.index(helper) < APP_HTML.index(app)
+    for element_id in (
+        "performanceLegend",
+        "performanceComparison",
+        "performanceComparisonHead",
+        "performanceComparisonBody",
+        "performanceComparisonStatus",
+    ):
+        assert f'id="{element_id}"' in APP_HTML
+    assert 'aria-describedby="performanceComparisonCaption"' in APP_HTML
+    assert 'aria-details="performanceComparison"' in APP_HTML
+    assert 'role="img"' in APP_HTML
+
+
+def test_chart_uses_canonical_model_and_dom_legend():
+    body = fn_body("function initializeCharts()")
+    assert "BacktestComparison.buildModel" in body
+    assert "renderPerformanceComparison" in body
+    assert "renderPerformanceLegend" in body
+    assert "comparisonKey" in body
+    assert "display: false" in body
+
+
+def test_renderers_create_semantic_headers_and_native_legend_buttons():
+    comparison = fn_body("function renderPerformanceComparison(")
+    legend = fn_body("function renderPerformanceLegend(")
+    assert ".scope = 'col'" in comparison
+    assert ".scope = 'row'" in comparison
+    assert "Best" in comparison
+    assert "document.createElement('button')" in legend
+    assert "button.type = 'button'" in legend
+    assert "aria-pressed" in legend
+    assert "setDatasetVisibility" in legend
+
+
+def test_comparison_states_and_focus_styles_ship():
+    assert ".performance-comparison" in STYLES
+    assert ".performance-legend-button:focus-visible" in STYLES
+    assert ".performance-comparison-scroll:focus-visible" in STYLES
+    assert 'data-metric="final-value"' not in APP_HTML
+```
+
+Update the degraded-index test to assert that `initializeCharts()` still uses the exact older-payload-safe check and also calls the comparison renderer. Update the iFinD test to expect `BacktestComparison.buildModel` as the applicability boundary; retain structural `index:` filtering as defense in depth for chart datasets.
+
+In the cache/order owners, update `test_frontend_fast_boot.py` to expect `styles.css?v=126`, the helper before `app.js?v=117`, and all page scripts after `app.js?v=117`. Update `test_analytics_frontend.py` to locate `app.js?v=117`, and update the Admin Analytics lifecycle assertions to expect `styles.css?v=126` and `app.js?v=117`.
+
+- [ ] **Step 2: Run the tests and verify the UI contract is absent**
+
+```bash
+python -m pytest dashboard/backend/tests/test_backtest_comparison_frontend.py dashboard/backend/tests/test_chart_baseline_notice_frontend.py dashboard/backend/tests/test_ifind_ashare_frontend.py dashboard/backend/tests/test_frontend_fast_boot.py dashboard/backend/tests/test_analytics_frontend.py dashboard/backend/tests/test_admin_analytics_frontend.py -q
+```
+
+Expected: FAIL on the missing helper/script tag, markup, renderer, styles, and old `app.js?v=116` / `styles.css?v=125` references.
+
+- [ ] **Step 3: Add semantic comparison and DOM legend hosts**
+
+Change the stylesheet revision to `styles.css?v=126`, then load the pure helper immediately before the revised `app.js?v=117` tag:
+
+```html
+<link rel="stylesheet" href="styles.css?v=126">
+...
+<script src="js/backtest-comparison.js?v=1" defer></script>
+<script src="app.js?v=117" defer></script>
+<script src="js/analytics.js?v=1" defer></script>
+```
+
+Keep every page script after `app.js` in its existing relative order. Place these elements inside `.performance-card` after the benchmark notice and around the canvas/table:
+
+```html
+<div id="performanceLegend" class="performance-legend" role="group" aria-label="Chart series visibility"></div>
+<div class="chart-container">
+    <canvas id="performanceChart" role="img" aria-label="Portfolio value comparison chart" aria-describedby="performanceComparisonCaption" aria-details="performanceComparison"></canvas>
+</div>
+<section id="performanceComparison" class="performance-comparison" aria-labelledby="performanceComparisonTitle">
+    <div class="performance-comparison-header">
+        <h3 id="performanceComparisonTitle">Performance comparison</h3>
+        <p id="performanceComparisonCaption">Same capital, date range, and sampling interval.</p>
+    </div>
+    <div class="performance-comparison-scroll" tabindex="0" aria-label="Performance comparison table">
+        <table>
+            <thead id="performanceComparisonHead"></thead>
+            <tbody id="performanceComparisonBody"></tbody>
+        </table>
+    </div>
+    <p id="performanceComparisonStatus" class="performance-comparison-status" role="status" aria-live="polite"></p>
+</section>
+```
+
+Remove the Agent-only Trading Performance Summary markup. Do not move Trading Log yet; Task 5 changes its structure and location in one reviewable edit.
+
+- [ ] **Step 4: Replace Agent-only metric rendering with the model renderer**
+
+Remove `loadPerformanceMetrics()`, `displayPerformanceMetrics()`, and the selector-based `displayNoMetrics()` implementation. Replace every existing caller in the same change so no removed symbol survives:
+
+- `onBacktestAgentSelectChange()`: remove the extra `loadPerformanceMetrics()` after `await loadData()` because `loadData()` owns the selected surface.
+- `prepareLiveBacktestView()`, `attachToLiveBacktest()`, and `showBacktestLaunchFailure()`: call `clearPerformanceComparison(...)`; the first two then render the live-only `Your Agent` legend.
+- completed-run polling: remove `await loadPerformanceMetrics()` after `await loadData()`.
+- `showPlaygroundPanel('backtest')`: remove the second loader call after `loadData()`.
+- the no-run branch in `loadData()`: call `clearPerformanceComparison('empty', ...)`; after `initializeCharts()` remove `displayPerformanceMetrics(selectedRun)` because `initializeCharts()` renders the model.
+
+Add stable formatters and state helpers:
+
+```javascript
+function formatComparisonMetric(metric, value, currency = 'USD') {
+    if (!Number.isFinite(value)) return '—';
+    if (metric.kind === 'currency') {
+        return new Intl.NumberFormat('en-US', {
+            style: 'currency', currency, maximumFractionDigits: 0,
+        }).format(value);
+    }
+    if (metric.kind === 'percent') return `${value >= 0 ? '+' : ''}${value.toFixed(2)}%`;
+    return value.toFixed(2);
+}
+
+function formatComparisonDelta(value, label) {
+    if (!Number.isFinite(value)) return '';
+    const sign = value > 0 ? '+' : value < 0 ? '-' : '';
+    const css = value > 0 ? 'is-positive' : value < 0 ? 'is-negative' : 'is-neutral';
+    return `<span class="performance-delta ${css}">${escapeHtml(label)} ${sign}${Math.abs(value).toFixed(2)}pp</span>`;
+}
+
+function setPerformanceComparisonState(state, message = '') {
+    const region = document.getElementById('performanceComparison');
+    const status = document.getElementById('performanceComparisonStatus');
+    if (!region || !status) return;
+    region.dataset.state = state;
+    status.textContent = message;
+}
+
+function clearPerformanceComparison(state = 'empty', message = '') {
+    document.getElementById('performanceComparisonHead')?.replaceChildren();
+    document.getElementById('performanceComparisonBody')?.replaceChildren();
+    renderPerformanceLegend({ columns: [] });
+    setPerformanceComparisonState(state, message);
+}
+```
+
+Implement the renderer with DOM nodes so headings always come from the normalized model, never from `entry.label`:
+
+```javascript
+function renderPerformanceComparison(payload, run) {
+    const head = document.getElementById('performanceComparisonHead');
+    const body = document.getElementById('performanceComparisonBody');
+    if (!head || !body) return;
+    const model = window.BacktestComparison.buildModel(payload, run);
+    const currency = run?.reporting_currency
+        || run?.metadata?.reporting_currency
+        || 'USD';
+
+    const headerRow = document.createElement('tr');
+    const metricHeader = document.createElement('th');
+    metricHeader.scope = 'col';
+    metricHeader.textContent = 'Metric';
+    headerRow.appendChild(metricHeader);
+    for (const column of model.columns) {
+        const header = document.createElement('th');
+        header.scope = 'col';
+        header.dataset.seriesKey = column.key;
+        const swatch = document.createElement('span');
+        swatch.className = 'performance-series-swatch';
+        swatch.style.backgroundColor = column.color;
+        swatch.setAttribute('aria-hidden', 'true');
+        header.append(swatch, document.createTextNode(column.label));
+        headerRow.appendChild(header);
+    }
+    head.replaceChildren(headerRow);
+
+    const rows = window.BacktestComparison.METRICS.map((metric) => {
+        const row = document.createElement('tr');
+        const rowHeader = document.createElement('th');
+        rowHeader.scope = 'row';
+        rowHeader.textContent = metric.label;
+        row.appendChild(rowHeader);
+        for (const column of model.columns) {
+            const cell = document.createElement('td');
+            const value = column.metrics[metric.key];
+            cell.dataset.seriesKey = column.key;
+            cell.textContent = formatComparisonMetric(metric, value, currency);
+            if (model.bestByMetric[metric.key].includes(column.key)) {
+                cell.classList.add('performance-best');
+                const best = document.createElement('span');
+                best.className = 'performance-best-label';
+                best.textContent = 'Best';
+                cell.appendChild(best);
+            }
+            if (metric.key === 'totalReturn' && column.key === 'agent') {
+                const deltas = document.createElement('span');
+                deltas.className = 'performance-deltas';
+                for (const benchmark of model.columns.filter((item) => item.key !== 'agent')) {
+                    const html = formatComparisonDelta(
+                        model.agentDeltas[benchmark.key],
+                        benchmark.label,
+                    );
+                    if (html) deltas.insertAdjacentHTML('beforeend', html);
+                }
+                cell.appendChild(deltas);
+            }
+            row.appendChild(cell);
+        }
+        return row;
+    });
+    body.replaceChildren(...rows);
+
+    const missing = model.columns.filter((column) => !column.available);
+    const message = missing.length
+        ? `${missing.map((column) => column.label).join(', ')} unavailable for this run.`
+        : '';
+    setPerformanceComparisonState(missing.length ? 'partial' : 'ready', message);
+}
+```
+
+- [ ] **Step 5: Build DOM legend buttons and canonical Chart.js datasets**
+
+In `initializeCharts()`:
+
+```javascript
+const model = window.BacktestComparison.buildModel(backtestChartData, window.SELECTED_RUN);
+const chartColumns = model.columns.filter((column) => column.available);
+const datasets = chartColumns.map((column) => ({
+    label: column.label,
+    comparisonKey: column.key,
+    data: column.values,
+    borderColor: column.color,
+    backgroundColor: 'transparent',
+    borderWidth: 2.5,
+    borderDash: column.dashed ? [6, 4] : [],
+    tension: 0,
+    fill: false,
+    pointRadius: 0,
+    pointHoverRadius: 5,
+}));
+renderPerformanceComparison(backtestChartData, window.SELECTED_RUN);
+renderPerformanceLegend(model);
+```
+
+Disable the built-in Chart.js legend and add the native DOM legend:
+
+```javascript
+function renderPerformanceLegend(model, { disabled = false } = {}) {
+    const host = document.getElementById('performanceLegend');
+    if (!host) return;
+    const available = (model?.columns || []).filter((column) => column.available);
+    const buttons = available.map((column, index) => {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'performance-legend-button';
+        button.dataset.datasetIndex = String(index);
+        button.setAttribute('aria-pressed', 'true');
+        button.disabled = disabled;
+        const swatch = document.createElement('span');
+        swatch.className = 'performance-series-swatch';
+        swatch.style.backgroundColor = column.color;
+        swatch.setAttribute('aria-hidden', 'true');
+        button.append(swatch, document.createTextNode(column.label));
+        button.addEventListener('click', () => {
+            if (!chartInstance) return;
+            const visible = button.getAttribute('aria-pressed') === 'true';
+            chartInstance.setDatasetVisibility(index, !visible);
+            button.setAttribute('aria-pressed', String(!visible));
+            chartInstance.update();
+        });
+        return button;
+    });
+    host.replaceChildren(...buttons);
+}
+```
+
+The comparison table is not mutated by this handler.
+
+For live runs, render one disabled `Your Agent` legend button with `aria-pressed="true"` and set the comparison state text to `Benchmark metrics will appear when this run finishes.`. Clear stale historical rows in `prepareLiveBacktestView()` and `attachToLiveBacktest()` before the live chart paints.
+
+- [ ] **Step 6: Add the comparison and legend styles**
+
+Add scoped rules with the existing palette:
+
+```css
+.performance-legend { display: flex; justify-content: center; flex-wrap: wrap; gap: 6px; }
+.performance-legend-button { display: inline-flex; align-items: center; gap: 6px; min-height: 32px; padding: 4px 8px; border: 1px solid transparent; border-radius: 4px; background: transparent; color: var(--text-primary); }
+.performance-legend-button[aria-pressed="false"] { color: var(--text-muted); opacity: .7; }
+.performance-legend-button:focus-visible,
+.performance-comparison-scroll:focus-visible { outline: 2px solid var(--info-color); outline-offset: 2px; }
+.performance-series-swatch { width: 14px; height: 3px; border-radius: 2px; }
+.performance-comparison { border-top: 1px solid var(--border-color); background: rgba(8, 18, 40, .28); }
+.performance-comparison-header { display: flex; justify-content: space-between; gap: 12px; padding: 12px 14px; }
+.performance-comparison-scroll { overflow-x: auto; }
+.performance-comparison table { width: 100%; min-width: 680px; border-collapse: collapse; font-variant-numeric: tabular-nums; }
+.performance-comparison th,
+.performance-comparison td { padding: 10px 12px; border-top: 1px solid var(--border-color); text-align: right; }
+.performance-comparison th:first-child { text-align: left; }
+.performance-comparison [data-series-key="agent"] { background: rgba(0, 191, 255, .06); }
+.performance-best { color: var(--success-color); }
+.performance-best-label { margin-left: 4px; font-size: 9px; text-transform: uppercase; }
+.performance-deltas { display: flex; justify-content: flex-end; flex-wrap: wrap; gap: 4px; margin-top: 4px; }
+.performance-delta.is-positive { color: var(--success-color); }
+.performance-delta.is-negative { color: var(--danger-color); }
+.performance-comparison-status:empty { display: none; }
+```
+
+- [ ] **Step 7: Run the comparison integration tests**
+
+```bash
+python -m pytest dashboard/backend/tests/test_backtest_comparison_frontend.py dashboard/backend/tests/test_chart_baseline_notice_frontend.py dashboard/backend/tests/test_ifind_ashare_frontend.py dashboard/backend/tests/test_frontend_fast_boot.py dashboard/backend/tests/test_analytics_frontend.py dashboard/backend/tests/test_admin_analytics_frontend.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit the comparison surface**
+
+```bash
+git add dashboard/frontend/app.html dashboard/frontend/app.js dashboard/frontend/styles.css dashboard/backend/tests/test_backtest_comparison_frontend.py dashboard/backend/tests/test_chart_baseline_notice_frontend.py dashboard/backend/tests/test_ifind_ashare_frontend.py dashboard/backend/tests/test_frontend_fast_boot.py dashboard/backend/tests/test_analytics_frontend.py dashboard/backend/tests/test_admin_analytics_frontend.py
+git commit -m "feat(ui): compare backtest performance with benchmarks"
+```
+
+---
+
+### Task 4: Isolate Historical Chart and Trading Log Loading
+
+**Files:**
+- Modify: `dashboard/frontend/app.js:4897-4916,7252-7277,9279-9385`
+- Modify: `dashboard/backend/tests/test_backtest_comparison_frontend.py`
+- Modify: `dashboard/backend/tests/test_trading_log_order_events_ui.py`
+
+**Interfaces:**
+- Consumes: selected run id, existing `API.get`, `initializeCharts()`, and `loadTradingLogForRun()`.
+- Produces: `beginBacktestSurfaceRequest(runId)`, `isCurrentBacktestSurfaceRequest(token)`, and `loadHistoricalBacktestSurfaces(selectedRun)`; `loadTradingLogForRun(runId, {isCurrent})` paints only when current.
+
+- [ ] **Step 1: Write failing stale-response and partial-failure tests**
+
+Add these extraction/runtime helpers to `test_backtest_comparison_frontend.py` so the test executes the shipped functions instead of copies:
+
+```python
+def extract_app_function(source, name):
+    for marker in (f"async function {name}(", f"function {name}("):
+        start = source.find(marker)
+        if start != -1:
+            break
+    else:
+        raise AssertionError(f"{name} not found in app.js")
+    depth = 0
+    index = source.index("{", start)
+    while index < len(source):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start:index + 1]
+        index += 1
+    raise AssertionError(f"unterminated function {name}")
+
+
+def run_app_functions(source, names, harness_lines):
+    script = "\n".join(
+        [*(extract_app_function(source, name) for name in names), *harness_lines]
+    )
+    result = subprocess.run(
+        ["node", "-e", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+```
+
+Then add a Node test for the token helpers:
+
+```python
+def test_request_token_rejects_previous_run_after_selection_changes():
+    source = (ROOT / "frontend" / "app.js").read_text(encoding="utf-8")
+    result = run_app_functions(
+        source,
+        ["beginBacktestSurfaceRequest", "isCurrentBacktestSurfaceRequest"],
+        [
+            "global.window = { SELECTED_RUN: { run_id: 'run-a' } };",
+            "let liveBacktestChartActive = false;",
+            "let backtestSurfaceRequestSeq = 0;",
+            "const first = beginBacktestSurfaceRequest('run-a');",
+            "window.SELECTED_RUN = { run_id: 'run-b' };",
+            "const second = beginBacktestSurfaceRequest('run-b');",
+            "console.log(JSON.stringify({",
+            "  first: isCurrentBacktestSurfaceRequest(first),",
+            "  second: isCurrentBacktestSurfaceRequest(second),",
+            "}));",
+        ],
+    )
+    assert result == {"first": False, "second": True}
+```
+
+Add source-contract assertions:
+
+```python
+def test_historical_surfaces_settle_independently():
+    body = fn_body("async function loadHistoricalBacktestSurfaces(")
+    assert "Promise.allSettled" in body
+    assert "setPerformanceComparisonState('error'" in body
+    assert "loadTradingLogForRun" in body
+    assert "isCurrentBacktestSurfaceRequest" in body
+```
+
+Extend the Trading Log test harness to prove `loadTradingLogForRun()` ignores a resolved response when `isCurrent()` returns false and does not overwrite the existing feed.
+
+- [ ] **Step 2: Run the tests and verify sequential loading still fails the contract**
+
+```bash
+python -m pytest dashboard/backend/tests/test_backtest_comparison_frontend.py dashboard/backend/tests/test_trading_log_order_events_ui.py -q
+```
+
+Expected: FAIL because the token functions and `Promise.allSettled` coordinator do not exist.
+
+- [ ] **Step 3: Add the request token and current-run guard**
+
+Near `backtestChartData`, add:
+
+```javascript
+let backtestSurfaceRequestSeq = 0;
+
+function beginBacktestSurfaceRequest(runId) {
+    return { seq: ++backtestSurfaceRequestSeq, runId };
+}
+
+function isCurrentBacktestSurfaceRequest(token) {
+    return token?.seq === backtestSurfaceRequestSeq
+        && token.runId === window.SELECTED_RUN?.run_id
+        && !liveBacktestChartActive;
+}
+```
+
+Increment `backtestSurfaceRequestSeq` when entering or attaching to a live run so late historical promises cannot repaint the live surface.
+
+- [ ] **Step 4: Coordinate both requests without coupling their failures**
+
+Extract the historical fetch branch from `loadData()`:
+
+```javascript
+async function loadHistoricalBacktestSurfaces(selectedRun) {
+    const token = beginBacktestSurfaceRequest(selectedRun.run_id);
+    setPerformanceComparisonState('loading', 'Loading performance comparison…');
+    clearTradingLog('Loading orders…');
+    const chartUrl = `${API_BASE}/api/backtest/${encodeURIComponent(selectedRun.run_id)}/chart-data?t=${Date.now()}`;
+
+    const chartRequest = API.get(chartUrl).then((payload) => {
+        if (!isCurrentBacktestSurfaceRequest(token)) return;
+        backtestChartData = payload;
+        initializeCharts();
+    }).catch((error) => {
+        if (!isCurrentBacktestSurfaceRequest(token)) return;
+        backtestChartData = null;
+        if (chartInstance) {
+            chartInstance.destroy();
+            chartInstance = null;
+        }
+        renderPerformanceLegend({ columns: [] });
+        setPerformanceComparisonState(
+            'error',
+            'Performance comparison is unavailable. Reload to retry.',
+        );
+        console.warn('Could not load performance comparison:', error.message);
+    });
+
+    const logRequest = loadTradingLogForRun(selectedRun.run_id, {
+        isCurrent: () => isCurrentBacktestSurfaceRequest(token),
+    });
+    await Promise.allSettled([chartRequest, logRequest]);
+}
+```
+
+Call this function after rendering Run config. Remove the sequential chart fetch, `displayPerformanceMetrics(selectedRun)`, and awaited log call from `loadData()`.
+
+Change `loadTradingLogForRun` to accept `{isCurrent = () => true}` and guard both success and catch painting. It continues to own only the Trading Log error text.
+
+- [ ] **Step 5: Run loading and existing launch/live tests**
+
+```bash
+python -m pytest dashboard/backend/tests/test_backtest_comparison_frontend.py dashboard/backend/tests/test_trading_log_order_events_ui.py dashboard/backend/tests/test_backtest_launch_visibility.py dashboard/backend/tests/test_backtest_progress_card.py dashboard/backend/tests/test_backtest_progress_status.py -q
+```
+
+Expected: PASS. A chart failure leaves the log result untouched; a log failure leaves the comparison untouched; an older run cannot repaint a newer or live run.
+
+- [ ] **Step 6: Commit the independent loading flow**
+
+```bash
+git add dashboard/frontend/app.js dashboard/backend/tests/test_backtest_comparison_frontend.py dashboard/backend/tests/test_trading_log_order_events_ui.py
+git commit -m "fix(backtest): isolate comparison and order loading"
+```
+
+---
+
+### Task 5: Move Trading Log Right and Render a Vertical Activity Feed
+
+**Files:**
+- Modify: `dashboard/frontend/app.html:1263-1327`
+- Modify: `dashboard/frontend/app.js:4898-4903,4991-5001,7173-7277`
+- Modify: `dashboard/frontend/styles.css:1808-2030,2413-2431,2561-2597`
+- Modify: `dashboard/backend/tests/test_trading_log_order_events_ui.py`
+- Modify: `dashboard/backend/tests/test_backtest_comparison_frontend.py`
+
+**Interfaces:**
+- Consumes: existing normalized order records and audit renderers from `normalizeOrderRecord()`, `renderOrderCostAudit()`, and `renderMarketRuleAudit()`.
+- Produces: `#tradingLogFeed[role=list]`, `#tradingLogCount`, `#tradingLogStatusSummary`, and `paintTradingLog()` output as complete `article[role=listitem]` events.
+
+- [ ] **Step 1: Rewrite the failing markup contract and extend behavioral assertions**
+
+Replace the eight-column assertion with:
+
+```python
+def test_trading_log_markup_is_an_accessible_right_rail_feed():
+    html = _APP_HTML.read_text(encoding="utf-8")
+    center_end = html.index('</section>', html.index('class="center-panel"'))
+    log_at = html.index('id="tradingLogFeed"')
+    right_at = html.index('class="right-panel"')
+    assert right_at < log_at
+    assert log_at > center_end
+    assert 'id="tradingLogFeed"' in html
+    assert 'role="list"' in html
+    assert 'tabindex="0"' in html
+    assert 'aria-label="Trading Log orders"' in html
+    assert 'id="tradingLogCount"' in html
+    assert 'id="tradingLogStatusSummary"' in html
+    assert 'class="trading-log-table"' not in html
+```
+
+Update `_render_harness()` so `document.getElementById()` returns a feed plus count/summary text nodes. Keep every existing behavior test. Add assertions that a rendered event contains `role="listitem"`, action, asset, timestamp, quantity, price, value, status, reason, native currency, costs, market-rule audit, repeat count, and the truncation notice.
+
+- [ ] **Step 2: Run the Trading Log tests and verify the wide table is still shipped**
+
+```bash
+python -m pytest dashboard/backend/tests/test_trading_log_order_events_ui.py -q
+```
+
+Expected: FAIL on the old table markup and `<tr>` renderer.
+
+- [ ] **Step 3: Move the log card and replace the table host**
+
+Inside `.right-panel`, replace the removed summary with:
+
+```html
+<section class="section-card trading-log-card" aria-labelledby="tradingLogTitle">
+    <div class="section-header trading-log-header">
+        <div>
+            <h2 id="tradingLogTitle">Trading Log</h2>
+            <p class="trading-log-summary"><span id="tradingLogCount">0 orders</span><span id="tradingLogStatusSummary"></span></p>
+        </div>
+        <div class="log-controls">
+            <label class="sr-only" for="tradingLogFilter">Filter Trading Log orders</label>
+            <select class="filter-select" id="tradingLogFilter">
+                <option value="all">All Orders</option>
+                <option value="buy">Buys Only</option>
+                <option value="sell">Sells Only</option>
+            </select>
+        </div>
+    </div>
+    <div id="tradingLogFeed" class="trading-log-scroll" role="list" tabindex="0" aria-label="Trading Log orders">
+        <p class="trading-log-empty">Run a backtest to see orders here.</p>
+    </div>
+</section>
+```
+
+Remove the former Trading Log section from `.center-panel`.
+
+- [ ] **Step 4: Render complete vertical order events**
+
+Change `paintTradingLog()` to target `tradingLogFeed`. Keep filtering before summary counts. Render each record with this hierarchy:
+
+```javascript
+return `<article class="trading-log-event" role="listitem">
+    <div class="trading-log-event-head">
+        <span class="trading-log-action ${actionClass}">${actionLabel}</span>
+        <div class="trading-log-asset"><strong>${escapeHtml(order.symbol)}</strong>${assetName ? `<small>${escapeHtml(assetName)}</small>` : ''}<time>${escapeHtml(formatTradeTimestamp(order.timestamp))}</time></div>
+        <span class="order-status order-status-${order.status}" aria-label="Order status: ${statusLabel}">${statusLabel}</span>
+    </div>
+    <div class="trading-log-event-meta">
+        <span><small>Filled / requested</small>${escapeHtml(quantity)}</span>
+        <span><small>Execution price</small>${formatTradingMoney(order.price, '$')}${priceAudit}</span>
+        <span><small>Filled value</small>${order.executedShares > 0 ? `${formatTradingMoney(order.value, '$')}${valueAudit}` : '--'}</span>
+    </div>
+    ${costAudit}
+    <p class="trading-log-reason">${escapeHtml(reason)}${marketRuleAudit}${repeatNote}</p>
+</article>`;
+```
+
+Call `renderTradingLogSummary(filtered)` immediately after applying the All/Buy/Sell filter, before the empty branch, so zero-result filters also update the count. Use paragraph messages instead of table rows for empty and truncation states. The summary sets the pluralized visible count and a `filled / partial / rejected` breakdown. Continue storing normalized records once and reusing them on filter changes.
+
+- [ ] **Step 5: Style the independent right-rail feed and responsive placement**
+
+Scope the layout to Backtest so other `.main-container` pages do not change:
+
+```css
+@media (min-width: 1280px) {
+    .playground-backtest-panel.main-container { grid-template-columns: minmax(220px, 250px) minmax(620px, 1fr) minmax(320px, 360px); }
+}
+.trading-log-card { display: grid; grid-template-rows: auto minmax(0, 1fr); max-height: 720px; min-width: 0; }
+.trading-log-header { align-items: flex-start; }
+.trading-log-summary { display: flex; flex-wrap: wrap; gap: 4px 10px; margin-top: 5px; color: var(--text-muted); font-size: 10px; }
+.trading-log-scroll { min-height: 0; overflow-y: auto; overflow-x: hidden; border-top: 1px solid var(--border-color); }
+.trading-log-scroll:focus-visible { outline: 2px solid var(--info-color); outline-offset: -2px; }
+.trading-log-event { padding: 12px; border-bottom: 1px solid var(--border-color); }
+.trading-log-event-head { display: grid; grid-template-columns: max-content minmax(0, 1fr) max-content; gap: 8px; align-items: start; }
+.trading-log-event-meta { display: flex; flex-wrap: wrap; gap: 4px 10px; margin: 8px 0 0 46px; color: var(--text-secondary); font-variant-numeric: tabular-nums; }
+.trading-log-event-meta > span { display: grid; gap: 2px; min-width: 86px; }
+.trading-log-event-meta small { color: var(--text-muted); font-size: 9px; }
+.trading-log-event .trading-log-reason { margin: 8px 0 0 46px; max-width: none; overflow-wrap: anywhere; }
+@media (max-width: 1279px) {
+    .playground-backtest-panel.main-container { grid-template-columns: 1fr; }
+    .playground-backtest-panel .right-panel { display: flex; }
+    .trading-log-card { max-height: 560px; }
+}
+@media (max-width: 600px) {
+    .trading-log-card { max-height: none; }
+    .trading-log-scroll { overflow-y: visible; }
+    .trading-log-event-meta,
+    .trading-log-event .trading-log-reason { margin-left: 0; }
+}
+```
+
+Reconcile these scoped rules with the existing generic 1200/900 pixel rules so Backtest ordering is Run config, performance, Trading Log and no `.right-panel { display:none }` rule wins at mobile widths.
+
+- [ ] **Step 6: Run Trading Log and layout contracts**
+
+```bash
+python -m pytest dashboard/backend/tests/test_trading_log_order_events_ui.py dashboard/backend/tests/test_backtest_comparison_frontend.py -q
+```
+
+Expected: PASS, including every pre-existing audit-detail test.
+
+- [ ] **Step 7: Commit the approved layout**
+
+```bash
+git add dashboard/frontend/app.html dashboard/frontend/app.js dashboard/frontend/styles.css dashboard/backend/tests/test_trading_log_order_events_ui.py dashboard/backend/tests/test_backtest_comparison_frontend.py
+git commit -m "feat(ui): move Trading Log beside backtest results"
+```
+
+---
+
+### Task 6: Run Full Regression and Visual Verification
+
+**Files:**
+- Verify only: no source, fixture, screenshot, or test file is modified in this task.
+
+**Interfaces:**
+- Consumes: all prior task outputs, including the Task 3 asset revisions `styles.css?v=126`, `js/backtest-comparison.js?v=1`, and `app.js?v=117`.
+- Produces: passing focused/full suites and recorded viewport/degraded-state evidence; no additional commit.
+
+- [ ] **Step 1: Run the complete focused regression set**
+
+```bash
+python -m pytest dashboard/backend/tests/test_backtest_chart_data.py dashboard/backend/tests/test_chart_style.py dashboard/backend/tests/test_equity_plot.py dashboard/backend/tests/test_backtest_comparison_frontend.py dashboard/backend/tests/test_trading_log_order_events_ui.py dashboard/backend/tests/test_chart_baseline_notice_frontend.py dashboard/backend/tests/test_ifind_ashare_frontend.py dashboard/backend/tests/test_frontend_fast_boot.py dashboard/backend/tests/test_analytics_frontend.py dashboard/backend/tests/test_admin_analytics_frontend.py dashboard/backend/tests/test_backtest_launch_visibility.py dashboard/backend/tests/test_backtest_progress_card.py dashboard/backend/tests/test_backtest_progress_status.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run the full backend/frontend contract suite**
+
+```bash
+python -m pytest dashboard/backend/tests/ --timeout=180 -p no:cacheprovider
+```
+
+Expected: PASS with no test reading or modifying `dashboard/storage/data/backtest.db`.
+
+- [ ] **Step 3: Start the local app for visual verification**
+
+Run on an unused local port:
+
+```bash
+python -m uvicorn dashboard.backend.app:app --host 127.0.0.1 --port 8000
+```
+
+Open `http://127.0.0.1:8000/app?view=backtest`. Use the committed synthetic fixture to mock only these authenticated reads in the browser session:
+
+- `/api/backtest/runs` returns an array containing `fixture.run` plus `initial_equity`, `final_equity`, `total_return`, `max_drawdown`, `sharpe_ratio`, `start_date`, `end_date`, and `created_at` synthetic fields;
+- `/api/backtest/agent-fixture/chart-data` returns `fixture.chart`;
+- `/runs/agent-fixture/trades` returns `fixture.trades`; and
+- `/backtest/status` returns `{"running": false}`.
+
+Do not point the browser at a real database or copy a production response.
+
+- [ ] **Step 4: Capture and inspect three viewport screenshots**
+
+Using the browser/Playwright tooling available to the executing agent, capture:
+
+1. 1440 x 1000: Run config left, chart/comparison center, Trading Log right; right rail scrolls without moving the page.
+2. 1024 x 900: Trading Log is below performance; comparison has contained horizontal scrolling; no page-level horizontal overflow.
+3. 390 x 844: single column, nonblank chart, readable controls, contained comparison scroll, natural-height log, no overlap.
+
+For each viewport, also verify canvas pixels are nonblank, all four US legend labels render, Agent deltas show `pp`, keyboard focus is visible on legend/filter/scroll regions, toggling a legend button leaves its comparison column visible, and the full order reason is present.
+
+- [ ] **Step 5: Inspect degraded states with the same safe fixture**
+
+Repeat the desktop check with:
+
+- `index_baselines_ok: false` and both index series removed: Agent and Buy & Hold remain, DJIA/Nasdaq cells say unavailable, and the index notice is visible;
+- the Buy & Hold series removed: its column says unavailable with no fabricated Agent delta;
+- chart-data returning 503: Trading Log remains populated while performance shows its error;
+- trades returning 503: performance remains populated while only Trading Log shows its error; and
+- two rapid run selections resolved out of order: only the final selection is visible.
+
+- [ ] **Step 6: Verify repository hygiene**
+
+```bash
+git diff --check
+git status --short --untracked-files=all
+git status --short dashboard/storage/data/backtest.db .superpowers work
+```
+
+Expected: `git diff --check` passes; the database, `.superpowers/`, and `work/` status command prints nothing; no screenshot or browser-session artifact is present. Task 6 creates no source changes and no commit.

--- a/docs/superpowers/specs/2026-08-28-backtest-benchmark-comparison-design.md
+++ b/docs/superpowers/specs/2026-08-28-backtest-benchmark-comparison-design.md
@@ -1,0 +1,347 @@
+# Backtest Benchmark Comparison and Trading Log Layout Design
+
+**Date:** 2026-08-28
+
+**Status:** Approved
+**Scope:** Backtest performance comparison and Trading Log presentation
+
+## Goal
+
+Make the Backtest page answer two questions without requiring the user to
+estimate values from chart lines:
+
+1. Did the selected Agent outperform the relevant benchmarks?
+2. Which orders explain the Agent's result?
+
+The approved desktop layout keeps Run config on the left, places the portfolio
+value chart and benchmark metric table in the center, and moves Trading Log to
+an independently scrolling right rail.
+
+## Current problem
+
+The chart already plots the Agent against DJIA and Nasdaq-100 for supported US
+market runs, but Trading Performance Summary reports metrics for the Agent
+only. A user can see that the curves differ but cannot scan exact Final Value,
+Total Return, Max Drawdown, or Sharpe Ratio values across the series.
+
+Trading Log currently uses an eight-column table below the chart. It consumes
+vertical space and separates the decisions from the performance result they
+produced. The table's minimum width also makes it unsuitable for the approved
+right-rail position.
+
+US backtests persist a paired Buy & Hold run, but the current chart-data route
+includes that stored baseline only when market index baselines are disabled.
+For a US run, the response therefore contains the Agent, DJIA, and Nasdaq-100,
+but omits the available Buy & Hold series.
+
+## Product decisions
+
+1. Supported US runs compare Your Agent, DJIA, Nasdaq-100, and Buy & Hold.
+2. The comparison table contains Final Value, Total Return, Max Drawdown, and
+   Sharpe Ratio. Annualized Return and Annualized Volatility are not added.
+3. The chart and comparison table form one performance surface. The table sits
+   directly below the chart and uses the same series names and colors.
+4. Trading Log moves to a right rail and changes from a wide table to a
+   vertical activity feed without dropping existing order information.
+5. Run config remains the left rail on wide desktop viewports.
+6. Chart/comparison and Trading Log load independently so a failure in one does
+   not erase the other.
+
+Annualized Return is deliberately excluded because short backtests can make an
+annualized projection look much more certain than the observed period warrants.
+The selected four metrics describe the actual run and match the metrics already
+shown for the Agent.
+
+## Approved layout
+
+### Wide desktop
+
+At viewports at least 1280 CSS pixels wide, the Backtest content uses three
+columns:
+
+- a 220-250 pixel Run config rail;
+- a flexible performance column with a practical minimum width of 620 pixels;
+  and
+- a 320-360 pixel Trading Log rail.
+
+The performance card contains, in order:
+
+1. the existing title, market-data badge, run selector, and range controls;
+2. a DOM legend and the portfolio value chart; and
+3. the Performance comparison table.
+
+The former right-side Trading Performance Summary is removed. Its Agent-only
+values are represented in the highlighted Your Agent column of the comparison
+table.
+
+Trading Log aligns with the top of Trading Performance and has an independent
+vertical scrollbar. Its header and filter stay visible while the event feed
+scrolls. The rail must not force the entire page to grow with a long run.
+
+### Narrow desktop and tablet
+
+Below 1280 CSS pixels, Trading Log moves below the performance card. Run config
+follows the page's existing responsive behavior. The comparison table keeps all
+available series and uses contained horizontal scrolling when its columns
+cannot fit; it must not shrink values or headings until they overlap.
+
+### Mobile
+
+On small screens, Run config, Trading Performance, Performance comparison, and
+Trading Log use one column. The chart keeps a stable minimum height. The
+comparison table scrolls horizontally inside its own region, and the Trading
+Log feed expands naturally instead of using a fixed-height nested scroller.
+
+## Performance comparison
+
+### Columns and order
+
+The frontend normalizes available series into this canonical order regardless
+of payload order:
+
+1. Your Agent;
+2. DJIA;
+3. Nasdaq-100; and
+4. Buy & Hold.
+
+The Agent column receives a restrained blue background and remains the visual
+anchor. Benchmark columns use the same swatches as their chart series. A value
+that is best for its metric receives a textual `Best` marker as well as color,
+so color is never the only signal.
+
+Legend controls change chart-line visibility only. The comparison table keeps
+all available series visible so hiding a visually noisy line cannot also hide
+its exact benchmark result.
+
+For Final Value, Total Return, and Sharpe Ratio, the largest finite value is
+best. For Max Drawdown, the value closest to zero is best. Exact ties at the raw
+numeric value may mark every tied series. Missing values never participate in
+best-value selection.
+
+### Metric formulas
+
+Every column is calculated from the aligned `values` array in the same
+chart-data response. This keeps the Agent and benchmark calculations on the
+same timestamps and prevents a stored Agent metric from being compared with a
+differently sampled benchmark metric.
+
+For a cleaned finite value sequence `v`:
+
+- `Final Value = v[last]`.
+- `Total Return = (v[last] / v[first] - 1) * 100`.
+- `Max Drawdown = min(v[i] / running_peak[i] - 1) * 100`.
+- `Sharpe Ratio = mean(period_returns) / population_stddev(period_returns) *
+  sqrt(252 * 6.5)`, with a zero risk-free rate, matching the existing hourly
+  Backtest convention.
+
+At least two finite portfolio values are required for Total Return and Max
+Drawdown. Sharpe Ratio additionally requires at least two finite period returns
+and non-zero population standard deviation. An undefined metric renders as the
+unavailable marker rather than zero.
+
+Currency values use the selected run's reporting currency and existing locale
+formatting. Percentages use two decimal places. Sharpe Ratio uses two decimal
+places. Calculations keep full precision; formatting occurs only at render
+time.
+
+### Relative Agent result
+
+The Your Agent cell in the Total Return row includes one compact delta for each
+available benchmark:
+
+```text
+Agent total return - benchmark total return
+```
+
+The delta is expressed in percentage points (`pp`), not percent. Positive
+deltas use the existing success treatment, negative deltas use the existing
+danger treatment, and exact zero uses neutral text. A missing benchmark produces
+no fabricated delta.
+
+## Chart-data contract
+
+The existing authenticated endpoint remains:
+
+```text
+GET /api/backtest/{run_id}/chart-data
+```
+
+No new database table, migration, or endpoint is required. The response keeps
+its current `agent_run_id`, `timestamps`, `x_labels`, `series`, and
+`index_baselines_ok` fields.
+
+For supported US runs, the route must pass the paired stored Buy & Hold curve
+to `build_backtest_chart_data` even when market index baselines are enabled.
+The expected successful series set is therefore:
+
+```text
+Agent + DJIA index + Nasdaq-100 + buy-and-hold
+```
+
+The frontend identifies series by stable run identifiers first:
+
+- `agent_run_id` identifies Your Agent;
+- `index:^DJI` identifies DJIA;
+- `index:^NDX` identifies Nasdaq-100; and
+- the selected run's `baseline_buyhold_run_id` identifies Buy & Hold.
+
+Existing labels remain a backward-compatible fallback for older cached
+payloads. Display labels are normalized to `Your Agent`, `DJIA`, `Nasdaq-100`,
+and `Buy & Hold`; internal agent names and run ids are not exposed as headings.
+
+For a market profile where US index baselines are not applicable, such as an
+iFinD China A-share run, the page shows only the applicable Agent and Buy & Hold
+columns. It must not imply that DJIA or Nasdaq-100 is a valid benchmark for that
+market.
+
+## Trading Log activity feed
+
+The existing run-scoped order endpoint and normalized frontend record model
+remain the data source. Only presentation changes.
+
+Each event exposes the same information currently available in the table:
+
+- action, symbol, and company or asset name;
+- timestamp;
+- requested and filled quantity;
+- execution price and total value;
+- order status;
+- reporting-currency and native-currency details when present;
+- transaction-cost details when present; and
+- the complete decision reason.
+
+The primary row contains the action badge, asset, timestamp, and status. A
+secondary metadata row contains quantity, price, total value, and optional cost
+details. The reason appears below the metadata and wraps within the rail. Long
+content may wrap to additional lines but must not be silently discarded.
+
+The existing All Orders, Buys Only, and Sells Only filtering behavior remains.
+The header also reports the visible order count and settled-status summary when
+those values are available from the normalized records.
+
+Empty, loading, truncated, and error messages occupy the feed body and do not
+change the rail width. The existing truncation notice remains explicit when the
+backend limits the number of returned records.
+
+## Loading and partial error behavior
+
+Chart/comparison and Trading Log are independent render regions:
+
+- While chart-data loads, the chart and comparison table show a stable loading
+  state; Trading Log may render as soon as its request completes.
+- If chart-data fails, Trading Log remains usable and the performance region
+  shows a retryable error without stale values from another run.
+- If Trading Log fails, the chart and comparison remain usable and only the
+  right rail shows its retryable error.
+- Switching the selected run clears or marks both regions as loading before
+  new results arrive, and late responses for the previous run are ignored.
+
+When `index_baselines_ok` is `false`, the Agent and available Buy & Hold data
+remain visible. DJIA and Nasdaq-100 stay represented as unavailable columns so
+the provider outage is explicit, and the existing benchmark notice remains
+visible. An unavailable index metric never receives a `Best` marker or Agent
+delta.
+
+If a paired Buy & Hold run id or curve is absent for a historical run, the Buy
+& Hold column renders unavailable with concise context. The frontend does not
+substitute another run, another date range, or synthetic values.
+
+## Accessibility and keyboard behavior
+
+- The comparison uses a semantic table with column and row headers.
+- The DOM legend uses native buttons with visible focus and `aria-pressed` to
+  toggle series. Swatches are accompanied by text labels.
+- The chart has an accessible name and references the comparison table as its
+  exact-value alternative.
+- The Trading Log is a semantic list of order events. Its scroll region is
+  keyboard focusable on wide desktop and has an accessible name.
+- The order filter has an associated accessible label and remains keyboard
+  operable as a native select.
+- Loading and error changes use the page's existing live-region conventions
+  without repeatedly announcing chart hover updates.
+- Focus order follows visual order: Run config, performance controls, legend,
+  comparison, Trading Log filter, and Trading Log events.
+- Positive, negative, best, action, and status states never rely on color
+  alone.
+
+## Security and privacy
+
+The existing session-scoped route and run ownership checks remain unchanged.
+The comparison exposes only portfolio values already returned by chart-data.
+Trading Log continues to render the existing safe order payload and must use
+the current escaping and DOM construction helpers for user- or model-provided
+text.
+
+Tests and fixtures use synthetic run ids, equity curves, trades, prices, and
+reasons. Real API keys, local databases, `.superpowers/`, and `work/` are not
+committed.
+
+## Test coverage
+
+Focused backend tests cover:
+
+- US chart-data returning Agent, DJIA, Nasdaq-100, and the paired Buy & Hold
+  series;
+- non-US chart-data retaining only applicable Agent and Buy & Hold series;
+- index-provider failure retaining Agent and Buy & Hold while setting
+  `index_baselines_ok` to `false`;
+- a missing or inaccessible paired Buy & Hold curve not substituting another
+  run; and
+- session ownership remaining enforced for the selected Agent run.
+
+Focused frontend contract tests cover:
+
+- canonical series identification and ordering independent of payload order;
+- Final Value, Total Return, Max Drawdown, and Sharpe formulas for all series;
+- flat, missing, non-finite, and insufficient series producing unavailable
+  metrics instead of fabricated zeroes;
+- percentage-point Agent deltas and best-value selection, including ties;
+- partial index and Buy & Hold failure presentation;
+- run-switch stale-response protection;
+- DOM legend labels, `aria-pressed`, table headers, and focusable log region;
+- vertical Trading Log event rendering without loss of quantity, price, value,
+  status, currency, cost, reason, empty, error, or truncation information; and
+- wide, narrow, and mobile layout contracts without overlapping text or page-
+  level horizontal overflow.
+
+The implementation is also visually checked at representative 1440, 1024, and
+390 CSS-pixel viewports. The checks verify that the chart is nonblank, the
+comparison columns remain readable, the right rail scrolls independently on
+wide desktop, and the stacked layouts do not overlap.
+
+## Non-goals
+
+- Adding Annualized Return, Annualized Volatility, alpha, beta, or tracking
+  error metrics.
+- Changing backtest execution, trade generation, market data, transaction
+  costs, or stored run metrics.
+- Adding a database table, migration, or historical backfill.
+- Comparing unrelated runs, models, date ranges, or initial capital amounts.
+- Making DJIA or Nasdaq-100 appear for markets where those indexes are not an
+  applicable baseline.
+- Redesigning Run config, Backtest launch, Paper Trading, or Admin Analytics.
+- Changing Trading Log filters or backend pagination limits.
+
+## Acceptance criteria
+
+1. A supported US Backtest displays Your Agent, DJIA, Nasdaq-100, and Buy & Hold
+   on the chart and in one exact-value comparison table.
+2. Each available series has Final Value, Total Return, Max Drawdown, and Sharpe
+   Ratio calculated from the same aligned chart-data timestamps and values.
+3. The Agent Total Return cell states its percentage-point difference from
+   every available benchmark.
+4. The best value in each metric is identified with text as well as color, and
+   unavailable values are never treated as zero or best.
+5. On a viewport at least 1280 CSS pixels wide, Run config is left, performance
+   is center, Trading Log is right, and Trading Log scrolls independently.
+6. On narrower viewports, Trading Log moves below performance and no text,
+   controls, comparison values, or order details overlap.
+7. Every existing Trading Log field, filter, empty state, error state, and
+   truncation notice remains available in the vertical feed presentation.
+8. Chart/comparison failure does not erase Trading Log, and Trading Log failure
+   does not erase chart/comparison.
+9. Index-provider or Buy & Hold partial failure is explicit and never replaced
+   with a mismatched or fabricated baseline.
+10. Keyboard users can operate range controls, legend toggles, order filtering,
+    and the wide-screen log scroller with a visible focus indicator.
+11. No response, fixture, commit, or PR exposes a real secret or local database.


### PR DESCRIPTION
## Summary
- add Buy & Hold, DJIA, and Nasdaq-100 comparison curves and metrics for supported backtests
- render an accessible performance comparison table with native legend controls and partial benchmark states
- move Trading Log into a responsive right-rail activity feed while preserving order audit details and independent loading/error states

## Verification
- focused benchmark and Trading Log suite: 165 passed
- full dashboard backend suite on latest `main`: 3779 passed, 147 skipped
- browser verification at 1440px, 1024px, and 390px with a temporary SQLite database
- no repository database, credentials, `.superpowers/`, `work/`, or screenshots included

## Notes
- Benchmark metrics are calculated from aligned chart-data values using the documented population-standard-deviation Sharpe calculation.
- iFinD A-share runs omit US index benchmarks while retaining Buy & Hold.