### PR TITLE
feat(ui): split My Agents into Prompted Models and Open Agents

### DIFF
--- a/dashboard/backend/api/auth.py
+++ b/dashboard/backend/api/auth.py
@@ -28,6 +28,7 @@ from dashboard.backend.api.rate_limit import (
 )
 from dashboard.backend.domain.brokers.repository import broker_store
 from dashboard.backend.domain.analytics import instrumentation as analytics_instrumentation
+from dashboard.backend.domain.agents.service import agent_service
 from dashboard.backend.domain.credits.service import credits_service
 from dashboard.backend.infrastructure.brokers import pending_links, robinhood_oauth
 from dashboard.backend.infrastructure.email import sender as email_sender
@@ -449,6 +450,12 @@ async def signup(payload: SignupRequest, request: Request):
     await _ensure_welcome_credits(user["id"], category="signup")
 
     token, entitlements = await asyncio.to_thread(_issue_session, user, request)
+    browser_session = (request.headers.get("x-browser-id") or "").strip() or None
+    await asyncio.to_thread(
+        agent_service.provision_starter_agents,
+        owner_user_id=user["id"],
+        owner_browser_session=browser_session,
+    )
     analytics_instrumentation.emit_account_event(
         event_name="account_signed_up",
         user_id=user["id"],

--- a/dashboard/backend/domain/agents/defaults.py
+++ b/dashboard/backend/domain/agents/defaults.py
@@ -35,6 +35,40 @@ DEFAULT_STARTER_INSTRUCTION = (
     "everything into one stock."
 )
 
+def starter_agent_description(name: str) -> str:
+    """Card copy for a pre-created prompted-model starter."""
+    return (
+        f"A {name} starter — open it to edit the trading instruction "
+        "and run a backtest."
+    )
+
+
+# Pre-created Prompted Models cards for a brand-new account. Mirrored in
+# ``dashboard/frontend/app.js`` (guest fallback POST). Signup provisions
+# server-side so a stale browser localStorage guard cannot skip the set.
+STARTER_AGENTS: tuple[Dict[str, str], ...] = (
+    {
+        "name": "DeepSeek V4 Pro",
+        "model_name": "deepseek/deepseek-v4-pro",
+        "description": starter_agent_description("DeepSeek V4 Pro"),
+    },
+    {
+        "name": "GPT-5.5",
+        "model_name": "openai/gpt-5.5",
+        "description": starter_agent_description("GPT-5.5"),
+    },
+    {
+        "name": "Claude Sonnet 4.6",
+        "model_name": "anthropic/claude-sonnet-4-6",
+        "description": starter_agent_description("Claude Sonnet 4.6"),
+    },
+)
+
+# First-card aliases: tests and the original single-starter call sites.
+STARTER_AGENT_NAME = STARTER_AGENTS[0]["name"]
+STARTER_AGENT_MODEL = STARTER_AGENTS[0]["model_name"]
+STARTER_AGENT_DESCRIPTION = STARTER_AGENTS[0]["description"]
+
 
 def default_starter_pipeline() -> List[Dict[str, Any]]:
     """The one-step pipeline a new built-in agent starts with."""

--- a/dashboard/backend/domain/agents/service.py
+++ b/dashboard/backend/domain/agents/service.py
@@ -19,7 +19,10 @@ from typing import Any, Dict, List, Optional, Tuple
 from dashboard.backend.domain.agents.repository import agent_store, _UNSET
 from dashboard.backend.domain.agents import auth_cache
 from dashboard.backend.domain.agents.credential_store import agent_credential_store
-from dashboard.backend.domain.agents.defaults import default_starter_pipeline
+from dashboard.backend.domain.agents.defaults import (
+    STARTER_AGENTS,
+    default_starter_pipeline,
+)
 from dashboard.backend.domain.agents.taxonomy import coerce_category, normalize_category
 from dashboard.backend.domain.agents.runtime import (
     DEFAULT_RUNTIME_TYPE,
@@ -441,6 +444,87 @@ class AgentService:
                 agent_id=agent["agent_id"],
             )
         return agent
+
+    def provision_starter_agents(
+        self,
+        *,
+        owner_user_id: int,
+        owner_browser_session: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Create the Prompted Models starter cards for a brand-new account.
+
+        Called from signup so the first My Agents paint cannot be skipped by a
+        stale browser ``localStorage`` guard (user ids recycle on local SQLite
+        and on Render's ephemeral disk). Idempotent on ``model_name``: an
+        account that already has DeepSeek still receives GPT-5.5 and Claude.
+        Fail-open per card: signup must still succeed if one write fails.
+        """
+        from dashboard.backend.domain.backtesting.constants import (
+            DEFAULT_AGENT_CASH_ALLOCATION,
+        )
+        from dashboard.backend.domain.portfolios.service import portfolio_service
+
+        owned = list(self.agents.list_agents(owner_user_id=int(owner_user_id)))
+        by_model = {str(agent.get("model_name") or ""): agent for agent in owned}
+        created: List[Dict[str, Any]] = []
+        for spec in STARTER_AGENTS:
+            model_name = spec["model_name"]
+            existing_agent = by_model.get(model_name)
+            if existing_agent:
+                if existing_agent.get("name") != spec["name"]:
+                    try:
+                        updated = self.agents.update_agent(
+                            existing_agent["agent_id"], name=spec["name"]
+                        )
+                        if updated:
+                            by_model[model_name] = updated
+                    except Exception as exc:
+                        print(
+                            f"[agents] ERROR starter rename failed for "
+                            f"user={owner_user_id} model={model_name}: {exc}"
+                        )
+                continue
+            try:
+                portfolio_service.ensure_cash_for_new_agent(
+                    int(owner_user_id), float(DEFAULT_AGENT_CASH_ALLOCATION)
+                )
+                agent = self.create_agent(
+                    name=spec["name"],
+                    model_name=model_name,
+                    owner_user_id=int(owner_user_id),
+                    owner_browser_session=owner_browser_session,
+                    agent_type="builtin",
+                    description=spec["description"],
+                    cash_allocation=float(DEFAULT_AGENT_CASH_ALLOCATION),
+                )
+                created.append(agent)
+                by_model[model_name] = agent
+            except Exception as exc:
+                print(
+                    f"[agents] ERROR starter provision failed for "
+                    f"user={owner_user_id} model={model_name}: {exc}"
+                )
+        try:
+            portfolio_service.get_or_create_portfolio(int(owner_user_id))
+        except Exception as exc:
+            print(
+                f"[agents] ERROR starter portfolio reconcile failed "
+                f"for user={owner_user_id}: {exc}"
+            )
+        return created
+
+    def provision_starter_agent(
+        self,
+        *,
+        owner_user_id: int,
+        owner_browser_session: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """First starter only — prefer ``provision_starter_agents``."""
+        created = self.provision_starter_agents(
+            owner_user_id=owner_user_id,
+            owner_browser_session=owner_browser_session,
+        )
+        return created[0] if created else None
 
     def _create_builtin_copy(
         self,

--- a/dashboard/backend/tests/test_admin_analytics_frontend.py
+++ b/dashboard/backend/tests/test_admin_analytics_frontend.py
@@ -190,8 +190,8 @@ def test_app_lifecycle_and_cache_versions_are_wired():
     assert "window.AdminAnalytics.syncAuth(user)" in APP_JS
     assert "window.AdminAnalytics.onEnter()" in APP_JS
     assert "window.AdminAnalytics.refresh()" in APP_JS
-    assert 'styles.css?v=128' in APP_HTML
-    assert 'app.js?v=119' in APP_HTML
+    assert 'styles.css?v=130' in APP_HTML
+    assert 'app.js?v=123' in APP_HTML
     assert 'js/admin-analytics.js?v=2' in APP_HTML
     assert 'js/admin-tabs.js?v=3' in APP_HTML
 

--- a/dashboard/backend/tests/test_agent_editor_header_ui.py
+++ b/dashboard/backend/tests/test_agent_editor_header_ui.py
@@ -39,3 +39,17 @@ def test_dirty_badge_is_hidden_by_default_and_toggled_by_editor_state():
     assert 'class="agent-editor-dirty-badge"' in badge
     assert " hidden" in badge
     assert "badge.hidden = !dirty" in _AGENT_EDITOR_JS
+
+
+def test_prompted_model_name_follows_the_model_dropdown():
+    """Cards whose title is already a model label lock the name to the
+    dropdown so 'DeepSeek V4 Pro' cannot drift from the selected model.
+    """
+    assert "function nameFollowsModel(" in _AGENT_EDITOR_JS
+    assert "function syncBoundAgentName(" in _AGENT_EDITOR_JS
+    assert "nameInput.readOnly = bound" in _AGENT_EDITOR_JS
+    assert "agentEditorModelSelect" in _AGENT_EDITOR_JS
+    assert "syncBoundAgentName();" in _AGENT_EDITOR_JS
+    assert "agent-editor-name-input--bound" in _AGENT_EDITOR_JS
+    styles = (_FRONTEND / "styles.css").read_text(encoding="utf-8")
+    assert ".agent-editor-name-input--bound" in styles

--- a/dashboard/backend/tests/test_agent_starter_defaults.py
+++ b/dashboard/backend/tests/test_agent_starter_defaults.py
@@ -31,6 +31,10 @@ from dashboard.backend.domain.agents.defaults import (
     DEFAULT_STARTER_INSTRUCTION,
     SIMPLE_INSTRUCTION_OUTPUT_FORMAT,
     SIMPLE_INSTRUCTION_PRESET_KEY,
+    STARTER_AGENT_DESCRIPTION,
+    STARTER_AGENT_MODEL,
+    STARTER_AGENT_NAME,
+    STARTER_AGENTS,
 )
 from dashboard.backend.tests._frontend_source import js_string_const
 
@@ -70,6 +74,64 @@ def _create(client, **overrides):
 # --------------------------------------------------------------------------
 # Server-side seeding
 # --------------------------------------------------------------------------
+
+
+def test_provision_starter_agents_creates_the_three_model_cards(client):
+    from dashboard.backend.domain.agents.service import agent_service
+
+    created = agent_service.provision_starter_agents(owner_user_id=42)
+    assert {a["model_name"] for a in created} == {s["model_name"] for s in STARTER_AGENTS}
+    by_model = {a["model_name"]: a for a in created}
+    for spec in STARTER_AGENTS:
+        agent = by_model[spec["model_name"]]
+        assert agent["name"] == spec["name"]
+        assert agent["agent_type"] == "builtin"
+        assert agent["description"] == spec["description"]
+        assert agent["pipeline"]
+
+
+def test_provision_starter_agents_is_idempotent_on_model_name(client):
+    from dashboard.backend.domain.agents.service import agent_service
+
+    first = agent_service.provision_starter_agents(owner_user_id=42)
+    second = agent_service.provision_starter_agents(owner_user_id=42)
+    assert len(first) == len(STARTER_AGENTS)
+    assert second == []
+
+
+def test_provision_renames_a_starter_whose_title_drifted_from_its_model(client):
+    """A Claude card stored under the DeepSeek title must be rewritten.
+
+    The grid title used to read `agent.name` while the subtitle read the
+    model, so a drifted row showed "DeepSeek V4 Pro" over "Claude Sonnet 4.6".
+    """
+    from dashboard.backend.domain.agents.service import agent_service
+
+    drifted = agent_service.create_agent(
+        name="DeepSeek V4 Pro",
+        model_name="anthropic/claude-sonnet-4-6",
+        owner_user_id=42,
+        owner_browser_session=None,
+        agent_type="builtin",
+    )
+    agent_service.provision_starter_agents(owner_user_id=42)
+    listed = agent_service.agents.list_agents(owner_user_id=42)
+    claude = next(
+        a for a in listed if a["model_name"] == "anthropic/claude-sonnet-4-6"
+    )
+    assert claude["agent_id"] == drifted["agent_id"]
+    assert claude["name"] == "Claude Sonnet 4.6"
+
+
+def test_provision_starter_agent_fail_open_does_not_raise(client, monkeypatch):
+    from dashboard.backend.domain.agents.service import agent_service
+
+    def boom(**_kwargs):
+        raise RuntimeError("store unavailable")
+
+    monkeypatch.setattr(agent_service, "create_agent", boom)
+    assert agent_service.provision_starter_agent(owner_user_id=1) is None
+    assert agent_service.provision_starter_agents(owner_user_id=1) == []
 
 
 def test_new_builtin_agent_is_seeded_with_the_starter_instruction(client):
@@ -192,6 +254,23 @@ def test_output_format_matches_the_frontend():
 
 def test_starter_instruction_matches_the_frontend():
     assert _js_const("DEFAULT_STARTER_INSTRUCTION") == DEFAULT_STARTER_INSTRUCTION
+
+
+def test_starter_agent_identity_matches_the_frontend():
+    assert _js_const("DEFAULT_STARTER_AGENT_NAME") == STARTER_AGENT_NAME
+    assert _js_const("DEFAULT_FOUNDATION_MODEL") == STARTER_AGENT_MODEL
+    assert _js_const("DEFAULT_STARTER_AGENT_DESCRIPTION") == STARTER_AGENT_DESCRIPTION
+
+
+def test_starter_agents_roster_matches_the_frontend():
+    from dashboard.backend.tests._frontend_source import js_const
+
+    decl = js_const("STARTER_AGENTS")
+    assert len(STARTER_AGENTS) == 3
+    for spec in STARTER_AGENTS:
+        assert spec["name"] in decl
+        assert spec["model_name"] in decl
+        assert spec["description"] in decl
 
 
 def test_the_editor_can_read_the_starter_instruction():

--- a/dashboard/backend/tests/test_agents_api.py
+++ b/dashboard/backend/tests/test_agents_api.py
@@ -10,6 +10,7 @@ from dashboard.backend.tests.auth_cookies_helpers import _cookie_session_token
 
 from dashboard.backend.app import app
 from dashboard.backend.domain.agents.credential_store import AgentCredentialStore
+from dashboard.backend.domain.agents.defaults import STARTER_AGENTS
 
 
 @pytest.fixture
@@ -309,8 +310,11 @@ def test_claim_account_links_browser_agents(client):
 
     listed = client.get("/api/v1/agents", headers={"Authorization": f"Bearer {token}"})
     assert listed.status_code == 200
-    assert len(listed.json()["agents"]) == 1
-    assert listed.json()["agents"][0]["agent_id"] == agent_id
+    listed_agents = listed.json()["agents"]
+    listed_ids = {a["agent_id"] for a in listed_agents}
+    assert agent_id in listed_ids
+    # Guest card plus the three signup starters.
+    assert len(listed_agents) == 1 + len(STARTER_AGENTS)
 
 
 def test_logout_list_hides_account_bound_agents(client):

--- a/dashboard/backend/tests/test_ai_hedge_fund_frontend.py
+++ b/dashboard/backend/tests/test_ai_hedge_fund_frontend.py
@@ -190,34 +190,32 @@ def test_marketplace_cta_is_unified_add_to_my_agents():
     assert "Copy to My Agents" not in _APP_JS
 
 
-def test_hosted_agents_are_not_given_a_runtime_flavoured_section():
-    """The hosted AI Hedge Fund agent shares a shelf with every other stock
-    strategy rather than getting a runtime-flavoured section of its own.
+def test_hosted_agents_land_on_the_open_agents_shelf():
+    """Hosted runtimes (AI Hedge Fund) render under Open Agents, not mixed
+    into Prompted Models. Shelves still resolve through one function, so no
+    predicate can double-count or drop an agent.
 
-    #309 briefly split My Agents on `runtime_type === 'ai_hedge_fund'` into an
-    "Open Agents" section. Rewritten 2026-08-05: the shelves are asset-class
-    based now (Stocks / Crypto / Futures / Connected Agents), so a hosted agent
-    lands on Stocks like everything else and its *market* -- a separate axis --
-    comes from `category`. The separation the runtime split was after still
-    holds, and it now generalizes: a hosted A-share agent shelves correctly and
-    files under the China A-Share chip, which the runtime test could not do.
+    runtime_type is always present and truthy (server-defaulted to 'pipeline'),
+    so the hosted check MUST be an inequality against 'pipeline'.
     """
     assert "Foundation Agents" not in _APP_HTML
-    assert "Open Agents" not in _APP_HTML
-    # The retired axes: "Prompting LLMs" was how-it-decides (now a card label),
-    # "U.S. Stock Trading" was geography (now a market chip).
+    assert ">Open Agents</h3>" in _APP_HTML
+    assert ">Prompted Models</h3>" in _APP_HTML
     assert ">Prompting LLMs</h3>" not in _APP_HTML
     assert ">U.S. Stock Trading</h3>" not in _APP_HTML
-    assert ">Stocks</h3>" in _APP_HTML
-    assert 'id="agentsGridStocks"' in _APP_HTML
+    assert ">Stocks</h3>" not in _APP_HTML
+    assert 'id="agentsGridOpen"' in _APP_HTML
+    assert 'id="agentsGridPrompted"' in _APP_HTML
 
-    # The runtime-keyed *sections* are gone: shelves resolve through one
-    # function, so no predicate can double-count or drop.
     assert "isOpenAgent" not in _APP_JS
-    assert "agentsGridOpen" not in _APP_JS
     assert "const AGENT_SHELVES = [" in _APP_JS
     assert "function agentShelfKey(agent)" in _APP_JS
-    assert "agentShelfKey(a) === 'stocks'" in _APP_JS
+    assert "agentShelfKey(a) === 'prompted'" in _APP_JS
+    assert "agentShelfKey(a) === 'open'" in _APP_JS
+    key_fn = _APP_JS.split("function agentShelfKey(agent)", 1)[1].split("\n}", 1)[0]
+    assert "!== 'pipeline'" in key_fn
+    assert "return 'open'" in key_fn
+    assert "return 'prompted'" in key_fn
 
 
 def test_uncategorized_hosted_agents_still_resolve_to_the_us_market():

--- a/dashboard/backend/tests/test_analytics_frontend.py
+++ b/dashboard/backend/tests/test_analytics_frontend.py
@@ -41,12 +41,12 @@ def _function_body(source: str, signature: str) -> str:
 
 
 def test_analytics_script_loads_between_app_and_page_scripts():
-    app_at = APP_HTML.index('<script src="app.js?v=119" defer></script>')
+    app_at = APP_HTML.index('<script src="app.js?v=123" defer></script>')
     analytics_at = APP_HTML.index(
         '<script src="js/analytics.js?v=1" defer></script>'
     )
     editor_at = APP_HTML.index(
-        '<script src="js/agent-editor.js?v=28" defer></script>'
+        '<script src="js/agent-editor.js?v=30" defer></script>'
     )
     assert app_at < analytics_at < editor_at
 

--- a/dashboard/backend/tests/test_auth.py
+++ b/dashboard/backend/tests/test_auth.py
@@ -11,6 +11,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from dashboard.backend.app import app
+from dashboard.backend.domain.agents.defaults import STARTER_AGENTS
 from dashboard.backend.users import UserStore
 
 def _session_token(client) -> str:
@@ -94,6 +95,18 @@ def test_signup_login_me_logout_flow(client):
     assert "password_hash" not in signup_data["user"]
     assert "token" not in signup_data
     assert _session_token(client)  # signup set the session cookie
+
+    listed = client.get("/api/v1/agents")
+    assert listed.status_code == 200
+    listed_by_model = {
+        a.get("model_name"): a for a in listed.json()["agents"]
+    }
+    for spec in STARTER_AGENTS:
+        starter = listed_by_model.get(spec["model_name"])
+        assert starter, f"signup must provision {spec['name']}"
+        assert starter["name"] == spec["name"]
+        assert starter["agent_type"] == "builtin"
+        assert starter["pipeline"], "starter must be usable without Configure"
 
     duplicate = client.post(
         "/api/auth/signup",

--- a/dashboard/backend/tests/test_backtest_comparison_frontend.py
+++ b/dashboard/backend/tests/test_backtest_comparison_frontend.py
@@ -191,8 +191,8 @@ def test_exact_raw_ties_mark_every_tied_series_best():
 
 def test_comparison_script_and_semantic_table_ship_before_app():
     helper = '<script src="js/backtest-comparison.js?v=1" defer></script>'
-    app = '<script src="app.js?v=119" defer></script>'
-    assert 'href="styles.css?v=128"' in APP_HTML
+    app = '<script src="app.js?v=123" defer></script>'
+    assert 'href="styles.css?v=130"' in APP_HTML
     assert APP_HTML.index(helper) < APP_HTML.index(app)
     for element_id in (
         "performanceLegend",

--- a/dashboard/backend/tests/test_frontend_fast_boot.py
+++ b/dashboard/backend/tests/test_frontend_fast_boot.py
@@ -139,11 +139,12 @@ def test_scripts_are_deferred():
 
 def test_agents_grid_ships_loading_skeleton():
     # Pre-JS, My Agents must show placeholder cards instead of a blank panel,
-    # in every shelf that renders agents. Only two do: Stocks (the one live
-    # asset class) and External. The Crypto/Futures rows are locked and have no
+    # in every shelf that renders agents. Prompted Models, Open Agents, and
+    # External all have grids. The Crypto/Futures rows are locked and have no
     # grid at all, so there is nothing to skeleton there.
     grid_ids = (
-        "agentsGridStocks",
+        "agentsGridPrompted",
+        "agentsGridOpen",
         "agentsGridExternal",
     )
     skeletons = [
@@ -190,9 +191,9 @@ def test_cache_busters_bumped():
     # the next bump, so the exact one looks like the broken guard and gets
     # "fixed" by loosening it. That collision has already cost this repo one
     # round of follow-ups (#347/#348).
-    assert "app.js?v=119" in APP_HTML
-    assert "js/agent-editor.js?v=28" in APP_HTML
-    assert "styles.css?v=128" in APP_HTML
+    assert "app.js?v=123" in APP_HTML
+    assert "js/agent-editor.js?v=30" in APP_HTML
+    assert "styles.css?v=130" in APP_HTML
     assert "js/leaderboard.js?v=32" in APP_HTML
     assert "home-page.js?v=50" in APP_HTML
     assert "js/credit-format.js?v=1" in APP_HTML

--- a/dashboard/backend/tests/test_frontend_shelves.py
+++ b/dashboard/backend/tests/test_frontend_shelves.py
@@ -1,13 +1,13 @@
-"""Guards for the My Agents shelf sections (2026-08-05).
+"""Guards for the My Agents shelf sections (2026-08-05, updated 2026-08-28).
 
 My Agents used to split agents into two buckets: "Foundation Agents" (whose
 subtitle called the product "A prompting game", the #1 trust-killer in every
-persona walkthrough) and "External Agents". This task replaces both with four
-static shelf sections keyed to the backend category taxonomy
-(`dashboard.backend.domain.agents.taxonomy.AGENT_CATEGORIES`), plus the
-unchanged external bucket, and adds the canonical no-real-money sentence next
-to the capital controls. None of this is enforceable at runtime -- app.html
-has no JS test harness -- so, per this suite's frontend convention
+persona walkthrough) and "External Agents". Asset-class shelves (Stocks /
+Crypto / Futures) replaced that, then this task split the live Stocks row into
+**Prompted Models** (pipeline / instruction agents) and **Open Agents** (hosted
+runtimes such as AI Hedge Fund), keeping the locked Crypto/Futures rows and
+the developer Connected Agents shelf. None of this is enforceable at runtime
+-- app.html has no JS test harness -- so, per this suite's frontend convention
 (`_frontend_source`), these are asserted against the shipped source directly.
 """
 
@@ -32,8 +32,12 @@ _HTML = _strip_html_comments(APP_HTML)
 
 _LIVE_SHELVES = [
     (
-        "Stocks",
-        "Trade U.S. blue-chip and Chinese A-share stocks, tested hour by hour on real market data.",
+        "Prompted Models",
+        "Write a trading instruction for an AI model and backtest it on market data.",
+    ),
+    (
+        "Open Agents",
+        "Open-source trading agents like AI Hedge Fund. Add them from Community, then customize and backtest.",
     ),
     (
         "For Developers: Connected Agents",
@@ -58,6 +62,8 @@ _RETIRED_SECTION_HEADERS = (
     "Prompting LLMs",
     "U.S. Stock Trading",
     "China A-Share Trading",
+    "Stocks",
+    "Foundation Agents",
 )
 
 _CANONICAL_NO_REAL_MONEY_SENTENCE = (
@@ -65,9 +71,13 @@ _CANONICAL_NO_REAL_MONEY_SENTENCE = (
     "you explicitly connect a brokerage account and turn on live trading."
 )
 
-# Live shelf id suffix -> the AGENT_SHELVES key it corresponds to. Only these
-# two are addressed from JS; the locked rows have no ids at all.
-_SHELF_SUFFIX_TO_KEY = {"Stocks": "stocks", "External": "external"}
+# Live shelf id suffix -> the AGENT_SHELVES key it corresponds to. Locked rows
+# have no ids at all.
+_SHELF_SUFFIX_TO_KEY = {
+    "Prompted": "prompted",
+    "Open": "open",
+    "External": "external",
+}
 
 
 def test_live_shelf_headers_and_subtitles_are_present():
@@ -77,9 +87,8 @@ def test_live_shelf_headers_and_subtitles_are_present():
 
 
 def test_geographic_section_headers_are_retired():
-    """The taxonomy is asset class now. These three named the old axes -- two
-    geographic, one about how the agent decides -- and must not survive as
-    section headers anywhere on the page.
+    """These named the old axes -- geography, asset class, and how the agent
+    decides -- and must not survive as section headers anywhere on the page.
     """
     for header in _RETIRED_SECTION_HEADERS:
         assert f">{header}</h3>" not in _HTML, header
@@ -97,7 +106,7 @@ def test_canonical_no_real_money_sentence_is_present_verbatim():
     assert _CANONICAL_NO_REAL_MONEY_SENTENCE in _HTML
 
 
-def test_two_live_sections_with_distinct_shelf_ids():
+def test_live_sections_with_distinct_shelf_ids():
     """Each live shelf gets its own grid/footer/empty/count id so the render
     loop can address them uniformly: `agentsGrid<Shelf>` /
     `agentsGridFooter<Shelf>` / `agentsEmpty<Shelf>` / `agentsCount<Shelf>`,
@@ -115,7 +124,7 @@ def test_retired_shelf_ids_are_gone():
     """A leftover id would silently double-register an element the render loop
     no longer expects to find.
     """
-    for suffix in ("Builtin", "PromptingLlms", "UsStocks", "CnAshares"):
+    for suffix in ("Builtin", "PromptingLlms", "UsStocks", "CnAshares", "Stocks"):
         assert f'id="agentsGrid{suffix}"' not in _HTML, suffix
         assert f'id="agentsGridFooter{suffix}"' not in _HTML, suffix
         assert f'id="agentsEmpty{suffix}"' not in _HTML, suffix
@@ -143,15 +152,15 @@ def test_locked_shelves_are_rendered_inert_not_empty():
         assert "agentsEmpty" not in section, slug
 
 
-def test_market_chip_container_is_inside_the_stocks_shelf():
-    """The chips filter the Stocks shelf, and they ride #agentsCategories'
+def test_market_chip_container_is_inside_the_prompted_shelf():
+    """The chips filter Prompted Models, and they ride #agentsCategories'
     existing delegated click handler -- so they must live inside that container,
     not in the page toolbar above it.
     """
-    stocks_at = _HTML.index('data-category="stocks"')
-    stocks = _HTML[stocks_at : _HTML.index("</section>", stocks_at)]
-    assert 'id="agentsMarketChips"' in stocks
-    assert _HTML.index('id="agentsCategories"') < stocks_at
+    prompted_at = _HTML.index('data-category="prompted"')
+    prompted = _HTML[prompted_at : _HTML.index("</section>", prompted_at)]
+    assert 'id="agentsMarketChips"' in prompted
+    assert _HTML.index('id="agentsCategories"') < prompted_at
 
 
 # --- C3: shelf rendering (app.js) -------------------------------------------
@@ -176,7 +185,7 @@ def _strip_js_comments(source: str) -> str:
     return re.sub(r"//[^\n]*", "", re.sub(r"/\*.*?\*/", "", source, flags=re.DOTALL))
 
 
-def test_agent_shelves_config_holds_only_the_two_live_shelves():
+def test_agent_shelves_config_holds_only_the_live_shelves():
     """`AGENT_SHELVES` drives rendering, so it lists only shelves that have a
     grid to render into. Crypto and Futures are locked, inert rows in app.html
     with no grid/footer/empty element -- listing them here would force a
@@ -185,18 +194,31 @@ def test_agent_shelves_config_holds_only_the_two_live_shelves():
     whole My Agents render.
     """
     config = js_const("AGENT_SHELVES")
-    for key in ("stocks", "external"):
+    for key in ("prompted", "open", "external"):
         assert f"key: '{key}'" in config, key
-    for absent in ("crypto", "futures", "prompting_llms", "us_stocks", "cn_ashares"):
+    for absent in ("stocks", "crypto", "futures", "prompting_llms", "us_stocks", "cn_ashares"):
         assert f"key: '{absent}'" not in config, absent
 
 
+def test_agent_shelf_key_splits_prompted_from_open():
+    """Hosted runtimes (AI Hedge Fund) must not land on Prompted Models.
+    runtime_type is always truthy, so the hosted check must be an inequality
+    against 'pipeline', never a truthiness test.
+    """
+    body = _strip_js_comments(fn_body("function agentShelfKey("))
+    assert "return 'external'" in body
+    assert "return 'open'" in body
+    assert "return 'prompted'" in body
+    assert "!== 'pipeline'" in body
+    assert "return 'stocks'" not in body
+
+
 def test_market_labels_is_the_only_declaration_of_the_market_names():
-    """One map, four consumers: the Stocks market chips, the Community category
-    chips, the agent-card submeta, and the Configure picker. A second hand-typed
-    copy would let one surface drift from the others -- which is exactly what
-    the retired SHELF_LABELS existed to prevent, so its name must be gone too,
-    not merely unused.
+    """One map, four consumers: the Prompted Models market chips, the Community
+    category chips, the agent-card submeta, and the Configure picker. A second
+    hand-typed copy would let one surface drift from the others -- which is
+    exactly what the retired SHELF_LABELS existed to prevent, so its name must
+    be gone too, not merely unused.
     """
     decl = js_const("MARKET_LABELS")
     assert "us_stocks: 'U.S.'" in decl
@@ -222,10 +244,10 @@ def test_card_submeta_carries_the_decision_axis_the_retired_shelf_used_to():
 def test_render_marketplace_category_chips_is_built_from_the_shared_label_map():
     """The chip row is built from MARKET_LABELS rather than a second hardcoded
     list, plus an 'all' chip that isn't a category at all. It is no longer built
-    from AGENT_SHELVES: Community filters templates by *market*, and there is
-    now one Stocks shelf holding both markets, so the shelf list and the chip
+    from AGENT_SHELVES: Community filters templates by *market*, and
+    Prompted Models holds both markets, so the shelf list and the chip
     list are different things -- built from AGENT_SHELVES this row would emit a
-    single, meaningless "Stocks" chip that matches no template.
+    single, meaningless "Prompted Models" chip that matches no template.
     """
     body = _strip_js_comments(fn_body("function renderMarketplaceCategoryChips()"))
     assert "MARKET_LABELS" in body
@@ -266,13 +288,53 @@ def test_my_foundation_agent_display_name_is_gone():
     assert "My Foundation Agent" not in body
 
 
-def test_my_trading_agent_display_name_is_present():
-    """Display-name rename only -- `ensureDefaultFoundationAgent`'s function
+def test_default_agent_is_named_deepseek_v4_pro():
+    """Display-name only -- `ensureDefaultFoundationAgent`'s function
     name and the guard-key plumbing it calls are untouched (see the prefix
     pin below); only the string handed to the create-agent API call changes.
     """
     body = _strip_js_comments(fn_body("async function ensureDefaultFoundationAgent("))
-    assert "My Trading Agent" in body
+    assert "STARTER_AGENTS" in body
+    assert "My Trading Agent" not in body
+    assert "My Foundation Agent" not in body
+    assert js_string_const("DEFAULT_STARTER_AGENT_NAME") == "DeepSeek V4 Pro"
+
+
+def test_prompted_card_title_follows_the_model_when_name_is_a_catalog_label():
+    """The right-hand Claude card was stored as name=DeepSeek V4 Pro. The
+    subtitle (model) was right; the <h3> was not. Bound titles must come from
+    agentDisplayName, not the raw stored name.
+    """
+    body = _strip_js_comments(fn_body("function renderAgentCards("))
+    assert "agentDisplayName(agent)" in body
+    assert "escapeHtml(agent.name)" not in body
+    display = _strip_js_comments(fn_body("function agentDisplayName("))
+    assert "catalogModelLabels()" in display
+    assert "formatAgentModelLabel" in display
+    align = _strip_js_comments(fn_body("async function alignStarterAgentNames("))
+    assert "agentDisplayName(agent)" in align
+    assert "API.patch" in align
+
+
+def test_ensure_default_fills_missing_starter_models():
+    """An account that already has DeepSeek must still receive GPT-5.5 and
+    Claude — skipping on `builtins.length` left those cards missing after the
+    one-card era.
+    """
+    body = _strip_js_comments(fn_body("async function ensureDefaultFoundationAgent("))
+    assert "STARTER_AGENTS.filter" in body
+    assert "openai/gpt-5.5" in js_const("STARTER_AGENTS")
+    assert "anthropic/claude-sonnet-4-6" in js_const("STARTER_AGENTS")
+
+
+def test_signed_in_provision_guard_includes_account_created_at():
+    """User ids recycle on ephemeral SQLite. Keying only on `u:${id}` made a
+    brand-new account inherit the previous tenant's 'already provisioned'
+    stamp and skip the starter card.
+    """
+    body = _strip_js_comments(fn_body("function defaultAgentProvisionGuardKey("))
+    assert "user.created_at" in body
+    assert "u:${user.id}:${created}" in body
 
 
 def test_default_agent_provision_guard_prefix_is_byte_identical():
@@ -466,6 +528,7 @@ def test_market_chips_filter_the_grid_but_never_the_count_pill():
     body = _strip_js_comments(fn_body("function renderAgentCategories("))
     assert "allAgents.filter(shelf.match).length" in body
     assert "agentMarketKey(a) === agentMarketFilter" in body
+    assert "shelf.key === 'prompted'" in body
 
 
 def test_market_chip_selection_resets_pagination():
@@ -478,20 +541,40 @@ def test_market_chip_selection_resets_pagination():
     assert "applyAgentFilters()" in body
 
 
-def test_stocks_empty_state_distinguishes_search_chip_and_truly_empty():
+def test_prompted_empty_state_distinguishes_search_chip_and_truly_empty():
     """Three distinct cases, deliberately worded apart. Collapsing them would
     tell a user who is mid-search, or who clicked a market chip, that they own
-    no agents at all -- and Stocks is the onboarding surface now (it inherited
-    that role from the retired Prompting LLMs shelf), so its true-empty copy is
+    no agents at all -- and Prompted Models is the onboarding surface now (the
+    auto-provisioned DeepSeek card lands here), so its true-empty copy is
     the create-your-first voice, not the add-from-Community voice.
     """
-    body = _strip_js_comments(fn_body("function stocksEmptyHtml("))
+    body = _strip_js_comments(fn_body("function promptedEmptyHtml("))
     assert "No agents match your search." in body
     assert "You don't have any agents yet." in body
     assert "communityShelfButtonHtml" in body
 
 
-# --- shelf visual treatment (styles.css) ------------------------------------
+def test_open_agents_empty_state_points_at_community():
+    """Open Agents is the hosted-runtime shelf, so its empty copy should send
+    the user to Community (AI Hedge Fund) rather than the create-a-prompted-model
+    onboarding voice.
+    """
+    body = _strip_js_comments(fn_body("function openAgentsEmptyHtml("))
+    assert "No agents match your search." in body
+    assert "AI Hedge Fund" in body
+    assert "communityShelfButtonHtml" in body
+    assert "You don't have any agents yet." not in body
+
+
+def test_agent_card_identity_opens_the_editor():
+    """The card name is the 'click in to edit instructions' path, not only
+    the Configure button. Bound on the identity block so Run Backtest and the
+    overflow menu keep their own handlers.
+    """
+    body = _strip_js_comments(fn_body("function renderAgentCards("))
+    assert "querySelector('.agent-card-identity')" in body
+    assert "window.AgentEditor.open(agent)" in body
+    assert "Open to edit instructions" in body
 
 _STYLES_PATH = Path(__file__).resolve().parents[2] / "frontend" / "styles.css"
 _STYLES = re.sub(
@@ -557,3 +640,11 @@ def test_market_chips_reuse_the_community_chip_rules():
     """
     assert ".marketplace-category-chip {" in _STYLES
     assert not re.search(r"\.agents-market-chip\s*\{", _STYLES)
+
+
+def test_agent_card_identity_is_visibly_clickable():
+    """Clicking the name opens Configure; without a pointer cursor the
+    identity block looks like static chrome.
+    """
+    rule = _rule(".agent-card--status .agent-card-identity")
+    assert "cursor: pointer" in rule

--- a/dashboard/backend/tests/test_portfolio_allocate.py
+++ b/dashboard/backend/tests/test_portfolio_allocate.py
@@ -21,11 +21,21 @@ import dashboard.backend.domain.portfolios.repository as portfolio_repo
 import dashboard.backend.domain.portfolios.service as portfolio_service_module
 import dashboard.backend.users as users_module
 from dashboard.backend.app import app
+from dashboard.backend.domain.agents.defaults import STARTER_AGENTS
 from dashboard.backend.domain.backtesting.constants import (
     DEFAULT_AGENT_CASH_ALLOCATION,
     DEFAULT_PORTFOLIO_EQUITY,
     MAX_AGENT_CASH_ALLOCATION,
 )
+
+# Signup mints one starter per STARTER_AGENTS entry, each funded at
+# DEFAULT_AGENT_CASH_ALLOCATION. Cash checks after _signup() subtract this,
+# or they describe an empty-account world that no longer exists.
+STARTER_ALLOCATED = len(STARTER_AGENTS) * float(DEFAULT_AGENT_CASH_ALLOCATION)
+
+
+def _cash_after_signup() -> float:
+    return float(DEFAULT_PORTFOLIO_EQUITY) - STARTER_ALLOCATED
 
 
 @pytest.fixture
@@ -79,7 +89,8 @@ def test_create_agent_debits_portfolio(client):
     headers = _auth(token)
 
     before = client.get("/api/v1/portfolio", headers=headers).json()["portfolio"]
-    assert before["cash_available"] == float(DEFAULT_PORTFOLIO_EQUITY)
+    assert before["cash_available"] == _cash_after_signup()
+    assert before["allocated"] == STARTER_ALLOCATED
 
     created = client.post(
         "/api/v1/agents",
@@ -96,8 +107,8 @@ def test_create_agent_debits_portfolio(client):
     assert agent["cash_allocation"] == 2500
 
     after = client.get("/api/v1/portfolio", headers=headers).json()["portfolio"]
-    assert after["cash_available"] == float(DEFAULT_PORTFOLIO_EQUITY) - 2500
-    assert after["allocated"] == 2500
+    assert after["cash_available"] == _cash_after_signup() - 2500
+    assert after["allocated"] == STARTER_ALLOCATED + 2500
 
 
 def test_allocate_and_reclaim_endpoints(client):
@@ -123,7 +134,7 @@ def test_allocate_and_reclaim_endpoints(client):
         json={"agent_id": agent_id, "amount": 1500},
     )
     assert alloc.status_code == 200, alloc.text
-    assert alloc.json()["portfolio"]["cash_available"] == float(DEFAULT_PORTFOLIO_EQUITY) - 1500
+    assert alloc.json()["portfolio"]["cash_available"] == _cash_after_signup() - 1500
     assert alloc.json()["agent"]["cash_allocation"] == 1500
 
     reclaim = client.post(
@@ -132,7 +143,7 @@ def test_allocate_and_reclaim_endpoints(client):
         json={"agent_id": agent_id, "amount": 500},
     )
     assert reclaim.status_code == 200, reclaim.text
-    assert reclaim.json()["portfolio"]["cash_available"] == float(DEFAULT_PORTFOLIO_EQUITY) - 1000
+    assert reclaim.json()["portfolio"]["cash_available"] == _cash_after_signup() - 1000
     assert reclaim.json()["agent"]["cash_allocation"] == 1000
 
 
@@ -140,8 +151,9 @@ def test_allocate_blocked_when_insufficient_cash(client):
     token, _ = _signup(client, email="poor@example.com")
     headers = _auth(token)
 
-    # Drain most of the $10k ledger with maxed sleeves ($3k each).
-    for i in range(3):
+    # Starters already hold $3k. Two more maxed sleeves leave $1k, so a $3k
+    # allocate is within the per-agent max but over remaining cash.
+    for i in range(2):
         filled = client.post(
             "/api/v1/agents",
             headers=headers,
@@ -187,7 +199,7 @@ def test_delete_agent_returns_funds(client):
     agent_id = created.json()["agent"]["agent_id"]
 
     mid = client.get("/api/v1/portfolio", headers=headers).json()["portfolio"]
-    assert mid["cash_available"] == float(DEFAULT_PORTFOLIO_EQUITY) - float(
+    assert mid["cash_available"] == _cash_after_signup() - float(
         DEFAULT_AGENT_CASH_ALLOCATION
     )
 
@@ -196,8 +208,8 @@ def test_delete_agent_returns_funds(client):
     assert deleted.json()["reclaimed"] == float(DEFAULT_AGENT_CASH_ALLOCATION)
 
     after = client.get("/api/v1/portfolio", headers=headers).json()["portfolio"]
-    assert after["cash_available"] == float(DEFAULT_PORTFOLIO_EQUITY)
-    assert after["allocated"] == 0.0
+    assert after["cash_available"] == _cash_after_signup()
+    assert after["allocated"] == STARTER_ALLOCATED
 
 
 def test_patch_cash_allocation_moves_ledger(client):
@@ -218,7 +230,7 @@ def test_patch_cash_allocation_moves_ledger(client):
     assert up.status_code == 200, up.text
     assert up.json()["agent"]["cash_allocation"] == 3000
     pf = client.get("/api/v1/portfolio", headers=headers).json()["portfolio"]
-    assert pf["cash_available"] == float(DEFAULT_PORTFOLIO_EQUITY) - 3000
+    assert pf["cash_available"] == _cash_after_signup() - 3000
 
     down = client.patch(
         f"/api/v1/agents/{agent_id}",
@@ -227,7 +239,7 @@ def test_patch_cash_allocation_moves_ledger(client):
     )
     assert down.status_code == 200, down.text
     pf2 = client.get("/api/v1/portfolio", headers=headers).json()["portfolio"]
-    assert pf2["cash_available"] == float(DEFAULT_PORTFOLIO_EQUITY) - 500
+    assert pf2["cash_available"] == _cash_after_signup() - 500
 
 
 # ---------------------------------------------------------------------------
@@ -259,8 +271,8 @@ def test_portfolio_reports_preexisting_sleeves_as_allocated(env):
 
     pf = client.get("/api/v1/portfolio", headers=_auth(token)).json()["portfolio"]
 
-    assert pf["allocated"] == 1000.0
-    assert pf["cash_available"] == float(DEFAULT_PORTFOLIO_EQUITY) - 1000.0
+    assert pf["allocated"] == STARTER_ALLOCATED + 1000.0
+    assert pf["cash_available"] == _cash_after_signup() - 1000.0
 
 
 def test_deleting_a_preexisting_agent_succeeds_and_restores_cash(env):
@@ -274,8 +286,8 @@ def test_deleting_a_preexisting_agent_succeeds_and_restores_cash(env):
     assert deleted.status_code == 200, deleted.text
     assert agent_store.get_agent(agent_id) is None
     after = client.get("/api/v1/portfolio", headers=headers).json()["portfolio"]
-    assert after["cash_available"] == float(DEFAULT_PORTFOLIO_EQUITY)
-    assert after["allocated"] == 0.0
+    assert after["cash_available"] == _cash_after_signup()
+    assert after["allocated"] == STARTER_ALLOCATED
 
 
 def test_preexisting_agent_allocation_can_be_lowered(env):
@@ -291,7 +303,7 @@ def test_preexisting_agent_allocation_can_be_lowered(env):
     assert resp.status_code == 200, resp.text
     assert resp.json()["agent"]["cash_allocation"] == 400
     pf = client.get("/api/v1/portfolio", headers=headers).json()["portfolio"]
-    assert pf["cash_available"] == float(DEFAULT_PORTFOLIO_EQUITY) - 400
+    assert pf["cash_available"] == _cash_after_signup() - 400
 
 
 def test_preexisting_sleeve_cannot_be_spent_twice(env):
@@ -366,7 +378,7 @@ def test_patch_failure_leaves_the_ledger_untouched(env):
 
     assert agent_store.get_agent(agent_id)["cash_allocation"] == 1000
     pf = client.get("/api/v1/portfolio", headers=headers).json()["portfolio"]
-    assert pf["cash_available"] == float(DEFAULT_PORTFOLIO_EQUITY) - 1000
+    assert pf["cash_available"] == _cash_after_signup() - 1000
 
 
 # ---------------------------------------------------------------------------
@@ -431,7 +443,7 @@ def test_reclaiming_more_than_the_sleeve_is_rejected(client):
     assert resp.status_code == 400, resp.text
     assert client.get("/api/v1/portfolio", headers=headers).json()["portfolio"][
         "cash_available"
-    ] == float(DEFAULT_PORTFOLIO_EQUITY) - 500
+    ] == _cash_after_signup() - 500
 
 
 def test_concurrent_allocations_cannot_overspend(env):
@@ -441,19 +453,18 @@ def test_concurrent_allocations_cannot_overspend(env):
     client, agent_store, _ = env
     token, user = _signup(client, email="race@example.com")
     headers = _auth(token)
-    # Drain $6k so only $4k remains: either cap-sized request below fits on
-    # its own, but the two together overspend — exactly the race window.
-    for i in range(2):
-        drained = client.post(
-            "/api/v1/agents",
-            headers=headers,
-            json={
-                "name": f"Drain{i}",
-                "model_name": "local-model",
-                "cash_allocation": float(MAX_AGENT_CASH_ALLOCATION),
-            },
-        )
-        assert drained.status_code == 200, drained.text
+    # Starters hold $3k. Drain one more max sleeve so $4k remains: either
+    # cap-sized request below fits on its own, but the two together overspend.
+    drained = client.post(
+        "/api/v1/agents",
+        headers=headers,
+        json={
+            "name": "Drain",
+            "model_name": "local-model",
+            "cash_allocation": float(MAX_AGENT_CASH_ALLOCATION),
+        },
+    )
+    assert drained.status_code == 200, drained.text
     agents = [
         client.post(
             "/api/v1/agents",
@@ -487,7 +498,7 @@ def test_concurrent_allocations_cannot_overspend(env):
         float(a["cash_allocation"] or 0)
         for a in agent_store.list_agents(owner_user_id=user["id"])
     )
-    assert total_sleeves == 3 * float(MAX_AGENT_CASH_ALLOCATION)
+    assert total_sleeves == STARTER_ALLOCATED + 2 * float(MAX_AGENT_CASH_ALLOCATION)
 
 
 def test_service_serialises_concurrent_allocations_for_one_user(env, monkeypatch):
@@ -512,12 +523,11 @@ def test_service_serialises_concurrent_allocations_for_one_user(env, monkeypatch
     client, agent_store, _ = env
     _, user = _signup(client, email="svc-race@example.com")
     uid = user["id"]
-    # Drain $6k so only $4k remains: either cap-sized allocation below fits on
-    # its own, but the two together overspend — exactly the race window.
-    for i in range(2):
-        _preexisting_agent(
-            agent_store, uid, float(MAX_AGENT_CASH_ALLOCATION), name=f"Drain{i}"
-        )
+    # Starters hold $3k. Drain one more max sleeve so $4k remains: either
+    # cap-sized allocation below fits on its own, but the two together overspend.
+    _preexisting_agent(
+        agent_store, uid, float(MAX_AGENT_CASH_ALLOCATION), name="Drain"
+    )
     agents = [
         _preexisting_agent(agent_store, uid, 0.0, name=f"Race{i}") for i in range(2)
     ]
@@ -556,5 +566,5 @@ def test_service_serialises_concurrent_allocations_for_one_user(env, monkeypatch
         for a in agent_store.list_agents(owner_user_id=uid)
     )
     assert len(rejected) == 1, f"expected one rejection, got {rejected}"
-    expected = 3 * float(MAX_AGENT_CASH_ALLOCATION)
+    expected = STARTER_ALLOCATED + 2 * float(MAX_AGENT_CASH_ALLOCATION)
     assert total == expected, f"over-allocated: {total} against a 10000 account"

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -13,7 +13,7 @@
          because every API call is a CORS request. -->
     <link rel="preconnect" href="https://agentictrading.onrender.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css?v=128">
+    <link rel="stylesheet" href="styles.css?v=130">
     <!-- defer: ~200KB that was render-blocking. Deferred scripts execute in
          document order (this one first, the body-end ones after), all before
          DOMContentLoaded, so Chart is defined before any chart renders. -->
@@ -961,21 +961,21 @@
                     </div>
                 </div>
                 <div id="agentsCategories">
-                    <section class="agents-category" data-category="stocks">
+                    <section class="agents-category" data-category="prompted">
                         <div class="agents-category-head">
                             <div class="agents-category-heading">
                                 <span class="agents-category-icon" aria-hidden="true">
-                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="m19 9-5 5-4-4-3 3"/></svg>
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>
                                 </span>
-                                <h3 class="agents-category-title">Stocks</h3>
-                                <span id="agentsCountStocks" class="agents-category-count" hidden></span>
+                                <h3 class="agents-category-title">Prompted Models</h3>
+                                <span id="agentsCountPrompted" class="agents-category-count" hidden></span>
                             </div>
-                            <p class="agents-category-sub">Trade U.S. blue-chip and Chinese A-share stocks, tested hour by hour on real market data.</p>
+                            <p class="agents-category-sub">Write a trading instruction for an AI model and backtest it on market data.</p>
                             <!-- Filled by renderAgentMarketChips(); the chips ride
                                  #agentsCategories' delegated click handler. -->
                             <div id="agentsMarketChips" class="marketplace-category-chips agents-market-chips" role="group" aria-label="Filter by market"></div>
                         </div>
-                        <div id="agentsGridStocks" class="agents-grid">
+                        <div id="agentsGridPrompted" class="agents-grid">
                             <!-- Loading skeletons: visible pre-JS and while the first
                                  agents fetch runs. No removal code needed — every render
                                  path overwrites this grid's innerHTML (pinned by
@@ -984,8 +984,25 @@
                             <div class="section-card agent-card agent-card--skeleton" aria-hidden="true"></div>
                             <div class="section-card agent-card agent-card--skeleton" aria-hidden="true"></div>
                         </div>
-                        <div id="agentsGridFooterStocks" class="agents-grid-footer" hidden></div>
-                        <p id="agentsEmptyStocks" class="control-helper" hidden>You don't have any agents yet. Create one and test your first trading idea.</p>
+                        <div id="agentsGridFooterPrompted" class="agents-grid-footer" hidden></div>
+                        <p id="agentsEmptyPrompted" class="control-helper" hidden>You don't have any agents yet. Create one and test your first trading idea.</p>
+                    </section>
+                    <section class="agents-category" data-category="open">
+                        <div class="agents-category-head">
+                            <div class="agents-category-heading">
+                                <span class="agents-category-icon" aria-hidden="true">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2 2 7l10 5 10-5-10-5Z"/><path d="m2 17 10 5 10-5"/><path d="m2 12 10 5 10-5"/></svg>
+                                </span>
+                                <h3 class="agents-category-title">Open Agents</h3>
+                                <span id="agentsCountOpen" class="agents-category-count" hidden></span>
+                            </div>
+                            <p class="agents-category-sub">Open-source trading agents like AI Hedge Fund. Add them from Community, then customize and backtest.</p>
+                        </div>
+                        <div id="agentsGridOpen" class="agents-grid">
+                            <div class="section-card agent-card agent-card--skeleton" aria-hidden="true"></div>
+                        </div>
+                        <div id="agentsGridFooterOpen" class="agents-grid-footer" hidden></div>
+                        <p id="agentsEmptyOpen" class="control-helper" hidden>No open agents yet. Add a ready-made strategy like AI Hedge Fund from Community.</p>
                     </section>
                     <!-- Locked shelves. Crypto is a display-only price ticker
                          (quotes.py, never wired to the engine) and futures exist
@@ -2461,9 +2478,9 @@
     <script src="market-events/MarketEventFeed.js" defer></script>
     <script src="js/portfolio.js?v=17" defer></script>
     <script src="js/backtest-comparison.js?v=1" defer></script>
-    <script src="app.js?v=119" defer></script>
+    <script src="app.js?v=123" defer></script>
     <script src="js/analytics.js?v=1" defer></script>
-    <script src="js/agent-editor.js?v=28" defer></script>
+    <script src="js/agent-editor.js?v=30" defer></script>
     <script src="js/credit-format.js?v=1" defer></script>
     <script src="js/credits.js?v=8" defer></script>
     <script src="js/admin-model-providers.js?v=1" defer></script>

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -209,7 +209,27 @@ function setDefaultAgentId(agentId) {
 }
 
 const DEFAULT_AGENT_PROVISION_GUARD_PREFIX = 'default-agent-provisioned:';
+const STARTER_AGENTS = [
+  {
+    name: 'DeepSeek V4 Pro',
+    model_name: 'deepseek/deepseek-v4-pro',
+    description: 'A DeepSeek V4 Pro starter — open it to edit the trading instruction and run a backtest.',
+  },
+  {
+    name: 'GPT-5.5',
+    model_name: 'openai/gpt-5.5',
+    description: 'A GPT-5.5 starter — open it to edit the trading instruction and run a backtest.',
+  },
+  {
+    name: 'Claude Sonnet 4.6',
+    model_name: 'anthropic/claude-sonnet-4-6',
+    description: 'A Claude Sonnet 4.6 starter — open it to edit the trading instruction and run a backtest.',
+  },
+];
 const DEFAULT_FOUNDATION_MODEL = 'deepseek/deepseek-v4-pro';
+const DEFAULT_STARTER_AGENT_NAME = 'DeepSeek V4 Pro';
+const DEFAULT_STARTER_AGENT_DESCRIPTION =
+  'A DeepSeek V4 Pro starter — open it to edit the trading instruction and run a backtest.';
 const SIMPLE_INSTRUCTION_PRESET_KEY = 'simple_instruction';
 const SIMPLE_INSTRUCTION_OUTPUT_FORMAT =
   'JSON: { "orders": [{ "symbol": "...", "side": "buy|sell|hold", "qty": number, "order_type": "market|limit", "limit_price": number|null, "reason": "..." }] }';
@@ -230,10 +250,16 @@ window.DEFAULT_STARTER_INSTRUCTION = DEFAULT_STARTER_INSTRUCTION;
 function defaultAgentProvisionGuardKey() {
   // Prefer the signed-in account so a brand-new user on a browser that already
   // provisioned (or deleted) a guest starter still gets their own default.
-  // Guests keep the browser-scoped key so logout→login claim can find it.
+  // Include created_at: local SQLite (and Render's ephemeral disk) recycle
+  // user ids, so `u:1` from a wiped DB would skip provisioning for the next
+  // account that lands on id 1. Guests keep the browser-scoped key so
+  // logout→login claim can find it.
   const user = typeof getStoredAuthUser === 'function' ? getStoredAuthUser() : null;
   if (user?.id != null) {
-    return `${DEFAULT_AGENT_PROVISION_GUARD_PREFIX}u:${user.id}`;
+    const created = String(user.created_at || '').trim();
+    return created
+      ? `${DEFAULT_AGENT_PROVISION_GUARD_PREFIX}u:${user.id}:${created}`
+      : `${DEFAULT_AGENT_PROVISION_GUARD_PREFIX}u:${user.id}`;
   }
   return `${DEFAULT_AGENT_PROVISION_GUARD_PREFIX}b:${window.BROWSER_OWNER_ID || 'anon'}`;
 }
@@ -478,14 +504,15 @@ const AGENT_GRID_PAGE_SIZE = 5;
 const LEGACY_RUNTIME_MARKET = { ai_hedge_fund: 'us_stocks' };
 
 /** Category slug -> market display name. The single place these strings are
- * written: the Stocks shelf's market chips, the Community category chips, the
- * agent-card submeta and the Configure picker all read this map, so renaming a
- * market is one edit. Key order is chip order and mirrors the AgentCategory
- * Literal's declaration order in dashboard/backend/domain/agents/taxonomy.py.
+ * written: the Prompted Models shelf's market chips, the Community category
+ * chips, the agent-card submeta and the Configure picker all read this map, so
+ * renaming a market is one edit. Key order is chip order and mirrors the
+ * AgentCategory Literal's declaration order in
+ * dashboard/backend/domain/agents/taxonomy.py.
  *
- * Markets, not asset classes: My Agents shelves by what an agent trades, and
- * Stocks is the only asset class the engine can backtest, so both entries here
- * live under it. */
+ * Markets, not asset classes: Prompted Models still filters by what an agent
+ * trades, and equities are the only asset class the engine can backtest, so
+ * both entries here live under that shelf. */
 const MARKET_LABELS = {
   us_stocks: 'U.S.',
   cn_ashares: 'China A-Share',
@@ -548,8 +575,10 @@ function populateSupportedModelSelects() {
 // renderAgentCategories' "some grid is missing" guard, silently aborting the
 // entire My Agents render. Their order is their order in app.html.
 const AGENT_SHELVES = [
-  { key: 'stocks', title: 'Stocks',
-    match: (a) => agentShelfKey(a) === 'stocks' },
+  { key: 'prompted', title: 'Prompted Models',
+    match: (a) => agentShelfKey(a) === 'prompted' },
+  { key: 'open', title: 'Open Agents',
+    match: (a) => agentShelfKey(a) === 'open' },
   { key: 'external', title: 'For Developers: Connected Agents',
     match: (a) => agentShelfKey(a) === 'external' },
 ];
@@ -557,29 +586,34 @@ const AGENT_SHELVES = [
 /** The single shelf an agent renders under. Exactly one value per agent, so no
  * agent can be double-counted or dropped off every shelf.
  *
- * Stocks is the only asset class the backtest engine supports (every entry in
- * the backend's _MARKET_PROFILES is equities), so every built-in lands there
- * regardless of category, and connected agents split off by `agent_type`. The
- * market an agent trades is a separate axis -- see agentMarketKey. */
+ * Built-ins split on how they decide: a prompt-and-model pipeline lands on
+ * Prompted Models; a hosted runtime (AI Hedge Fund today) lands on Open
+ * Agents. Connected agents split off by `agent_type`. The market an agent
+ * trades is a separate axis -- see agentMarketKey.
+ *
+ * runtime_type is always present and truthy (server-defaulted to 'pipeline'),
+ * so the hosted check MUST be an inequality against 'pipeline', never a
+ * truthiness test. */
 function agentShelfKey(agent) {
   if (!agent || agent.agent_type !== 'builtin') return 'external';
-  return 'stocks';
+  if ((agent.runtime_type || 'pipeline') !== 'pipeline') return 'open';
+  return 'prompted';
 }
 
 /** Market a built-in agent trades, or '' when the platform genuinely doesn't
  * know -- a NULL/blank category, or a slug from a newer or older backend.
  *
- * '' is not a bug and must never hide the agent: those agents stay on Stocks
- * under the All chip and are excluded only by an explicit market filter, which
- * is the honest outcome when the market is unknown. */
+ * '' is not a bug and must never hide the agent: those agents stay on
+ * Prompted Models under the All chip and are excluded only by an explicit
+ * market filter, which is the honest outcome when the market is unknown. */
 function agentMarketKey(agent) {
   const slug = String(agent?.category || '').trim().toLowerCase();
   if (MARKET_LABELS[slug]) return slug;
   return LEGACY_RUNTIME_MARKET[String(agent?.runtime_type || '').trim().toLowerCase()] || '';
 }
 
-/** 'all' or one of MARKET_LABELS' keys. Narrows the Stocks shelf's grid only --
- * never its count pill, which reports what the shelf holds. */
+/** 'all' or one of MARKET_LABELS' keys. Narrows the Prompted Models shelf's
+ * grid only -- never its count pill, which reports what the shelf holds. */
 let agentMarketFilter = 'all';
 
 /** 'us_stocks' -> 'UsStocks' -- app.html's per-shelf element id suffix (agentsGrid<Suffix> etc). */
@@ -786,6 +820,8 @@ function formatAgentModelLabel(modelName) {
     'claude-sonnet-4.6': 'Claude Sonnet 4.6',
     'gpt-5.5': 'GPT-5.5',
     'openai/gpt-5.5': 'GPT-5.5',
+    'deepseek/deepseek-v4-pro': 'DeepSeek V4 Pro',
+    'deepseek-v4-pro': 'DeepSeek V4 Pro',
     'local-model': 'Local model',
     'rule-based': 'Rule-based',
     'rule-based-demo': 'Rule-based',
@@ -802,6 +838,30 @@ function formatAgentModelLabel(modelName) {
   label = label.replace(/[-_]+/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
   label = label.replace(/\b(\d)\s+(\d)\b/g, '$1.$2');
   return label;
+}
+
+function catalogModelLabels() {
+  return new Set([
+    ...SUPPORTED_MODELS.map((model) => model.label),
+    ...STARTER_AGENTS.map((spec) => spec.name),
+  ]);
+}
+
+/** Card/editor title for a prompted-model agent.
+
+ * If the stored name is already a catalog model label (or empty), it is bound
+ * to the current model — so a Claude card cannot keep showing "DeepSeek V4 Pro"
+ * after the model field moved. Custom titles ("My dip buyer") stay as stored.
+ */
+function agentDisplayName(agent) {
+  const stored = String(agent?.name || '').trim();
+  if ((agent?.agent_type || '') !== 'builtin') return stored || 'Agent';
+  if ((agent?.runtime_type || 'pipeline') !== 'pipeline') return stored || 'Agent';
+  const modelLabel = formatAgentModelLabel(agent?.model_name);
+  if (!stored || stored === modelLabel || catalogModelLabels().has(stored)) {
+    return modelLabel;
+  }
+  return stored;
 }
 
 function agentRobotIcon() {
@@ -1415,7 +1475,7 @@ function renderAgentCards(grid, agents, categoryKey) {
     card.setAttribute('data-agent-id', agent.agent_id);
     const model = formatAgentModelLabel(agent.model_name);
     const type = agentTypeLabel(agent);
-    // Under the All chip the Stocks shelf mixes markets, so the card has to
+    // Under the All chip Prompted Models mixes markets, so the card has to
     // say which. Omitted rather than guessed when agentMarketKey returns ''.
     const market = MARKET_LABELS[agentMarketKey(agent)];
     const submeta = `${model} · ${type}${market ? ` · ${market}` : ''}`;
@@ -1427,7 +1487,7 @@ function renderAgentCards(grid, agents, categoryKey) {
         <div class="agent-card-identity">
           ${agentRobotIcon()}
           <div class="agent-card-identity-text">
-            <h3 class="agent-name">${escapeHtml(agent.name)}${agent.agent_id === defaultId ? ' <span class="agent-default-badge">Default</span>' : ''}</h3>
+            <h3 class="agent-name">${escapeHtml(agentDisplayName(agent))}${agent.agent_id === defaultId ? ' <span class="agent-default-badge">Default</span>' : ''}</h3>
             <p class="agent-card-submeta" title="${escapeHtml(submeta)}">${escapeHtml(submeta)}</p>
           </div>
         </div>
@@ -1436,6 +1496,23 @@ function renderAgentCards(grid, agents, categoryKey) {
       ${running ? renderAgentRunningBody(agent, running) : renderAgentCardBody(agent, statusBadge.key)}
       ${running ? renderAgentRunningActions(agent) : renderAgentCardActions(agent, statusBadge.key)}
     `;
+    const identity = card.querySelector('.agent-card-identity');
+    if (identity) {
+      identity.setAttribute('role', 'button');
+      identity.setAttribute('tabindex', '0');
+      identity.setAttribute('title', 'Open to edit instructions');
+      const openEditor = (event) => {
+        event.preventDefault();
+        if (!window.AgentEditor) return;
+        navigateToPage('playground', { playgroundTab: 'agents' });
+        showPlaygroundPanel('agents');
+        window.AgentEditor.open(agent);
+      };
+      identity.addEventListener('click', openEditor);
+      identity.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') openEditor(event);
+      });
+    }
     grid.appendChild(card);
   });
 
@@ -1543,23 +1620,28 @@ function renderAgentCards(grid, agents, categoryKey) {
   });
 }
 
-// Empty-state HTML for the Stocks shelf. Three cases, deliberately worded
-// apart: a live search hiding everything, a market chip with nothing on it yet,
-// and a genuinely empty shelf. Collapsing them would tell a searching or
-// filtering user they own no agents. Stocks is also the onboarding surface (it
-// inherited that role from the retired Prompting LLMs shelf), so the true-empty
+// Empty-state HTML for the Prompted Models shelf. Three cases, deliberately
+// worded apart: a live search hiding everything, a market chip with nothing on
+// it yet, and a genuinely empty shelf. Collapsing them would tell a searching
+// or filtering user they own no agents. Prompted Models is the onboarding
+// surface (the auto-provisioned DeepSeek card lands here), so the true-empty
 // case keeps the create-your-first voice rather than the Community-upsell voice
-// the old market shelves used.
+// used by Open Agents.
 //
 // External renders a placeholder CARD instead (renderExternalPlaceholderCard),
 // so it has no entry here.
-function stocksEmptyHtml({ searching, marketFilter }) {
+function promptedEmptyHtml({ searching, marketFilter }) {
   if (searching) return 'No agents match your search.';
   if (marketFilter !== 'all') {
     const label = escapeHtml(MARKET_LABELS[marketFilter] || '');
     return `No ${label} agents yet. Add a ready-made ${label} strategy from ${communityShelfButtonHtml(marketFilter)}.`;
   }
   return `You don't have any agents yet. Create one and test your first trading idea, or browse ready-made strategies in ${communityShelfButtonHtml('all')}.`;
+}
+
+function openAgentsEmptyHtml({ searching }) {
+  if (searching) return 'No agents match your search.';
+  return `No open agents yet. Add a ready-made strategy like AI Hedge Fund from ${communityShelfButtonHtml('all')}.`;
 }
 
 // A real <button>, not an <a href="#">: this is the primary path off an empty
@@ -1574,9 +1656,9 @@ function communityShelfButtonHtml(category) {
   return `<button type="button" class="agents-empty-community-btn" data-community-category="${escapeHtml(category)}">Community</button>`;
 }
 
-/** The Stocks shelf's market filter row: 'All' plus one chip per MARKET_LABELS
- * entry, reusing the Community chip classes so the same taxonomy looks the same
- * on both surfaces.
+/** The Prompted Models shelf's market filter row: 'All' plus one chip per
+ * MARKET_LABELS entry, reusing the Community chip classes so the same taxonomy
+ * looks the same on both surfaces.
  *
  * Built once, then only toggled. This runs from renderAgentCategories, which is
  * bound to the search box's `input` event -- rebuilding innerHTML per keystroke
@@ -1649,7 +1731,7 @@ function renderAgentCategories(agents) {
     }
 
     let matched = pinDefaultFirst(agents.filter(shelf.match));
-    if (shelf.key === 'stocks' && agentMarketFilter !== 'all') {
+    if (shelf.key === 'prompted' && agentMarketFilter !== 'all') {
       // agentMarketKey returns '' for a NULL/blank/unknown category, so those
       // agents match no chip and appear under All only -- visible, but never
       // filed under a market the platform can't actually vouch for.
@@ -1675,7 +1757,9 @@ function renderAgentCategories(agents) {
     if (!emptyEl) return;
     emptyEl.hidden = matched.length > 0;
     if (matched.length === 0) {
-      emptyEl.innerHTML = stocksEmptyHtml({ searching, marketFilter: agentMarketFilter });
+      emptyEl.innerHTML = shelf.key === 'open'
+        ? openAgentsEmptyHtml({ searching })
+        : promptedEmptyHtml({ searching, marketFilter: agentMarketFilter });
     }
   });
 }
@@ -1759,7 +1843,7 @@ function populateBacktestAgentSelect() {
     .map((agent) => {
       const type = agent.agent_type === 'builtin' ? 'Built-in' : 'External';
       const model = agent.model_name || 'local-model';
-      const label = `${agent.name} · ${model} · ${type}`;
+      const label = `${agentDisplayName(agent)} · ${model} · ${type}`;
       return `<option value="${escapeHtml(agent.agent_id)}">${escapeHtml(label)}</option>`;
     })
     .join('');
@@ -1891,41 +1975,44 @@ async function onBacktestAgentSelectChange() {
   }
 }
 
-// First-visit onboarding: a brand-new owner gets one real Foundation agent so
-// the row is never empty. The guard key means "we provisioned once for this
-// identity" — deleting the agent must NOT resurrect it.
+// First-visit onboarding: a brand-new owner gets the Prompted Models starters
+// (DeepSeek V4 Pro, GPT-5.5, Claude Sonnet 4.6). The guard key means "we
+// provisioned the set for this identity" — deleting every starter must NOT
+// resurrect them. Missing models in a non-empty list are still filled so an
+// account that only received the original DeepSeek card gets the other two.
 let defaultAgentProvisionInFlight = null;
+
+function stampDefaultAgentProvisionGuard(agentId) {
+  try {
+    const guardKey = defaultAgentProvisionGuardKey();
+    if (!localStorage.getItem(guardKey)) {
+      localStorage.setItem(guardKey, agentId || '1');
+    }
+  } catch (e) {
+    /* storage unavailable — delete-guard simply won't persist */
+  }
+}
 
 async function ensureDefaultFoundationAgent(agents) {
   if (isDemoMode()) return false;
   const builtins = agents.filter((a) => a.agent_type === 'builtin');
-  if (builtins.length) {
+  const present = new Set(builtins.map((a) => String(a.model_name || '')));
+  const missing = STARTER_AGENTS.filter((spec) => !present.has(spec.model_name));
+  if (!missing.length) {
     // A builtin visible only via the unclaimed-browser-session fallback (#235)
     // is not proof claim-account actually landed — owner_user_id is still null
     // server-side. Stamping the guard against it would permanently mark this
-    // identity "onboarded" for an agent it may never end up owning. Still skip
-    // provisioning either way (never worth creating a duplicate starter), but
-    // only persist the guard once ownership is confirmed.
+    // identity "onboarded" for an agent it may never end up owning.
     const user = typeof getStoredAuthUser === 'function' ? getStoredAuthUser() : null;
     const owned = user?.id != null
       ? builtins.find((a) => a.owner_user_id === user.id)
       : builtins[0];
-    if (owned) {
-      try {
-        const guardKey = defaultAgentProvisionGuardKey();
-        if (!localStorage.getItem(guardKey)) {
-          localStorage.setItem(guardKey, owned.agent_id);
-        }
-      } catch (e) {
-        /* storage unavailable — delete-guard simply won't persist */
-      }
-    }
+    if (owned) stampDefaultAgentProvisionGuard(owned.agent_id);
     return false;
   }
-  const guardKey = defaultAgentProvisionGuardKey();
-  if (hasDefaultAgentProvisionGuard()) return false;
+  if (!builtins.length && hasDefaultAgentProvisionGuard()) return false;
   if (defaultAgentProvisionInFlight) {
-    // Another loadAgents is already creating the starter — wait for it so a
+    // Another loadAgents is already creating starters — wait for it so a
     // signup race does not skip provisioning and leave My Agents empty.
     try {
       return await defaultAgentProvisionInFlight;
@@ -1934,36 +2021,68 @@ async function ensureDefaultFoundationAgent(agents) {
     }
   }
   defaultAgentProvisionInFlight = (async () => {
-    try {
-      const data = await API.post(`${API_BASE}/api/v1/agents`, {
-        name: 'My Trading Agent',
-        model_name: DEFAULT_FOUNDATION_MODEL,
-        agent_type: 'builtin',
-        description: 'Your starter agent — configure it and run a backtest.',
-        cash_allocation: DEFAULT_AGENT_CASH_ALLOCATION,
-      });
-      const agent = data?.agent;
-      if (!agent?.agent_id) return false;
-      localStorage.setItem(guardKey, agent.agent_id);
-      // The starter instruction is seeded server-side by AgentService.create_agent
-      // for every builtin agent. It used to be a follow-up PATCH from here, which
-      // failed silently in prod for months (PATCH was missing from the CORS
-      // allow_methods, so the preflight 400'd) and left every default agent with
-      // an empty pipeline. Seeding in the same call that creates the row means it
-      // cannot half-succeed.
-      if (!getDefaultAgentId()) setDefaultAgentId(agent.agent_id);
-      return true;
-    } catch (error) {
-      // Non-fatal: the row falls back to its empty state with the Add Agent CTA.
-      console.warn('Default agent provisioning skipped:', error.message);
-      return false;
+    let createdAny = false;
+    let firstId = null;
+    for (const spec of missing) {
+      try {
+        const data = await API.post(`${API_BASE}/api/v1/agents`, {
+          name: spec.name,
+          model_name: spec.model_name,
+          agent_type: 'builtin',
+          description: spec.description,
+          cash_allocation: DEFAULT_AGENT_CASH_ALLOCATION,
+        });
+        const agent = data?.agent;
+        if (!agent?.agent_id) continue;
+        createdAny = true;
+        firstId = firstId || agent.agent_id;
+        // The starter instruction is seeded server-side by AgentService.create_agent
+        // for every builtin agent. It used to be a follow-up PATCH from here, which
+        // failed silently in prod for months (PATCH was missing from the CORS
+        // allow_methods, so the preflight 400'd) and left every default agent with
+        // an empty pipeline. Seeding in the same call that creates the row means it
+        // cannot half-succeed.
+      } catch (error) {
+        // Non-fatal: the row falls back to its empty state with the Add Agent CTA.
+        console.warn('Default agent provisioning skipped:', error.message);
+      }
     }
+    if (createdAny) {
+      stampDefaultAgentProvisionGuard(firstId);
+      if (!getDefaultAgentId()) setDefaultAgentId(firstId);
+    }
+    return createdAny;
   })();
   try {
     return await defaultAgentProvisionInFlight;
   } finally {
     defaultAgentProvisionInFlight = null;
   }
+}
+
+async function alignStarterAgentNames(agents) {
+  // Persist the card-title binding: a Claude starter whose stored name is
+  // still "DeepSeek V4 Pro" (model changed, or a copy) is rewritten so the
+  // editor and the grid cannot disagree after the next fetch.
+  if (isDemoMode() || !Array.isArray(agents) || !agents.length) return false;
+  let changed = false;
+  for (const agent of agents) {
+    if ((agent.agent_type || '') !== 'builtin') continue;
+    if ((agent.runtime_type || 'pipeline') !== 'pipeline') continue;
+    const nextName = agentDisplayName(agent);
+    if (!nextName || nextName === String(agent.name || '').trim()) continue;
+    try {
+      await API.patch(
+        `${API_BASE}/api/v1/agents/${encodeURIComponent(agent.agent_id)}`,
+        { name: nextName },
+      );
+      agent.name = nextName;
+      changed = true;
+    } catch (error) {
+      console.warn('Starter name align skipped:', error.message);
+    }
+  }
+  return changed;
 }
 
 // Auth boot gate: nav goes live before the boot's auth awaits, so a My Agents
@@ -2046,6 +2165,7 @@ async function loadAgentsNow() {
         console.warn('Refresh after default-agent provisioning failed:', refreshError.message);
       }
     }
+    await alignStarterAgentNames(agents);
 
     allAgents = agents;
     applyAgentFilters();
@@ -2081,8 +2201,8 @@ async function loadAgentsNow() {
 let marketplaceTemplates = [];
 let marketplaceCloneInFlight = false;
 let marketplaceLoadInFlight = null;
-/** 'all' or one of MARKET_LABELS' keys. Set by the chip row and by the Stocks
- * shelf's empty-state Community button (via navigateToPage's options). */
+/** 'all' or one of MARKET_LABELS' keys. Set by the chip row and by the Prompted
+ * Models shelf's empty-state Community button (via navigateToPage's options). */
 let marketplaceCategoryFilter = 'all';
 
 /** 'all' or one of MODEL_VENDORS' keys. ANDs with marketplaceCategoryFilter. */
@@ -2173,7 +2293,7 @@ function setMarketplaceVendorFilter(vendorKey) {
 /** Chip row above the marketplace grid: 'All' plus one chip per market, built
  * from MARKET_LABELS rather than a second hardcoded list. Built from the label
  * map rather than AGENT_SHELVES because Community filters templates by
- * *market*, and there is now one Stocks shelf holding both markets -- the shelf
+ * *market*, and Prompted Models holds both markets -- the shelf
  * list and the chip list are different things. */
 function renderMarketplaceCategoryChips() {
   const container = document.getElementById('marketplaceCategoryChips');
@@ -2232,7 +2352,7 @@ function renderMarketplaceVendorChips() {
 }
 
 /** Empty-state copy. Three cases, deliberately worded apart -- the same concern
- * stocksEmptyHtml records for My Agents.
+ * promptedEmptyHtml records for My Agents.
  *
  * A typed query wins over the facet case: when a search is what emptied the
  * grid, offering "Clear filters" sends the user to fix the wrong thing. */

--- a/dashboard/frontend/js/agent-editor.js
+++ b/dashboard/frontend/js/agent-editor.js
@@ -795,7 +795,7 @@
     // "" is a real, saveable choice, not a placeholder: the backend folds an
     // empty string to NULL, which un-shelves the agent. It is listed first so
     // an agent that has never been categorized shows its actual state.
-    const options = [['', 'Not set (shows under Prompting LLMs)']].concat(
+    const options = [['', 'Not set (visible under All)']].concat(
       Object.keys(labels).map((slug) => [slug, labels[slug]]),
     );
     select.innerHTML = '';
@@ -889,7 +889,9 @@
     const liveToggle = document.getElementById('agentEditorLiveTradingEnabled');
     const credentialInput = document.getElementById('agentEditorFinancialDatasetsKey');
     return {
-      name: nameInput ? nameInput.value.trim() : '',
+      name: nameFollowsModel(currentAgent)
+        ? selectedModelLabel()
+        : (nameInput ? nameInput.value.trim() : ''),
       description: descInput ? descInput.value.trim() : '',
       category,
       cash_allocation,
@@ -1041,6 +1043,55 @@
       select.insertBefore(opt, select.firstChild);
     }
     select.value = current;
+  }
+
+  function selectedModelLabel() {
+    const select = document.getElementById('agentEditorModelSelect');
+    const opt = select?.selectedOptions?.[0];
+    const fromOption = opt?.textContent?.trim();
+    if (fromOption) return fromOption;
+    const value = select?.value || currentAgent?.model_name || '';
+    if (typeof window.formatAgentModelLabel === 'function') {
+      return window.formatAgentModelLabel(value);
+    }
+    return value;
+  }
+
+  function catalogModelLabels() {
+    const select = document.getElementById('agentEditorModelSelect');
+    return new Set(
+      Array.from(select?.options || [])
+        .map((opt) => opt.textContent.trim())
+        .filter(Boolean),
+    );
+  }
+
+  function nameFollowsModel(agent) {
+    // Prompted-model cards whose title is already a model label stay locked to
+    // the dropdown: changing Model rewrites the name. Custom titles ("My dip
+    // buyer") stay editable. Hosted runtimes have no model picker.
+    if (isAiHedgeFundAgent(agent)) return false;
+    if ((agent?.agent_type || '') !== 'builtin') return false;
+    const name = String(agent?.name || '').trim();
+    if (!name) return true;
+    const label = selectedModelLabel();
+    if (name === label) return true;
+    return catalogModelLabels().has(name);
+  }
+
+  function syncBoundAgentName() {
+    const nameInput = document.getElementById('agentEditorNameInput');
+    if (!nameInput) return;
+    const bound = nameFollowsModel(currentAgent);
+    nameInput.readOnly = bound;
+    nameInput.tabIndex = bound ? -1 : 0;
+    nameInput.classList.toggle('agent-editor-name-input--bound', bound);
+    nameInput.setAttribute('aria-readonly', bound ? 'true' : 'false');
+    if (bound) {
+      const label = selectedModelLabel();
+      nameInput.value = label;
+      if (currentAgent) currentAgent.name = label;
+    }
   }
 
   function serializePipeline(steps) {
@@ -1234,6 +1285,7 @@
     fillHeader(agent);
     populateModelSelect(agent);
     configureEditorMode(agent);
+    syncBoundAgentName();
 
     const instructionEl = document.getElementById('agentEditorSimpleInstruction');
     const defaultText = document.getElementById('agentEditorDefaultInstructionText');
@@ -1263,7 +1315,11 @@
     // Baseline the stored state so the dirty badge only fires on real edits.
     captureSavedSnapshot();
 
-    document.getElementById('agentEditorNameInput')?.focus();
+    if (document.getElementById('agentEditorNameInput')?.readOnly) {
+      document.getElementById('agentEditorSimpleInstruction')?.focus();
+    } else {
+      document.getElementById('agentEditorNameInput')?.focus();
+    }
   }
 
   function close(force) {
@@ -1463,6 +1519,10 @@
     const body = document.getElementById('agentEditorView');
     body?.addEventListener('input', markDirtyFromInput);
     body?.addEventListener('change', markDirtyFromInput);
+    document.getElementById('agentEditorModelSelect')?.addEventListener('change', () => {
+      syncBoundAgentName();
+      markDirtyFromInput();
+    });
     document.querySelector('.agent-editor-body')?.addEventListener(
       'scroll',
       scheduleActiveAiHedgeFundTooltipPosition,

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -8964,6 +8964,19 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
     flex: 1;
 }
 
+.agent-card--status .agent-card-identity {
+    cursor: pointer;
+    border-radius: 8px;
+}
+.agent-card--status .agent-card-identity:hover .agent-name,
+.agent-card--status .agent-card-identity:focus-visible .agent-name {
+    color: var(--home-accent-cyan, #22d3ee);
+}
+.agent-card--status .agent-card-identity:focus-visible {
+    outline: 2px solid var(--home-accent-cyan, #22d3ee);
+    outline-offset: 2px;
+}
+
 .agent-card-icon {
     flex: 0 0 auto;
     display: inline-flex;
@@ -9884,6 +9897,20 @@ body.agent-editor-open {
     outline: none;
     border-color: rgba(34, 211, 238, 0.5);
     box-shadow: 0 0 0 2px rgba(34, 211, 238, 0.12);
+}
+
+.agent-editor-name-input--bound,
+.agent-editor-name-input:read-only {
+    border-color: transparent;
+    background: transparent;
+    padding-left: 0;
+    cursor: default;
+}
+
+.agent-editor-name-input--bound:focus,
+.agent-editor-name-input:read-only:focus {
+    border-color: transparent;
+    box-shadow: none;
 }
 
 .agent-editor-description {


### PR DESCRIPTION
## Summary
- Split My Agents into **Prompted Models** (instruction/pipeline agents) and **Open Agents** (hosted runtimes such as AI Hedge Fund).
- New accounts get three starter cards — DeepSeek V4 Pro, GPT-5.5, and Claude Sonnet 4.6 — provisioned on signup so a stale browser guard cannot leave the shelf empty. Prompted-model titles stay locked to the selected model.
- Prompted Models subtitle now says "market data" rather than "real market data".

## Test plan
- [ ] Sign up a new account and confirm Prompted Models shows DeepSeek V4 Pro, GPT-5.5, and Claude Sonnet 4.6 (not the empty state).
- [ ] Open the Claude card: title and Model dropdown both say Claude Sonnet 4.6; changing Model updates the title.
- [ ] Confirm Open Agents is a separate shelf (AI Hedge Fund clones land there, not under Prompted Models).
- [ ] Hard-refresh an account that already had only DeepSeek and confirm GPT-5.5 and Claude cards appear with matching titles.
- [ ] `pytest dashboard/backend/tests/test_frontend_shelves.py dashboard/backend/tests/test_agent_starter_defaults.py dashboard/backend/tests/test_auth.py::test_signup_login_me_logout_flow -q`


Made with [Cursor](https://cursor.com)