### PR TITLE
fix: recover OpenRouter empty pipeline responses

### DIFF
--- a/dashboard/backend/infrastructure/llm/execution/adapters/openai.py
+++ b/dashboard/backend/infrastructure/llm/execution/adapters/openai.py
@@ -111,8 +111,18 @@ class OpenAIExecutionAdapter:
                 "openrouter",
                 "openai_compatible",
             }:
+                effort = request.reasoning_effort.strip().lower()
+                reasoning = {"effort": request.reasoning_effort}
+                if provider.adapter_type == "openrouter" and effort in {
+                    "none",
+                    "off",
+                    "false",
+                    "0",
+                    "disabled",
+                }:
+                    reasoning.update({"enabled": False, "exclude": True})
                 kwargs["extra_body"] = {
-                    "reasoning": {"effort": request.reasoning_effort}
+                    "reasoning": reasoning,
                 }
             response = client.chat.completions.create(**kwargs)
             text = _response_text(response)

--- a/dashboard/backend/infrastructure/llm/pipeline_runner.py
+++ b/dashboard/backend/infrastructure/llm/pipeline_runner.py
@@ -23,6 +23,10 @@ from dashboard.backend.infrastructure.llm.backtest_harness import (
     extract_token_usage,
     parse_llm_response,
 )
+from dashboard.backend.infrastructure.llm.execution.errors import (
+    ExecutionErrorCategory,
+    LLMExecutionError,
+)
 
 POST_TRADE_PRESET_KEY = "post_trade_analysis"
 
@@ -459,6 +463,25 @@ def recombine_pipeline(
     return list(decision_steps or []) + list(post_trade_steps or [])
 
 
+def _create_pipeline_response(
+    client,
+    *,
+    model: str,
+    prompt: str,
+    reasoning_effort: Optional[str] = None,
+):
+    """Create one pipeline request, optionally overriding model reasoning."""
+    request = {
+        "model": model,
+        "max_tokens": DEFAULT_MAX_OUTPUT_TOKENS,
+        "system": PIPELINE_SYSTEM_PROMPT,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    if reasoning_effort is not None:
+        request["reasoning_effort"] = reasoning_effort
+    return client.messages.create(**request)
+
+
 def run_pipeline_decision(
     client,
     *,
@@ -480,6 +503,7 @@ def run_pipeline_decision(
     total_out = 0
     llm_calls = 0
     last_parsed: Optional[Dict[str, Any]] = None
+    request_model = model or LLM_MODEL_NAME
 
     for index, step in enumerate(decision_steps):
         if not isinstance(step, dict):
@@ -496,12 +520,29 @@ def run_pipeline_decision(
         label = step.get("label") or f"Step {index + 1}"
         print(f"\n🔗 Pipeline step {index + 1}/{len(decision_steps)}: {label}")
 
-        response = client.messages.create(
-            model=model or LLM_MODEL_NAME,
-            max_tokens=DEFAULT_MAX_OUTPUT_TOKENS,
-            system=PIPELINE_SYSTEM_PROMPT,
-            messages=[{"role": "user", "content": prompt}],
-        )
+        try:
+            response = _create_pipeline_response(
+                client,
+                model=request_model,
+                prompt=prompt,
+            )
+        except LLMExecutionError as first_error:
+            if first_error.category is not ExecutionErrorCategory.RESPONSE_INVALID:
+                raise
+            try:
+                response = _create_pipeline_response(
+                    client,
+                    model=request_model,
+                    prompt=prompt,
+                    reasoning_effort="none",
+                )
+            except TypeError as retry_error:
+                # Older client/test doubles may reject only the optional
+                # keyword. Keep the original safe category in that case, but
+                # preserve unrelated client TypeErrors for diagnostics.
+                if "reasoning_effort" in str(retry_error):
+                    raise first_error from retry_error
+                raise
         llm_calls += 1
         in_delta, out_delta = extract_token_usage(response)
         total_in += in_delta

--- a/dashboard/backend/infrastructure/llm/pipeline_runner.py
+++ b/dashboard/backend/infrastructure/llm/pipeline_runner.py
@@ -23,6 +23,10 @@ from dashboard.backend.infrastructure.llm.backtest_harness import (
     extract_token_usage,
     parse_llm_response,
 )
+from dashboard.backend.infrastructure.llm.execution.errors import (
+    ExecutionErrorCategory,
+    LLMExecutionError,
+)
 
 POST_TRADE_PRESET_KEY = "post_trade_analysis"
 
@@ -459,6 +463,25 @@ def recombine_pipeline(
     return list(decision_steps or []) + list(post_trade_steps or [])
 
 
+def _create_pipeline_response(
+    client,
+    *,
+    model: str,
+    prompt: str,
+    reasoning_effort: Optional[str] = None,
+):
+    """Create one pipeline request, optionally overriding model reasoning."""
+    request = {
+        "model": model,
+        "max_tokens": DEFAULT_MAX_OUTPUT_TOKENS,
+        "system": PIPELINE_SYSTEM_PROMPT,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    if reasoning_effort is not None:
+        request["reasoning_effort"] = reasoning_effort
+    return client.messages.create(**request)
+
+
 def run_pipeline_decision(
     client,
     *,
@@ -480,6 +503,7 @@ def run_pipeline_decision(
     total_out = 0
     llm_calls = 0
     last_parsed: Optional[Dict[str, Any]] = None
+    request_model = model or LLM_MODEL_NAME
 
     for index, step in enumerate(decision_steps):
         if not isinstance(step, dict):
@@ -496,12 +520,26 @@ def run_pipeline_decision(
         label = step.get("label") or f"Step {index + 1}"
         print(f"\n🔗 Pipeline step {index + 1}/{len(decision_steps)}: {label}")
 
-        response = client.messages.create(
-            model=model or LLM_MODEL_NAME,
-            max_tokens=DEFAULT_MAX_OUTPUT_TOKENS,
-            system=PIPELINE_SYSTEM_PROMPT,
-            messages=[{"role": "user", "content": prompt}],
-        )
+        try:
+            response = _create_pipeline_response(
+                client,
+                model=request_model,
+                prompt=prompt,
+            )
+        except LLMExecutionError as first_error:
+            if first_error.category is not ExecutionErrorCategory.RESPONSE_INVALID:
+                raise
+            try:
+                response = _create_pipeline_response(
+                    client,
+                    model=request_model,
+                    prompt=prompt,
+                    reasoning_effort="none",
+                )
+            except TypeError as retry_error:
+                # Older client/test doubles may reject the optional keyword.
+                # Keep the original safe execution category in that case.
+                raise first_error from retry_error
         llm_calls += 1
         in_delta, out_delta = extract_token_usage(response)
         total_in += in_delta

--- a/dashboard/backend/tests/infrastructure/llm/test_execution_adapter_model_routes.py
+++ b/dashboard/backend/tests/infrastructure/llm/test_execution_adapter_model_routes.py
@@ -38,7 +38,12 @@ def _provider(provider_id: str, adapter_type: str, base_url: str) -> ProviderRec
     )
 
 
-def _request(provider_id: str, model_id: str) -> LLMExecutionRequest:
+def _request(
+    provider_id: str,
+    model_id: str,
+    *,
+    reasoning_effort: str | None = None,
+) -> LLMExecutionRequest:
     return LLMExecutionRequest(
         user_id=7,
         run_id="run-model-route",
@@ -48,6 +53,7 @@ def _request(provider_id: str, model_id: str) -> LLMExecutionRequest:
         model_id=model_id,
         messages=(LLMMessage(role="user", content="Return one word."),),
         usage_policy=UsagePolicy(max_output_tokens=16),
+        reasoning_effort=reasoning_effort,
     )
 
 
@@ -132,6 +138,39 @@ def test_openrouter_keeps_provider_qualified_model(monkeypatch):
 
     assert captured["model"] == "openai/gpt-5.5"
     assert result.model_id == "openai/gpt-5.5"
+
+
+def test_openrouter_reasoning_none_disables_reasoning(monkeypatch):
+    captured = {}
+
+    def create(**kwargs):
+        captured.update(kwargs)
+        return _openai_response("qwen/qwen3.7-plus")
+
+    client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create)),
+        close=lambda: None,
+    )
+    monkeypatch.setattr(
+        openai_module,
+        "build_safe_http_client",
+        lambda *_args, **_kwargs: _Closable(),
+    )
+    adapter = openai_module.OpenRouterAdapter(client_factory=lambda **_kwargs: client)
+
+    adapter.complete(
+        _request(
+            "openrouter",
+            "qwen/qwen3.7-plus",
+            reasoning_effort="none",
+        ),
+        _credential("openrouter"),
+        _provider("openrouter", "openrouter", "https://openrouter.ai/api/v1"),
+    )
+
+    assert captured["extra_body"] == {
+        "reasoning": {"effort": "none", "enabled": False, "exclude": True}
+    }
 
 
 def test_anthropic_uses_native_model_and_keeps_canonical_result(monkeypatch):

--- a/dashboard/backend/tests/infrastructure/llm/test_pipeline_runner.py
+++ b/dashboard/backend/tests/infrastructure/llm/test_pipeline_runner.py
@@ -1,18 +1,61 @@
 """Tests for sub-agent pipeline backtest execution."""
 
 from datetime import datetime
+from types import SimpleNamespace
 
 import pytest
 
+from dashboard.backend.infrastructure.llm.execution.errors import (
+    ExecutionErrorCategory,
+    LLMExecutionError,
+)
 from dashboard.backend.infrastructure.llm.pipeline_runner import (
     apply_prompt_patches,
     is_last_bar_of_trading_day,
     pipeline_output_to_decision,
     recombine_pipeline,
+    run_pipeline_decision,
     split_pipeline,
     trading_day_key,
     _build_step_prompt,
 )
+
+
+class _PipelineResponse:
+    def __init__(self, text, input_tokens=7, output_tokens=3):
+        self.content = [SimpleNamespace(type="text", text=text)]
+        self.usage = SimpleNamespace(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+        )
+
+
+class _SequencedMessages:
+    def __init__(self, outcomes):
+        self.outcomes = list(outcomes)
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+
+class _PipelineClient:
+    def __init__(self, outcomes):
+        self.messages = _SequencedMessages(outcomes)
+
+
+_PIPELINE = [
+    {
+        "id": "decision",
+        "label": "Decision",
+        "prompt": "Choose the action.",
+        "outputFormat": '{"orders": []}',
+    }
+]
 
 
 def test_pipeline_output_to_decision_orders():
@@ -156,6 +199,139 @@ def test_apply_prompt_patches_by_id_and_skips_post_trade():
     assert patched[1]["prompt"] == "new signal"
     assert len(applied) == 2
     assert decision[0]["prompt"] == "old gather"  # deepcopy, original untouched
+
+
+def test_run_pipeline_decision_retries_response_invalid_once():
+    client = _PipelineClient(
+        [
+            LLMExecutionError(ExecutionErrorCategory.RESPONSE_INVALID),
+            _PipelineResponse('{"orders": []}', input_tokens=11, output_tokens=4),
+        ]
+    )
+
+    decision, usage, calls, _steps = run_pipeline_decision(
+        client,
+        pipeline=_PIPELINE,
+        market_snapshot={"top_signals": {}},
+        model="qwen/qwen3.7-plus",
+    )
+
+    assert decision == {"actions": []}
+    assert usage == (11, 4)
+    assert calls == 1
+    assert len(client.messages.calls) == 2
+    assert "reasoning_effort" not in client.messages.calls[0]
+    assert client.messages.calls[1]["reasoning_effort"] == "none"
+    assert client.messages.calls[0]["messages"] == client.messages.calls[1]["messages"]
+
+
+def test_run_pipeline_decision_reraises_after_one_failed_retry():
+    client = _PipelineClient(
+        [
+            LLMExecutionError(ExecutionErrorCategory.RESPONSE_INVALID),
+            LLMExecutionError(ExecutionErrorCategory.RESPONSE_INVALID),
+        ]
+    )
+
+    with pytest.raises(LLMExecutionError) as error:
+        run_pipeline_decision(
+            client,
+            pipeline=_PIPELINE,
+            market_snapshot={"top_signals": {}},
+        )
+
+    assert error.value.category is ExecutionErrorCategory.RESPONSE_INVALID
+    assert len(client.messages.calls) == 2
+
+
+def test_run_pipeline_decision_preserves_response_invalid_for_legacy_client():
+    class _LegacyMessages:
+        def __init__(self):
+            self.calls = []
+
+        def create(self, **kwargs):
+            self.calls.append(kwargs)
+            if "reasoning_effort" in kwargs:
+                raise TypeError(
+                    "create() got an unexpected keyword argument 'reasoning_effort'"
+                )
+            raise LLMExecutionError(ExecutionErrorCategory.RESPONSE_INVALID)
+
+    client = SimpleNamespace(messages=_LegacyMessages())
+
+    with pytest.raises(LLMExecutionError) as error:
+        run_pipeline_decision(
+            client,
+            pipeline=_PIPELINE,
+            market_snapshot={"top_signals": {}},
+        )
+
+    assert error.value.category is ExecutionErrorCategory.RESPONSE_INVALID
+    assert len(client.messages.calls) == 2
+
+
+def test_run_pipeline_decision_propagates_unrelated_retry_type_error():
+    class _BrokenMessages:
+        def __init__(self):
+            self.calls = []
+
+        def create(self, **kwargs):
+            self.calls.append(kwargs)
+            if "reasoning_effort" not in kwargs:
+                raise LLMExecutionError(ExecutionErrorCategory.RESPONSE_INVALID)
+            raise TypeError("client serialization failed")
+
+    client = SimpleNamespace(messages=_BrokenMessages())
+
+    with pytest.raises(TypeError, match="client serialization failed"):
+        run_pipeline_decision(
+            client,
+            pipeline=_PIPELINE,
+            market_snapshot={"top_signals": {}},
+        )
+
+    assert len(client.messages.calls) == 2
+
+
+@pytest.mark.parametrize(
+    "category",
+    [
+        ExecutionErrorCategory.CREDENTIAL_MISSING,
+        ExecutionErrorCategory.CREDENTIAL_INVALID,
+        ExecutionErrorCategory.PROVIDER_UNAVAILABLE,
+        ExecutionErrorCategory.PROVIDER_TIMEOUT,
+        ExecutionErrorCategory.BILLING_FAILED,
+        ExecutionErrorCategory.USAGE_UNAVAILABLE,
+        ExecutionErrorCategory.WORKER_FAILED,
+    ],
+)
+def test_run_pipeline_decision_does_not_retry_other_execution_errors(category):
+    client = _PipelineClient([LLMExecutionError(category)])
+
+    with pytest.raises(LLMExecutionError) as error:
+        run_pipeline_decision(
+            client,
+            pipeline=_PIPELINE,
+            market_snapshot={"top_signals": {}},
+        )
+
+    assert error.value.category is category
+    assert len(client.messages.calls) == 1
+
+
+def test_run_pipeline_decision_does_not_retry_invalid_business_json():
+    client = _PipelineClient([_PipelineResponse("not-json")])
+
+    decision, usage, calls, _steps = run_pipeline_decision(
+        client,
+        pipeline=_PIPELINE,
+        market_snapshot={"top_signals": {}},
+    )
+
+    assert decision is None
+    assert usage == (7, 3)
+    assert calls == 1
+    assert len(client.messages.calls) == 1
 
 
 def test_trading_day_boundary_helpers():

--- a/dashboard/backend/tests/infrastructure/llm/test_pipeline_runner.py
+++ b/dashboard/backend/tests/infrastructure/llm/test_pipeline_runner.py
@@ -1,18 +1,61 @@
 """Tests for sub-agent pipeline backtest execution."""
 
 from datetime import datetime
+from types import SimpleNamespace
 
 import pytest
 
+from dashboard.backend.infrastructure.llm.execution.errors import (
+    ExecutionErrorCategory,
+    LLMExecutionError,
+)
 from dashboard.backend.infrastructure.llm.pipeline_runner import (
     apply_prompt_patches,
     is_last_bar_of_trading_day,
     pipeline_output_to_decision,
     recombine_pipeline,
+    run_pipeline_decision,
     split_pipeline,
     trading_day_key,
     _build_step_prompt,
 )
+
+
+class _PipelineResponse:
+    def __init__(self, text, input_tokens=7, output_tokens=3):
+        self.content = [SimpleNamespace(type="text", text=text)]
+        self.usage = SimpleNamespace(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+        )
+
+
+class _SequencedMessages:
+    def __init__(self, outcomes):
+        self.outcomes = list(outcomes)
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+
+class _PipelineClient:
+    def __init__(self, outcomes):
+        self.messages = _SequencedMessages(outcomes)
+
+
+_PIPELINE = [
+    {
+        "id": "decision",
+        "label": "Decision",
+        "prompt": "Choose the action.",
+        "outputFormat": '{"orders": []}',
+    }
+]
 
 
 def test_pipeline_output_to_decision_orders():
@@ -156,6 +199,112 @@ def test_apply_prompt_patches_by_id_and_skips_post_trade():
     assert patched[1]["prompt"] == "new signal"
     assert len(applied) == 2
     assert decision[0]["prompt"] == "old gather"  # deepcopy, original untouched
+
+
+def test_run_pipeline_decision_retries_response_invalid_once():
+    client = _PipelineClient(
+        [
+            LLMExecutionError(ExecutionErrorCategory.RESPONSE_INVALID),
+            _PipelineResponse('{"orders": []}', input_tokens=11, output_tokens=4),
+        ]
+    )
+
+    decision, usage, calls, _steps = run_pipeline_decision(
+        client,
+        pipeline=_PIPELINE,
+        market_snapshot={"top_signals": {}},
+        model="qwen/qwen3.7-plus",
+    )
+
+    assert decision == {"actions": []}
+    assert usage == (11, 4)
+    assert calls == 1
+    assert len(client.messages.calls) == 2
+    assert "reasoning_effort" not in client.messages.calls[0]
+    assert client.messages.calls[1]["reasoning_effort"] == "none"
+    assert client.messages.calls[0]["messages"] == client.messages.calls[1]["messages"]
+
+
+def test_run_pipeline_decision_reraises_after_one_failed_retry():
+    client = _PipelineClient(
+        [
+            LLMExecutionError(ExecutionErrorCategory.RESPONSE_INVALID),
+            LLMExecutionError(ExecutionErrorCategory.RESPONSE_INVALID),
+        ]
+    )
+
+    with pytest.raises(LLMExecutionError) as error:
+        run_pipeline_decision(
+            client,
+            pipeline=_PIPELINE,
+            market_snapshot={"top_signals": {}},
+        )
+
+    assert error.value.category is ExecutionErrorCategory.RESPONSE_INVALID
+    assert len(client.messages.calls) == 2
+
+
+def test_run_pipeline_decision_preserves_response_invalid_for_legacy_client():
+    class _LegacyMessages:
+        def __init__(self):
+            self.calls = []
+
+        def create(self, **kwargs):
+            self.calls.append(kwargs)
+            if "reasoning_effort" in kwargs:
+                raise TypeError("create() got an unexpected keyword argument")
+            raise LLMExecutionError(ExecutionErrorCategory.RESPONSE_INVALID)
+
+    client = SimpleNamespace(messages=_LegacyMessages())
+
+    with pytest.raises(LLMExecutionError) as error:
+        run_pipeline_decision(
+            client,
+            pipeline=_PIPELINE,
+            market_snapshot={"top_signals": {}},
+        )
+
+    assert error.value.category is ExecutionErrorCategory.RESPONSE_INVALID
+    assert len(client.messages.calls) == 2
+
+
+@pytest.mark.parametrize(
+    "category",
+    [
+        ExecutionErrorCategory.CREDENTIAL_INVALID,
+        ExecutionErrorCategory.PROVIDER_UNAVAILABLE,
+        ExecutionErrorCategory.PROVIDER_TIMEOUT,
+        ExecutionErrorCategory.BILLING_FAILED,
+        ExecutionErrorCategory.USAGE_UNAVAILABLE,
+    ],
+)
+def test_run_pipeline_decision_does_not_retry_other_execution_errors(category):
+    client = _PipelineClient([LLMExecutionError(category)])
+
+    with pytest.raises(LLMExecutionError) as error:
+        run_pipeline_decision(
+            client,
+            pipeline=_PIPELINE,
+            market_snapshot={"top_signals": {}},
+        )
+
+    assert error.value.category is category
+    assert len(client.messages.calls) == 1
+
+
+def test_run_pipeline_decision_does_not_retry_invalid_business_json():
+    client = _PipelineClient([_PipelineResponse("not-json")])
+
+    decision, usage, calls, _steps = run_pipeline_decision(
+        client,
+        pipeline=_PIPELINE,
+        market_snapshot={"top_signals": {}},
+    )
+
+    assert decision is None
+    assert usage == (7, 3)
+    assert calls == 1
+    assert len(client.messages.calls) == 1
 
 
 def test_trading_day_boundary_helpers():

--- a/docs/superpowers/plans/2026-08-29-openrouter-empty-response-recovery.md
+++ b/docs/superpowers/plans/2026-08-29-openrouter-empty-response-recovery.md
@@ -1,0 +1,399 @@
+# OpenRouter Empty Response Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Recover one empty OpenRouter reasoning response per pipeline step with a single reasoning-disabled retry, while preserving fail-closed behavior and existing credit settlement.
+
+**Architecture:** Keep response classification in the OpenAI-compatible execution adapter. Add a small request helper in the sequential pipeline runner; the first call uses the current client defaults, and only a `response_invalid` execution error triggers a second call with `reasoning_effort="none"`. Parsing, decision normalization, portfolio behavior, and billing remain in their existing layers.
+
+**Tech Stack:** Python 3.12, Pydantic execution models, Anthropic-shaped client protocol, pytest, existing OpenRouter/OpenAI-compatible adapter.
+
+**Spec:** `docs/superpowers/specs/2026-08-29-openrouter-empty-response-recovery-design.md`
+
+## Global Constraints
+
+- Preserve the selected provider, model, prompt, max-output-token limit, billing mode, and run identity for both attempts.
+- Retry at most once per pipeline step and only for `response_invalid`.
+- The recovery attempt explicitly passes `reasoning_effort="none"`.
+- Credentials, provider errors, timeouts, billing/usage failures, and invalid business JSON are not retried.
+- Each attempt uses the existing independent reservation/release lifecycle and a unique `call_index`.
+- Do not log response bodies, reasoning text, API keys, or provider headers.
+- Do not change frontend state, Render memory, worker concurrency, deployment settings, database schema, pricing, or credit policy.
+- Use deterministic fake clients and responses; no network calls or real credentials.
+
+### Task 1: Make OpenRouter reasoning-disabled requests explicit
+
+**Files:**
+- Modify: `dashboard/backend/infrastructure/llm/execution/adapters/openai.py:108-118`
+- Test: `dashboard/backend/tests/infrastructure/llm/test_execution_adapter_model_routes.py`
+
+**Interfaces:**
+- Consumes: `LLMExecutionRequest.reasoning_effort` and `ProviderRecord.adapter_type`.
+- Produces: OpenRouter `chat.completions.create()` kwargs with a provider-safe `extra_body.reasoning` object; other OpenAI-compatible providers retain their current payload.
+
+- [ ] **Step 1: Extend the adapter test request factory and write the failing contract test**
+
+Update `_request()` to accept an optional `reasoning_effort` and add:
+
+```python
+def test_openrouter_reasoning_none_disables_reasoning(monkeypatch):
+    captured = {}
+
+    def create(**kwargs):
+        captured.update(kwargs)
+        return _openai_response("qwen/qwen3.7-plus")
+
+    client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create)),
+        close=lambda: None,
+    )
+    monkeypatch.setattr(
+        openai_module,
+        "build_safe_http_client",
+        lambda *_args, **_kwargs: _Closable(),
+    )
+    adapter = openai_module.OpenRouterAdapter(client_factory=lambda **_kwargs: client)
+
+    adapter.complete(
+        _request("openrouter", "qwen/qwen3.7-plus", reasoning_effort="none"),
+        _credential("openrouter"),
+        _provider("openrouter", "openrouter", "https://openrouter.ai/api/v1"),
+    )
+
+    assert captured["extra_body"] == {
+        "reasoning": {"effort": "none", "enabled": False, "exclude": True}
+    }
+```
+
+- [ ] **Step 2: Run the new test and verify the baseline fails**
+
+Run:
+
+```bash
+python -m pytest dashboard/backend/tests/infrastructure/llm/test_execution_adapter_model_routes.py::test_openrouter_reasoning_none_disables_reasoning -q
+```
+
+Expected: FAIL because the current adapter forwards only `{"effort": "none"}`.
+
+- [ ] **Step 3: Implement the minimal OpenRouter-only payload adjustment**
+
+Replace the current reasoning block in `OpenAIExecutionAdapter.complete()` with:
+
+```python
+if request.reasoning_effort and provider.adapter_type in {
+    "openrouter",
+    "openai_compatible",
+}:
+    effort = request.reasoning_effort.strip().lower()
+    reasoning = {"effort": request.reasoning_effort}
+    if provider.adapter_type == "openrouter" and effort in {
+        "none",
+        "off",
+        "false",
+        "0",
+        "disabled",
+    }:
+        reasoning.update({"enabled": False, "exclude": True})
+    kwargs["extra_body"] = {"reasoning": reasoning}
+```
+
+This keeps normal configured effort values unchanged and prevents the explicit recovery override from being ignored by OpenRouter models.
+
+- [ ] **Step 4: Run the adapter route tests**
+
+Run:
+
+```bash
+python -m pytest dashboard/backend/tests/infrastructure/llm/test_execution_adapter_model_routes.py -q
+```
+
+Expected: PASS, including the existing OpenAI, OpenRouter, Anthropic, and Gemini route tests.
+
+- [ ] **Step 5: Commit the adapter contract**
+
+```bash
+git add dashboard/backend/infrastructure/llm/execution/adapters/openai.py dashboard/backend/tests/infrastructure/llm/test_execution_adapter_model_routes.py
+git commit -m "fix: disable OpenRouter reasoning for recovery calls"
+```
+
+### Task 2: Specify pipeline recovery behavior with deterministic tests
+
+**Files:**
+- Modify: `dashboard/backend/tests/infrastructure/llm/test_pipeline_runner.py`
+
+**Interfaces:**
+- Consumes: `run_pipeline_decision(client, pipeline, market_snapshot, model)`.
+- Produces: tests that define the retry request shape, result accounting, retry limit, and non-retry boundaries before production code changes.
+
+- [ ] **Step 1: Add fake response and sequenced client helpers**
+
+Add these test-only helpers:
+
+```python
+from types import SimpleNamespace
+
+from dashboard.backend.infrastructure.llm.execution.errors import (
+    ExecutionErrorCategory,
+    LLMExecutionError,
+)
+from dashboard.backend.infrastructure.llm.pipeline_runner import run_pipeline_decision
+
+
+class _PipelineResponse:
+    def __init__(self, text, input_tokens=7, output_tokens=3):
+        self.content = [SimpleNamespace(type="text", text=text)]
+        self.usage = SimpleNamespace(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+        )
+
+
+class _SequencedMessages:
+    def __init__(self, outcomes):
+        self.outcomes = list(outcomes)
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+
+class _PipelineClient:
+    def __init__(self, outcomes):
+        self.messages = _SequencedMessages(outcomes)
+```
+
+- [ ] **Step 2: Write the retry-success, retry-exhaustion, and non-retry tests**
+
+Use one decision step and a valid empty order envelope:
+
+```python
+_PIPELINE = [{
+    "id": "decision",
+    "label": "Decision",
+    "prompt": "Choose the action.",
+    "outputFormat": '{"orders": []}',
+}]
+
+
+def test_run_pipeline_decision_retries_response_invalid_once():
+    client = _PipelineClient([
+        LLMExecutionError(ExecutionErrorCategory.RESPONSE_INVALID),
+        _PipelineResponse('{"orders": []}', input_tokens=11, output_tokens=4),
+    ])
+
+    decision, usage, calls, _steps = run_pipeline_decision(
+        client,
+        pipeline=_PIPELINE,
+        market_snapshot={"top_signals": {}},
+        model="qwen/qwen3.7-plus",
+    )
+
+    assert decision == {"actions": []}
+    assert usage == (11, 4)
+    assert calls == 1
+    assert len(client.messages.calls) == 2
+    assert "reasoning_effort" not in client.messages.calls[0]
+    assert client.messages.calls[1]["reasoning_effort"] == "none"
+    assert client.messages.calls[0]["messages"] == client.messages.calls[1]["messages"]
+
+
+def test_run_pipeline_decision_reraises_after_one_failed_retry():
+    client = _PipelineClient([
+        LLMExecutionError(ExecutionErrorCategory.RESPONSE_INVALID),
+        LLMExecutionError(ExecutionErrorCategory.RESPONSE_INVALID),
+    ])
+
+    with pytest.raises(LLMExecutionError) as error:
+        run_pipeline_decision(
+            client,
+            pipeline=_PIPELINE,
+            market_snapshot={"top_signals": {}},
+        )
+
+    assert error.value.category is ExecutionErrorCategory.RESPONSE_INVALID
+    assert len(client.messages.calls) == 2
+
+
+@pytest.mark.parametrize(
+    "category",
+    [
+        ExecutionErrorCategory.CREDENTIAL_INVALID,
+        ExecutionErrorCategory.PROVIDER_UNAVAILABLE,
+        ExecutionErrorCategory.PROVIDER_TIMEOUT,
+        ExecutionErrorCategory.BILLING_FAILED,
+        ExecutionErrorCategory.USAGE_UNAVAILABLE,
+    ],
+)
+def test_run_pipeline_decision_does_not_retry_other_execution_errors(category):
+    client = _PipelineClient([LLMExecutionError(category)])
+
+    with pytest.raises(LLMExecutionError) as error:
+        run_pipeline_decision(
+            client,
+            pipeline=_PIPELINE,
+            market_snapshot={"top_signals": {}},
+        )
+
+    assert error.value.category is category
+    assert len(client.messages.calls) == 1
+
+
+def test_run_pipeline_decision_does_not_retry_invalid_business_json():
+    client = _PipelineClient([_PipelineResponse("not-json")])
+
+    decision, usage, calls, _steps = run_pipeline_decision(
+        client,
+        pipeline=_PIPELINE,
+        market_snapshot={"top_signals": {}},
+    )
+
+    assert decision is None
+    assert usage == (7, 3)
+    assert calls == 1
+    assert len(client.messages.calls) == 1
+```
+
+- [ ] **Step 3: Run the new pipeline tests and verify the baseline fails**
+
+Run:
+
+```bash
+python -m pytest dashboard/backend/tests/infrastructure/llm/test_pipeline_runner.py -q
+```
+
+Expected: the existing normalization tests pass, while the new retry tests fail because `run_pipeline_decision()` currently performs only one unguarded model call.
+
+### Task 3: Implement the bounded `response_invalid` retry
+
+**Files:**
+- Modify: `dashboard/backend/infrastructure/llm/pipeline_runner.py:15-24,462-531`
+
+**Interfaces:**
+- Consumes: existing `client.messages.create()` Anthropic-shaped protocol and `ExecutionErrorCategory.RESPONSE_INVALID`.
+- Produces: unchanged `run_pipeline_decision()` return type, with at most one retry request carrying `reasoning_effort="none"`.
+
+- [ ] **Step 1: Add the execution-error imports and a private request helper**
+
+Import `ExecutionErrorCategory` and `LLMExecutionError`, then add:
+
+```python
+def _create_pipeline_response(
+    client,
+    *,
+    model: str,
+    prompt: str,
+    reasoning_effort: Optional[str] = None,
+):
+    request = {
+        "model": model,
+        "max_tokens": DEFAULT_MAX_OUTPUT_TOKENS,
+        "system": PIPELINE_SYSTEM_PROMPT,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    if reasoning_effort is not None:
+        request["reasoning_effort"] = reasoning_effort
+    return client.messages.create(**request)
+```
+
+- [ ] **Step 2: Replace the direct decision-step call with one bounded recovery**
+
+Inside `run_pipeline_decision()`, resolve `resolved_model = model or LLM_MODEL_NAME`, then use:
+
+```python
+try:
+    response = _create_pipeline_response(
+        client,
+        model=resolved_model,
+        prompt=prompt,
+    )
+except LLMExecutionError as first_error:
+    if first_error.category != ExecutionErrorCategory.RESPONSE_INVALID:
+        raise
+    print("   ⚠️  Empty model response; retrying once with reasoning disabled")
+    try:
+        response = _create_pipeline_response(
+            client,
+            model=resolved_model,
+            prompt=prompt,
+            reasoning_effort="none",
+        )
+    except TypeError:
+        # Preserve the original safe category for legacy clients that reject
+        # the optional retry kwarg instead of exposing an SDK TypeError.
+        raise first_error
+```
+
+Keep `llm_calls += 1`, usage extraction, parsing, and normalization immediately after this block. This means failed attempts do not become successful billable calls, while a successful retry follows the existing accounting path.
+
+- [ ] **Step 3: Run the pipeline test module**
+
+Run:
+
+```bash
+python -m pytest dashboard/backend/tests/infrastructure/llm/test_pipeline_runner.py -q
+```
+
+Expected: PASS for retry success, one-retry exhaustion, non-retryable errors, invalid JSON, and the existing pipeline normalization tests.
+
+- [ ] **Step 4: Commit the pipeline recovery**
+
+```bash
+git add dashboard/backend/infrastructure/llm/pipeline_runner.py dashboard/backend/tests/infrastructure/llm/test_pipeline_runner.py
+git commit -m "fix: recover OpenRouter empty pipeline responses"
+```
+
+### Task 4: Verify the complete regression surface
+
+**Files:**
+- Test: `dashboard/backend/tests/infrastructure/llm/test_execution_adapter_model_routes.py`
+- Test: `dashboard/backend/tests/infrastructure/llm/test_pipeline_runner.py`
+- Test: `dashboard/backend/tests/infrastructure/llm/test_execution_client.py`
+- Test: `dashboard/backend/tests/llm/test_backtest_harness.py`
+- Test: `dashboard/backend/tests/backtesting/test_portfolio_manager_move.py`
+
+**Interfaces:**
+- Consumes: the adapter payload contract and pipeline retry implementation from Tasks 1-3.
+- Produces: evidence that OpenRouter routing, unified execution, legacy harness behavior, and strict portfolio handling remain compatible.
+
+- [ ] **Step 1: Run the focused execution and pipeline tests**
+
+```bash
+python -m pytest \
+  dashboard/backend/tests/infrastructure/llm/test_execution_adapter_model_routes.py \
+  dashboard/backend/tests/infrastructure/llm/test_pipeline_runner.py \
+  dashboard/backend/tests/infrastructure/llm/test_execution_client.py -q
+```
+
+Expected: PASS with no network access and no real credential use.
+
+- [ ] **Step 2: Run related LLM and strict backtesting tests**
+
+```bash
+python -m pytest \
+  dashboard/backend/tests/llm/test_backtest_harness.py \
+  dashboard/backend/tests/llm/test_providers.py \
+  dashboard/backend/tests/backtesting/test_portfolio_manager_move.py -q
+```
+
+Expected: PASS; existing non-pipeline rescue behavior and strict fallback boundaries remain unchanged.
+
+- [ ] **Step 3: Run repository hygiene checks**
+
+```bash
+git diff --check
+git status --short --branch
+```
+
+Expected: no whitespace errors, no untracked secrets, and only the spec/plan plus the scoped adapter, pipeline, and test changes.
+
+- [ ] **Step 4: Push the fix branch for deployment verification**
+
+```bash
+git push -u origin fix/openrouter-empty-response-recovery
+```
+
+Expected: the branch contains both implementation commits after the already-pushed design commit; Render must deploy the new head before a real Qwen run can validate recovery.

--- a/docs/superpowers/specs/2026-08-29-openrouter-empty-response-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-29-openrouter-empty-response-recovery-design.md
@@ -1,0 +1,138 @@
+# OpenRouter Empty Response Recovery Design
+
+**Date:** 2026-08-29
+**Status:** Proposed
+**Scope:** Recover platform-credits backtests when OpenRouter returns no text
+
+## Incident
+
+The latest Qwen/OpenRouter platform-credits backtest reached the model call but
+ended with the safe error `ProviderExecutionError: The model returned an
+invalid response.` There was no Render out-of-memory signal. The OpenAI-
+compatible adapter currently extracts only `choices[0].message.content`.
+Reasoning models can spend the response budget on reasoning blocks, return an
+empty `content`, or otherwise provide no final text. The adapter correctly
+classifies that response as `response_invalid`, but the strict pipeline path
+does not recover from it, so the worker raises `LLMDecisionError` and the UI
+returns to its initial state without a result.
+
+The existing `{"orders": []}` normalization fix is separate: it handles valid
+JSON after text extraction and must remain unchanged.
+
+## Goal
+
+Give an OpenRouter reasoning model one bounded opportunity to return the same
+pipeline response with reasoning disabled. A successful retry must continue
+through the existing JSON parser and portfolio decision path. A second invalid
+response must fail exactly as it does today.
+
+## Request and provider contract
+
+1. Preserve the selected OpenRouter provider, model, prompt, max-output-token
+   limit, billing mode, and run identity for both attempts.
+2. Keep the current OpenRouter reasoning configuration as the default first
+   attempt. The configured `reasoning_effort` is passed through the existing
+   execution request and adapter contract.
+3. The recovery attempt explicitly passes `reasoning_effort="none"`. The
+   existing OpenRouter adapter maps that override to the provider's
+   reasoning-disabled payload, taking precedence over environment defaults.
+4. The retry is available only after an execution error whose category is
+   `response_invalid` (including an empty or reasoning-only response). It must
+   not be triggered by malformed request data, credential failures, provider
+   availability errors, timeouts, billing/usage failures, or invalid business
+   JSON returned as non-empty text.
+5. Retry at most once per pipeline step. There is no recursive retry, provider
+   fallback, model substitution, or frontend polling change.
+
+## Pipeline behavior
+
+`run_pipeline_decision()` remains sequential. For each step it performs the
+normal call first. If that call raises `LLMExecutionError` with category
+`response_invalid`, it logs a safe recovery message and repeats the exact
+request with `reasoning_effort="none"`. Each attempt receives its own
+monotonic `call_index`; only completed responses contribute token usage and
+the existing billable `llm_calls`/execution-summary aggregates.
+
+If the retry returns text, parsing and `pipeline_output_to_decision()` proceed
+normally. In particular, a valid `{"orders": []}` response remains the
+model-driven HOLD represented by `{"actions": []}`. If the retry is also
+empty/invalid, the original safe `response_invalid` error is re-raised so
+strict LLM backtests fail closed. Non-strict callers retain their existing
+fallback behavior.
+
+The retry helper must work with the existing Anthropic-shaped execution client
+and lightweight test doubles. It may add the override only to the retry
+request; callers that do not accept `reasoning_effort` must not be silently
+converted into a different error category.
+
+## Billing and settlement
+
+Each attempt is an independent call through the existing execution service.
+The client continues to allocate a unique `call_index` and to run the normal
+platform-credits reservation and settlement lifecycle for every attempt.
+
+- A failed attempt releases its reservation according to the current service
+  behavior.
+- A successful retry settles only the usage reported for that retry; aggregate
+  execution evidence continues to include completed calls using existing
+  semantics. The failed empty-response attempt is not treated as a billable
+  successful call.
+- BYOK calls never reserve, debit, or refund ATL Credits; this change does not
+  alter that lane.
+- No new ledger, refund, quota, or pricing policy is introduced.
+
+## Error and safety boundaries
+
+- Keep all public errors in the existing fixed `ExecutionErrorCategory` set.
+- Do not log upstream response bodies, reasoning text, API keys, or provider
+  request headers.
+- Do not treat an empty response as a HOLD. Only parseable empty envelopes
+  such as `{"orders": []}` are HOLD decisions.
+- Do not change Render memory, worker concurrency, deployment settings,
+  database schema, frontend state, or UI copy.
+
+## Implementation units
+
+- `dashboard/backend/infrastructure/llm/execution/adapters/openai.py`: retain
+  the safe empty-text classification and ensure the OpenRouter reasoning
+  override reaches the wire without changing other providers.
+- `dashboard/backend/infrastructure/llm/pipeline_runner.py`: add the bounded
+  `response_invalid` recovery around each decision-step model call.
+- `dashboard/backend/tests/infrastructure/llm/test_execution_adapter_model_routes.py`:
+  cover OpenRouter reasoning payloads and empty-response classification.
+- `dashboard/backend/tests/infrastructure/llm/test_pipeline_runner.py`: cover
+  one retry, retry success, retry exhaustion, non-retryable errors, and empty
+  `orders` HOLD handling.
+
+## Testing strategy
+
+Use deterministic fake clients and responses; no network calls or real
+credentials.
+
+1. Verify the first OpenRouter request preserves the configured reasoning
+   effort and the recovery request uses `none`.
+2. Verify an empty/ reasoning-only first response is retried once and a valid
+   second response is returned with the expected token totals and existing
+   billable call count.
+3. Verify a second `response_invalid` raises and does not make a third call.
+4. Verify credential, timeout, provider, billing, usage, and parse/business
+   JSON errors are not retried.
+5. Verify a retried `{"orders": []}` response is normalized to
+   `{"actions": []}` and reaches the existing HOLD behavior.
+
+Run the focused adapter and pipeline-runner tests, then the related backend
+LLM/backtesting test modules. Existing tests for non-empty decisions,
+OpenRouter environment defaults, and platform/BYOK settlement must remain
+green.
+
+## Acceptance criteria
+
+- The reproduced Qwen/OpenRouter empty-text failure either recovers on one
+  reasoning-disabled retry or reports the same safe failure promptly.
+- A successful retry produces a persisted backtest result rather than silently
+  returning to the initial page.
+- Only `response_invalid` receives one retry; all other failures keep current
+  fail-closed behavior.
+- Every attempt uses the existing billing and secret-handling paths.
+- No frontend, deployment, database, concurrency, or memory changes are part
+  of this pull request.


### PR DESCRIPTION
## Summary
- retry one `response_invalid` OpenRouter pipeline response with `reasoning_effort="none"`
- explicitly disable OpenRouter reasoning on the recovery request
- preserve existing fail-closed behavior, billing lifecycle, and `orders: []` HOLD normalization

## Verification
- `python -m pytest dashboard/backend/tests/infrastructure/llm dashboard/backend/tests/llm/test_backtest_harness.py dashboard/backend/tests/llm/test_providers.py dashboard/backend/tests/backtesting/test_portfolio_manager_move.py -q`
- 227 passed
- no network calls or real credentials used in tests

## Scope
No frontend, Render resource, concurrency, database, pricing, or credit-policy changes.