### PR TITLE
fix(backtest): accept empty pipeline orders as hold

### DIFF
--- a/dashboard/backend/infrastructure/llm/pipeline_runner.py
+++ b/dashboard/backend/infrastructure/llm/pipeline_runner.py
@@ -147,64 +147,95 @@ def pipeline_output_to_decision(parsed: Dict[str, Any]) -> Optional[Dict[str, An
     if not isinstance(parsed, dict):
         return None
 
+    saw_empty_envelope = False
+    saw_unusable_nonempty_envelope = False
+
     actions = parsed.get("actions")
-    if isinstance(actions, list) and actions:
-        return {"actions": actions}
+    if isinstance(actions, list):
+        if actions:
+            return {"actions": actions}
+        saw_empty_envelope = True
 
     orders = parsed.get("orders")
-    if isinstance(orders, list) and orders:
-        normalized = []
-        for order in orders:
-            if not isinstance(order, dict):
-                continue
-            side = str(order.get("side") or order.get("action") or "hold").lower()
-            if side not in ("buy", "sell", "hold"):
-                side = "hold"
-            qty = order.get("qty", order.get("quantity", order.get("position_size", 0)))
-            try:
-                position_size = int(qty)
-            except (TypeError, ValueError):
-                position_size = 0
-            normalized.append(
-                {
-                    "action": side,
-                    "symbol": order.get("symbol"),
-                    "confidence": float(order.get("confidence", 0.75) or 0.75),
-                    "reasoning": order.get("reason") or order.get("rationale") or "",
-                    "position_size": position_size,
-                    "stop_loss_price": order.get("stop_loss_price"),
-                    "take_profit_price": order.get("take_profit_price"),
-                }
-            )
-        if normalized:
-            return {"actions": normalized}
+    if isinstance(orders, list):
+        if not orders:
+            saw_empty_envelope = True
+        else:
+            normalized = []
+            for order in orders:
+                if not isinstance(order, dict):
+                    continue
+                side = str(order.get("side") or order.get("action") or "hold").lower()
+                if side not in ("buy", "sell", "hold"):
+                    side = "hold"
+                qty = order.get(
+                    "qty", order.get("quantity", order.get("position_size", 0))
+                )
+                try:
+                    position_size = int(qty)
+                except (TypeError, ValueError):
+                    position_size = 0
+                normalized.append(
+                    {
+                        "action": side,
+                        "symbol": order.get("symbol"),
+                        "confidence": float(order.get("confidence", 0.75) or 0.75),
+                        "reasoning": order.get("reason")
+                        or order.get("rationale")
+                        or "",
+                        "position_size": position_size,
+                        "stop_loss_price": order.get("stop_loss_price"),
+                        "take_profit_price": order.get("take_profit_price"),
+                    }
+                )
+            if normalized:
+                return {"actions": normalized}
+            saw_unusable_nonempty_envelope = True
 
     risk_actions = parsed.get("risk_actions")
-    if isinstance(risk_actions, list) and risk_actions:
-        normalized = []
-        for risk in risk_actions:
-            if not isinstance(risk, dict):
-                continue
-            action_type = str(risk.get("action") or "hold").lower()
-            if action_type in ("stop_loss", "take_profit", "trail"):
-                side = "sell"
-            elif action_type == "hold":
-                side = "hold"
-            else:
-                side = action_type if action_type in ("buy", "sell", "hold") else "hold"
-            size_pct = float(risk.get("size_pct", 1.0) or 1.0)
-            normalized.append(
-                {
-                    "action": side,
-                    "symbol": risk.get("symbol"),
-                    "confidence": 0.8,
-                    "reasoning": risk.get("reason") or risk.get("rationale") or action_type,
-                    "position_size": max(1, int(round(size_pct * 100))) if side == "sell" else 0,
-                }
-            )
-        if normalized:
-            return {"actions": normalized}
+    if isinstance(risk_actions, list):
+        if not risk_actions:
+            saw_empty_envelope = True
+        else:
+            normalized = []
+            for risk in risk_actions:
+                if not isinstance(risk, dict):
+                    continue
+                action_type = str(risk.get("action") or "hold").lower()
+                if action_type in ("stop_loss", "take_profit", "trail"):
+                    side = "sell"
+                elif action_type == "hold":
+                    side = "hold"
+                else:
+                    side = (
+                        action_type
+                        if action_type in ("buy", "sell", "hold")
+                        else "hold"
+                    )
+                size_pct = float(risk.get("size_pct", 1.0) or 1.0)
+                normalized.append(
+                    {
+                        "action": side,
+                        "symbol": risk.get("symbol"),
+                        "confidence": 0.8,
+                        "reasoning": risk.get("reason")
+                        or risk.get("rationale")
+                        or action_type,
+                        "position_size": (
+                            max(1, int(round(size_pct * 100)))
+                            if side == "sell"
+                            else 0
+                        ),
+                    }
+                )
+            if normalized:
+                return {"actions": normalized}
+            saw_unusable_nonempty_envelope = True
 
+    if saw_unusable_nonempty_envelope:
+        return None
+    if saw_empty_envelope:
+        return {"actions": []}
     return None
 
 

--- a/dashboard/backend/tests/backtesting/test_portfolio_manager_move.py
+++ b/dashboard/backend/tests/backtesting/test_portfolio_manager_move.py
@@ -321,6 +321,28 @@ def test_strict_llm_accepts_empty_actions_as_model_hold():
     assert pm.llm_decisions == 1
 
 
+def test_strict_pipeline_accepts_empty_orders_as_model_hold():
+    pm = CanonicalPortfolioManager(100000)
+    client = _FakeClient(_FakeResp('{"orders": []}', _FakeUsage(3, 2)))
+
+    result = pm.make_trading_decision_with_llm(
+        _llm_state(),
+        client,
+        pipeline=[
+            {
+                "label": "Trading instruction",
+                "prompt": "Return the orders for this bar.",
+                "outputFormat": '{"orders": []}',
+            }
+        ],
+        strict_llm=True,
+    )
+
+    assert result == {"actions": []}
+    assert pm.llm_calls == 1
+    assert pm.llm_decisions == 1
+
+
 @pytest.mark.parametrize(
     "action",
     [

--- a/dashboard/backend/tests/infrastructure/llm/test_pipeline_runner.py
+++ b/dashboard/backend/tests/infrastructure/llm/test_pipeline_runner.py
@@ -2,6 +2,8 @@
 
 from datetime import datetime
 
+import pytest
+
 from dashboard.backend.infrastructure.llm.pipeline_runner import (
     apply_prompt_patches,
     is_last_bar_of_trading_day,
@@ -15,6 +17,7 @@ from dashboard.backend.infrastructure.llm.pipeline_runner import (
 
 def test_pipeline_output_to_decision_orders():
     parsed = {
+        "actions": [],
         "orders": [
             {"symbol": "AAPL", "side": "buy", "qty": 10, "reason": "momentum"},
             {"symbol": "MSFT", "side": "hold", "qty": 0},
@@ -41,6 +44,56 @@ def test_pipeline_output_to_decision_actions_passthrough():
     }
     decision = pipeline_output_to_decision(parsed)
     assert decision == parsed
+
+
+def test_pipeline_output_to_decision_risk_actions():
+    decision = pipeline_output_to_decision(
+        {
+            "risk_actions": [
+                {
+                    "symbol": "AAPL",
+                    "action": "stop_loss",
+                    "size_pct": 0.5,
+                    "reason": "risk limit",
+                }
+            ]
+        }
+    )
+
+    assert decision is not None
+    assert decision["actions"] == [
+        {
+            "action": "sell",
+            "symbol": "AAPL",
+            "confidence": 0.8,
+            "reasoning": "risk limit",
+            "position_size": 50,
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "parsed",
+    [{"actions": []}, {"orders": []}, {"risk_actions": []}],
+)
+def test_pipeline_output_to_decision_empty_envelope_is_hold(parsed):
+    assert pipeline_output_to_decision(parsed) == {"actions": []}
+
+
+@pytest.mark.parametrize(
+    "parsed",
+    [
+        None,
+        {},
+        {"orders": None},
+        {"orders": "not-a-list"},
+        {"orders": ["not-an-order"]},
+        {"actions": [], "orders": ["not-an-order"]},
+        {"orders": [], "risk_actions": ["not-a-risk-action"]},
+    ],
+)
+def test_pipeline_output_to_decision_rejects_invalid_payload(parsed):
+    assert pipeline_output_to_decision(parsed) is None
 
 
 def test_build_step_prompt_includes_upstream_outputs():

--- a/docs/superpowers/plans/2026-08-29-pipeline-empty-orders-hold.md
+++ b/docs/superpowers/plans/2026-08-29-pipeline-empty-orders-hold.md
@@ -1,0 +1,279 @@
+# Pipeline Empty Orders Hold Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Treat explicitly empty pipeline decision envelopes as valid model-driven HOLD decisions without accepting malformed non-empty payloads.
+
+**Architecture:** Keep normalization at the existing `pipeline_output_to_decision()` boundary. Preserve non-empty envelope priority, distinguish empty supported lists from unusable non-empty lists, and return `{"actions": []}` only when no unusable non-empty list was seen. Verify the boundary with unit contracts and the strict pipeline path with a portfolio-manager integration test.
+
+**Tech Stack:** Python 3, pytest, existing hourly backtest pipeline and portfolio manager.
+
+**Spec:** `docs/superpowers/specs/2026-08-29-pipeline-empty-orders-hold-design.md`
+
+## Global Constraints
+
+- Support empty `actions`, `orders`, and `risk_actions` envelopes.
+- Preserve existing normalization and priority for non-empty envelopes.
+- Keep malformed, unsupported, incorrectly typed, and unusable non-empty payloads invalid.
+- Do not change prompts, providers, billing, retries, fallback budgets, frontend behavior, concurrency, or deployment limits.
+- Add no dependencies.
+
+---
+
+### Task 1: Define and implement the empty-envelope contract
+
+**Files:**
+- Modify: `dashboard/backend/infrastructure/llm/pipeline_runner.py:145-208`
+- Test: `dashboard/backend/tests/infrastructure/llm/test_pipeline_runner.py`
+
+**Interfaces:**
+- Consumes: `pipeline_output_to_decision(parsed: Dict[str, Any]) -> Optional[Dict[str, Any]]`.
+- Produces: the same signature, with each explicitly empty supported list normalized to `{"actions": []}`.
+
+- [ ] **Step 1: Write failing empty-envelope tests**
+
+Add `import pytest` and these tests below the existing non-empty action tests:
+
+```python
+@pytest.mark.parametrize(
+    "parsed",
+    [{"actions": []}, {"orders": []}, {"risk_actions": []}],
+)
+def test_pipeline_output_to_decision_empty_envelope_is_hold(parsed):
+    assert pipeline_output_to_decision(parsed) == {"actions": []}
+
+
+@pytest.mark.parametrize(
+    "parsed",
+    [
+        {},
+        {"orders": None},
+        {"orders": "not-a-list"},
+        {"orders": ["not-an-order"]},
+        {"actions": [], "orders": ["not-an-order"]},
+    ],
+)
+def test_pipeline_output_to_decision_rejects_invalid_payload(parsed):
+    assert pipeline_output_to_decision(parsed) is None
+```
+
+- [ ] **Step 2: Run the focused module and verify RED**
+
+Run:
+
+```bash
+python -m pytest dashboard/backend/tests/infrastructure/llm/test_pipeline_runner.py -q
+```
+
+Expected: the empty-envelope cases fail because the current function returns `None`; existing non-empty cases pass.
+
+- [ ] **Step 3: Implement explicit empty-envelope handling**
+
+Add state at the top of `pipeline_output_to_decision()`:
+
+```python
+saw_empty_envelope = False
+saw_unusable_nonempty_envelope = False
+```
+
+Replace the `actions` truthiness branch with:
+
+```python
+actions = parsed.get("actions")
+if isinstance(actions, list):
+    if actions:
+        return {"actions": actions}
+    saw_empty_envelope = True
+```
+
+For `orders`, retain the existing normalization loop inside the non-empty branch and mark both outcomes explicitly:
+
+```python
+orders = parsed.get("orders")
+if isinstance(orders, list):
+    if not orders:
+        saw_empty_envelope = True
+    else:
+        normalized = []
+        for order in orders:
+            if not isinstance(order, dict):
+                continue
+            side = str(order.get("side") or order.get("action") or "hold").lower()
+            if side not in ("buy", "sell", "hold"):
+                side = "hold"
+            qty = order.get("qty", order.get("quantity", order.get("position_size", 0)))
+            try:
+                position_size = int(qty)
+            except (TypeError, ValueError):
+                position_size = 0
+            normalized.append(
+                {
+                    "action": side,
+                    "symbol": order.get("symbol"),
+                    "confidence": float(order.get("confidence", 0.75) or 0.75),
+                    "reasoning": order.get("reason") or order.get("rationale") or "",
+                    "position_size": position_size,
+                    "stop_loss_price": order.get("stop_loss_price"),
+                    "take_profit_price": order.get("take_profit_price"),
+                }
+            )
+        if normalized:
+            return {"actions": normalized}
+        saw_unusable_nonempty_envelope = True
+```
+
+Replace the `risk_actions` branch with the full empty/non-empty split:
+
+```python
+risk_actions = parsed.get("risk_actions")
+if isinstance(risk_actions, list):
+    if not risk_actions:
+        saw_empty_envelope = True
+    else:
+        normalized = []
+        for risk in risk_actions:
+            if not isinstance(risk, dict):
+                continue
+            action_type = str(risk.get("action") or "hold").lower()
+            if action_type in ("stop_loss", "take_profit", "trail"):
+                side = "sell"
+            elif action_type == "hold":
+                side = "hold"
+            else:
+                side = (
+                    action_type
+                    if action_type in ("buy", "sell", "hold")
+                    else "hold"
+                )
+            size_pct = float(risk.get("size_pct", 1.0) or 1.0)
+            normalized.append(
+                {
+                    "action": side,
+                    "symbol": risk.get("symbol"),
+                    "confidence": 0.8,
+                    "reasoning": (
+                        risk.get("reason")
+                        or risk.get("rationale")
+                        or action_type
+                    ),
+                    "position_size": (
+                        max(1, int(round(size_pct * 100)))
+                        if side == "sell"
+                        else 0
+                    ),
+                }
+            )
+        if normalized:
+            return {"actions": normalized}
+        saw_unusable_nonempty_envelope = True
+```
+
+Finish the function with:
+
+```python
+if saw_unusable_nonempty_envelope:
+    return None
+if saw_empty_envelope:
+    return {"actions": []}
+return None
+```
+
+- [ ] **Step 4: Run the focused module and verify GREEN**
+
+Run:
+
+```bash
+python -m pytest dashboard/backend/tests/infrastructure/llm/test_pipeline_runner.py -q
+```
+
+Expected: every existing and new pipeline runner test passes.
+
+---
+
+### Task 2: Prove strict pipeline backtests preserve model HOLD
+
+**Files:**
+- Test: `dashboard/backend/tests/backtesting/test_portfolio_manager_move.py`
+
+**Interfaces:**
+- Consumes: `PortfolioManager.make_trading_decision_with_llm(..., pipeline: list[dict], strict_llm: bool) -> Dict` and Task 1's normalization contract.
+- Produces: regression coverage proving `orders: []` returns `{"actions": []}`, increments `llm_decisions`, and does not raise `LLMDecisionError`.
+
+- [ ] **Step 1: Add the strict pipeline regression test**
+
+Add after `test_strict_llm_accepts_empty_actions_as_model_hold`:
+
+```python
+def test_strict_pipeline_accepts_empty_orders_as_model_hold():
+    pm = CanonicalPortfolioManager(100000)
+    client = _FakeClient(_FakeResp('{"orders": []}', _FakeUsage(3, 2)))
+
+    result = pm.make_trading_decision_with_llm(
+        _llm_state(),
+        client,
+        pipeline=[
+            {
+                "label": "Trading instruction",
+                "prompt": "Return the orders for this bar.",
+                "outputFormat": '{"orders": []}',
+            }
+        ],
+        strict_llm=True,
+    )
+
+    assert result == {"actions": []}
+    assert pm.llm_calls == 1
+    assert pm.llm_decisions == 1
+```
+
+- [ ] **Step 2: Run the strict pipeline regression test**
+
+Run:
+
+```bash
+python -m pytest dashboard/backend/tests/backtesting/test_portfolio_manager_move.py::test_strict_pipeline_accepts_empty_orders_as_model_hold -q
+```
+
+Expected: PASS with no rule-based fallback.
+
+- [ ] **Step 3: Run the related regression suite**
+
+Run:
+
+```bash
+python -m pytest dashboard/backend/tests/infrastructure/llm/test_pipeline_runner.py dashboard/backend/tests/backtesting/test_portfolio_manager_move.py -q
+```
+
+Expected: both modules pass with no regression in non-empty decisions, strict error handling, or fallback accounting.
+
+- [ ] **Step 4: Check the diff and secrets**
+
+Run:
+
+```bash
+git diff --check
+git diff --stat origin/main...HEAD
+git diff origin/main...HEAD | rg -n 'rnd_[A-Za-z0-9]{16,}|RENDER_API_KEY=.+|OPENAI_API_KEY=.+'
+```
+
+Expected: no whitespace errors, only the spec/plan/function/tests changed, and the credential scan returns no matches.
+
+- [ ] **Step 5: Commit the implementation**
+
+Run:
+
+```bash
+git add dashboard/backend/infrastructure/llm/pipeline_runner.py dashboard/backend/tests/infrastructure/llm/test_pipeline_runner.py dashboard/backend/tests/backtesting/test_portfolio_manager_move.py
+git commit -m "fix(backtest): accept empty pipeline orders as hold"
+```
+
+- [ ] **Step 6: Push and create the pull request**
+
+Run:
+
+```bash
+git push -u origin fix/pipeline-empty-orders-hold
+gh pr create --repo Open-Finance-Lab/AgenticTrading --base main --head fix/pipeline-empty-orders-hold --title "fix(backtest): accept empty pipeline orders as hold" --body-file /tmp/pipeline-empty-orders-hold-pr.md
+```
+
+The PR body must include the reproduced Gemini/Qwen behavior, the normalization contract, the exact test commands, and explicit exclusions for retry, memory, concurrency, and frontend timeout work.

--- a/docs/superpowers/specs/2026-08-29-pipeline-empty-orders-hold-design.md
+++ b/docs/superpowers/specs/2026-08-29-pipeline-empty-orders-hold-design.md
@@ -1,0 +1,77 @@
+# Pipeline Empty Orders Hold Design
+
+## Problem
+
+The hourly backtest pipeline treats a valid empty decision envelope as an
+unparseable model decision. Both Gemini and Qwen have returned valid JSON such
+as:
+
+```json
+{"orders": []}
+```
+
+An empty order list means that the model chose not to trade during the current
+bar. `pipeline_output_to_decision()` currently checks list truthiness, so an
+empty list falls through to `None`. Strict LLM backtests then raise
+`LLMDecisionError` and discard the run even though parsing succeeded.
+
+## Goal
+
+Normalize an explicitly empty supported pipeline decision envelope to
+`{"actions": []}` so the backtest records a model-driven hold and continues.
+
+## Scope
+
+This change covers the three decision envelopes already supported by the
+pipeline runner:
+
+- `{"actions": []}`
+- `{"orders": []}`
+- `{"risk_actions": []}`
+
+The change is limited to pipeline decision normalization and its contract
+tests. It does not change prompts, provider adapters, billing, strict-LLM
+fallback budgets, retry policy, frontend polling, concurrency, or Render
+resource limits.
+
+## Normalization Contract
+
+`pipeline_output_to_decision(parsed)` keeps the current non-empty envelope
+priority and conversion behavior:
+
+1. A non-empty `actions` list is returned as the standard action envelope.
+2. Otherwise, a non-empty `orders` list is normalized into actions.
+3. Otherwise, a non-empty `risk_actions` list is normalized into actions.
+4. If a non-empty `orders` or `risk_actions` list contains no normalizable
+   records, return `None`; an empty sibling field must not hide that invalid
+   payload.
+5. If no supported list is non-empty and at least one supported field is
+   explicitly an empty list, return `{"actions": []}`.
+6. Return `None` for non-dictionary input, missing supported fields, or payloads
+   whose supported fields are only non-list values.
+
+The empty result is a model-driven HOLD, not a rule-based fallback. The
+existing portfolio manager therefore counts it as an LLM decision without
+executing trades.
+
+## Testing
+
+Add focused contract tests that prove:
+
+- each supported empty envelope normalizes to `{"actions": []}`;
+- missing and incorrectly typed envelopes remain invalid;
+- a non-empty orders envelope with no valid records remains invalid;
+- an empty envelope cannot mask a non-empty invalid orders envelope;
+- `run_pipeline_decision()` accepts an `orders: []` provider response and
+  returns a valid empty action decision instead of `None`.
+
+Run the pipeline runner test module and the strict portfolio-manager tests to
+verify both the normalization boundary and the downstream strict-LLM behavior.
+
+## Success Criteria
+
+- The reproduced Gemini and Qwen `{"orders": []}` response continues the
+  backtest as a HOLD.
+- Malformed or unsupported responses still fail closed.
+- Existing non-empty pipeline decisions are unchanged.
+- No frontend or deployment behavior changes in this pull request.


### PR DESCRIPTION
## Summary

- treat explicit empty `actions`, `orders`, and `risk_actions` envelopes as valid model-driven HOLD decisions
- preserve existing priority and normalization for non-empty decision envelopes
- keep malformed and unusable non-empty payloads invalid, including when an empty sibling is present

## Incident reproduction

Gemini and Qwen pipeline backtests returned valid JSON in the form:

```json
{"orders": []}
```

The response parsed successfully, but `pipeline_output_to_decision()` used list truthiness and returned `None`. Strict LLM mode then raised `LLMDecisionError: LLM pipeline returned no parseable decision`, ending the backtest even though the model had made a valid no-trade decision.

This change normalizes the response to `{"actions": []}`. The portfolio manager records it as an LLM decision and continues the backtest without executing a trade or using the rule-based fallback.

## Tests

```bash
python -m pytest dashboard/backend/tests/infrastructure/llm/test_pipeline_runner.py dashboard/backend/tests/backtesting/test_portfolio_manager_move.py -q
```

Result: `54 passed in 1.98s`

Coverage includes empty envelopes, malformed and mixed payloads, non-empty order and risk-action regressions, and the strict pipeline HOLD path.

## Out of scope

This PR does not change JSON retries, provider adapters, prompts, billing, memory limits, concurrency, frontend polling/timeouts, or deployment configuration.
