### PR TITLE
ux(agents): rename Prompted Models to LLMs and drop card submeta noise

### DIFF
--- a/dashboard/backend/tests/test_admin_analytics_frontend.py
+++ b/dashboard/backend/tests/test_admin_analytics_frontend.py
@@ -191,7 +191,7 @@ def test_app_lifecycle_and_cache_versions_are_wired():
     assert "window.AdminAnalytics.onEnter()" in APP_JS
     assert "window.AdminAnalytics.refresh()" in APP_JS
     assert 'styles.css?v=130' in APP_HTML
-    assert 'app.js?v=123' in APP_HTML
+    assert 'app.js?v=124' in APP_HTML
     assert 'js/admin-analytics.js?v=2' in APP_HTML
     assert 'js/admin-tabs.js?v=3' in APP_HTML
 

--- a/dashboard/backend/tests/test_ai_hedge_fund_frontend.py
+++ b/dashboard/backend/tests/test_ai_hedge_fund_frontend.py
@@ -192,7 +192,7 @@ def test_marketplace_cta_is_unified_add_to_my_agents():
 
 def test_hosted_agents_land_on_the_open_agents_shelf():
     """Hosted runtimes (AI Hedge Fund) render under Open Agents, not mixed
-    into Prompted Models. Shelves still resolve through one function, so no
+    into LLMs. Shelves still resolve through one function, so no
     predicate can double-count or drop an agent.
 
     runtime_type is always present and truthy (server-defaulted to 'pipeline'),
@@ -200,7 +200,7 @@ def test_hosted_agents_land_on_the_open_agents_shelf():
     """
     assert "Foundation Agents" not in _APP_HTML
     assert ">Open Agents</h3>" in _APP_HTML
-    assert ">Prompted Models</h3>" in _APP_HTML
+    assert ">LLMs</h3>" in _APP_HTML
     assert ">Prompting LLMs</h3>" not in _APP_HTML
     assert ">U.S. Stock Trading</h3>" not in _APP_HTML
     assert ">Stocks</h3>" not in _APP_HTML

--- a/dashboard/backend/tests/test_analytics_frontend.py
+++ b/dashboard/backend/tests/test_analytics_frontend.py
@@ -41,7 +41,7 @@ def _function_body(source: str, signature: str) -> str:
 
 
 def test_analytics_script_loads_between_app_and_page_scripts():
-    app_at = APP_HTML.index('<script src="app.js?v=123" defer></script>')
+    app_at = APP_HTML.index('<script src="app.js?v=124" defer></script>')
     analytics_at = APP_HTML.index(
         '<script src="js/analytics.js?v=1" defer></script>'
     )

--- a/dashboard/backend/tests/test_backtest_comparison_frontend.py
+++ b/dashboard/backend/tests/test_backtest_comparison_frontend.py
@@ -191,7 +191,7 @@ def test_exact_raw_ties_mark_every_tied_series_best():
 
 def test_comparison_script_and_semantic_table_ship_before_app():
     helper = '<script src="js/backtest-comparison.js?v=1" defer></script>'
-    app = '<script src="app.js?v=123" defer></script>'
+    app = '<script src="app.js?v=124" defer></script>'
     assert 'href="styles.css?v=130"' in APP_HTML
     assert APP_HTML.index(helper) < APP_HTML.index(app)
     for element_id in (

--- a/dashboard/backend/tests/test_frontend_fast_boot.py
+++ b/dashboard/backend/tests/test_frontend_fast_boot.py
@@ -191,7 +191,7 @@ def test_cache_busters_bumped():
     # the next bump, so the exact one looks like the broken guard and gets
     # "fixed" by loosening it. That collision has already cost this repo one
     # round of follow-ups (#347/#348).
-    assert "app.js?v=123" in APP_HTML
+    assert "app.js?v=124" in APP_HTML
     assert "js/agent-editor.js?v=30" in APP_HTML
     assert "styles.css?v=130" in APP_HTML
     assert "js/leaderboard.js?v=32" in APP_HTML

--- a/dashboard/backend/tests/test_frontend_shelves.py
+++ b/dashboard/backend/tests/test_frontend_shelves.py
@@ -4,7 +4,7 @@ My Agents used to split agents into two buckets: "Foundation Agents" (whose
 subtitle called the product "A prompting game", the #1 trust-killer in every
 persona walkthrough) and "External Agents". Asset-class shelves (Stocks /
 Crypto / Futures) replaced that, then this task split the live Stocks row into
-**Prompted Models** (pipeline / instruction agents) and **Open Agents** (hosted
+**LLMs** (pipeline / instruction agents) and **Open Agents** (hosted
 runtimes such as AI Hedge Fund), keeping the locked Crypto/Futures rows and
 the developer Connected Agents shelf. None of this is enforceable at runtime
 -- app.html has no JS test harness -- so, per this suite's frontend convention
@@ -32,7 +32,7 @@ _HTML = _strip_html_comments(APP_HTML)
 
 _LIVE_SHELVES = [
     (
-        "Prompted Models",
+        "LLMs",
         "Write a trading instruction for an AI model and backtest it on market data.",
     ),
     (
@@ -60,6 +60,7 @@ _LOCKED_SHELVES = [
 
 _RETIRED_SECTION_HEADERS = (
     "Prompting LLMs",
+    "Prompted Models",
     "U.S. Stock Trading",
     "China A-Share Trading",
     "Stocks",
@@ -196,6 +197,8 @@ def test_agent_shelves_config_holds_only_the_live_shelves():
     config = js_const("AGENT_SHELVES")
     for key in ("prompted", "open", "external"):
         assert f"key: '{key}'" in config, key
+    assert "title: 'LLMs'" in config
+    assert "title: 'Prompted Models'" not in config
     for absent in ("stocks", "crypto", "futures", "prompting_llms", "us_stocks", "cn_ashares"):
         assert f"key: '{absent}'" not in config, absent
 
@@ -230,15 +233,18 @@ def test_market_labels_is_the_only_declaration_of_the_market_names():
     assert not re.search(r"(?<![A-Z_])SHELF_LABELS", _strip_js_comments(APP_JS))
 
 
-def test_card_submeta_carries_the_decision_axis_the_retired_shelf_used_to():
-    """"Prompting LLMs" is gone as a section, so the how-does-it-decide axis it
-    carried moves onto the card. 'Built-in'/'External' named the plumbing;
-    'Hosted AI'/'Your own code' names what the user actually gets.
+def test_my_agents_card_submeta_drops_duplicate_model_and_hosted_ai():
+    """The card <h3> already names the model. Repeating it on the submeta
+    line with 'Hosted AI' was noise. Market stays when known -- the All chip
+    still mixes U.S. and China A-Share on this shelf.
     """
-    body = _strip_js_comments(fn_body("function agentTypeLabel("))
-    assert "'Hosted AI'" in body
-    assert "'Your own code'" in body
-    assert "'Built-in'" not in body
+    body = _strip_js_comments(fn_body("function renderAgentCards("))
+    assert "agentTypeLabel" not in body
+    assert "Hosted AI" not in body
+    assert "Your own code" not in body
+    assert "formatAgentModelLabel(agent.model_name)" not in body
+    assert "MARKET_LABELS[agentMarketKey(agent)]" in body
+    assert "function agentTypeLabel(" not in APP_JS
 
 
 def test_render_marketplace_category_chips_is_built_from_the_shared_label_map():

--- a/dashboard/backend/tests/test_my_agents_card_ui.py
+++ b/dashboard/backend/tests/test_my_agents_card_ui.py
@@ -192,7 +192,8 @@ def test_submeta_stays_one_line_so_cards_in_a_row_align():
 
 
 def test_agent_card_submeta_exposes_full_line_on_hover():
-    """Ellipsis hides the tail; title keeps the full model · type · market."""
+    """When a market label is shown, title keeps the full string past ellipsis."""
     render = _extract_function(_APP_JS, "renderAgentCards")
     assert 'class="agent-card-submeta" title="' in render
     assert "overflow-wrap: anywhere" not in render
+    assert "Hosted AI" not in render

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -967,7 +967,7 @@
                                 <span class="agents-category-icon" aria-hidden="true">
                                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>
                                 </span>
-                                <h3 class="agents-category-title">Prompted Models</h3>
+                                <h3 class="agents-category-title">LLMs</h3>
                                 <span id="agentsCountPrompted" class="agents-category-count" hidden></span>
                             </div>
                             <p class="agents-category-sub">Write a trading instruction for an AI model and backtest it on market data.</p>
@@ -2478,7 +2478,7 @@
     <script src="market-events/MarketEventFeed.js" defer></script>
     <script src="js/portfolio.js?v=17" defer></script>
     <script src="js/backtest-comparison.js?v=1" defer></script>
-    <script src="app.js?v=123" defer></script>
+    <script src="app.js?v=124" defer></script>
     <script src="js/analytics.js?v=1" defer></script>
     <script src="js/agent-editor.js?v=30" defer></script>
     <script src="js/credit-format.js?v=1" defer></script>

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -575,7 +575,7 @@ function populateSupportedModelSelects() {
 // renderAgentCategories' "some grid is missing" guard, silently aborting the
 // entire My Agents render. Their order is their order in app.html.
 const AGENT_SHELVES = [
-  { key: 'prompted', title: 'Prompted Models',
+  { key: 'prompted', title: 'LLMs',
     match: (a) => agentShelfKey(a) === 'prompted' },
   { key: 'open', title: 'Open Agents',
     match: (a) => agentShelfKey(a) === 'open' },
@@ -799,14 +799,6 @@ function renderAgentSparkline(agent, positive = true, metrics = {}) {
   const values = resolveAgentSparklineValues(agent, metrics);
   const seed = agent?.agent_id || agent?.name || 'spark';
   return renderAgentSparklineFromValues(values, positive, seed);
-}
-
-/** How the agent decides, shown on the card submeta. This is the axis the
- * retired "Prompting LLMs" section used to carry: the platform runs hosted
- * models for built-ins, while a connected agent runs the user's own program.
- * 'Built-in'/'External' named the plumbing; these name what the user gets. */
-function agentTypeLabel(agent) {
-  return agent.agent_type === 'builtin' ? 'Hosted AI' : 'Your own code';
 }
 
 /** Human-readable model label from provider paths like anthropic/claude-haiku-4-5. */
@@ -1473,12 +1465,10 @@ function renderAgentCards(grid, agents, categoryKey) {
     const card = document.createElement('div');
     card.className = `section-card agent-card agent-card--status agent-card--${statusBadge.key}${isBuiltin ? ' agent-card-builtin' : ''}`;
     card.setAttribute('data-agent-id', agent.agent_id);
-    const model = formatAgentModelLabel(agent.model_name);
-    const type = agentTypeLabel(agent);
-    // Under the All chip Prompted Models mixes markets, so the card has to
-    // say which. Omitted rather than guessed when agentMarketKey returns ''.
+    // Title already names the model. Decision-type copy repeated it. Under
+    // the All chip this shelf still mixes markets, so keep that when known.
     const market = MARKET_LABELS[agentMarketKey(agent)];
-    const submeta = `${model} · ${type}${market ? ` · ${market}` : ''}`;
+    const submeta = market || '';
     const running = getAgentBacktestRunning(agent.agent_id);
     if (running) card.classList.add('agent-card--running');
 
@@ -1488,7 +1478,7 @@ function renderAgentCards(grid, agents, categoryKey) {
           ${agentRobotIcon()}
           <div class="agent-card-identity-text">
             <h3 class="agent-name">${escapeHtml(agentDisplayName(agent))}${agent.agent_id === defaultId ? ' <span class="agent-default-badge">Default</span>' : ''}</h3>
-            <p class="agent-card-submeta" title="${escapeHtml(submeta)}">${escapeHtml(submeta)}</p>
+            ${submeta ? `<p class="agent-card-submeta" title="${escapeHtml(submeta)}">${escapeHtml(submeta)}</p>` : ''}
           </div>
         </div>
         <span class="status-badge ${statusBadge.className}"><span class="status-badge-dot" aria-hidden="true"></span>${statusBadge.label}</span>


### PR DESCRIPTION
## Summary
- Rename the My Agents shelf heading from **Prompted Models** to **LLMs**.
- Drop the duplicate model name and "Hosted AI" line on agent cards; the title already names the model. Market stays on the card when known (All chip still mixes U.S. and China A-Share).
- Bump `app.js?v=` to 124 so returning browsers pick up the copy.

## Test plan
- [ ] Open My Agents and confirm the first shelf title is **LLMs**.
- [ ] Confirm starter cards (DeepSeek / GPT-5.5 / Claude) no longer show a small model name or "Hosted AI" under the title.
- [ ] If an agent has a known market, that market label still appears.
- [ ] Community cards and the Connected Agents placeholder are unchanged.


Made with [Cursor](https://cursor.com)