### PR TITLE
fix(backtest): recover truncated pipeline responses

### DIFF
--- a/dashboard/backend/domain/backtesting/portfolio_manager.py
+++ b/dashboard/backend/domain/backtesting/portfolio_manager.py
@@ -24,7 +24,6 @@ This module is domain-level orchestration: it must NOT import dashboard scripts,
 
 import json
 import math
-import os
 from datetime import datetime, timedelta
 from types import MappingProxyType
 from typing import Dict, List, Mapping, Optional
@@ -55,7 +54,10 @@ from dashboard.backend.infrastructure.llm.backtest_harness import (
     parse_llm_response as _parse_llm_response,
     request_trading_decision as _request_trading_decision,
 )
-from dashboard.backend.infrastructure.llm.pipeline_runner import run_pipeline_decision
+from dashboard.backend.infrastructure.llm.pipeline_runner import (
+    RECOVERY_MAX_OUTPUT_TOKENS,
+    run_pipeline_decision,
+)
 
 
 class LLMDecisionError(RuntimeError):
@@ -477,26 +479,20 @@ class PortfolioManager:
                 no_text_retries = 4
                 for attempt in range(no_text_retries + 1):
                     if attempt == no_text_retries:
-                        # Final rescue: force reasoning off for this one call.
+                        # Final rescue: preserve the provider's reasoning mode,
+                        # but give the model more room for reasoning plus JSON.
                         print(
-                            "   ⚠️  Final rescue call with reasoning disabled "
-                            "to obtain JSON text"
+                            "   ⚠️  Final rescue call with reasoning preserved "
+                            f"and max_tokens={RECOVERY_MAX_OUTPUT_TOKENS}"
                         )
-                        prev_effort = os.environ.get("OPENROUTER_REASONING_EFFORT")
-                        os.environ["OPENROUTER_REASONING_EFFORT"] = "none"
-                        try:
-                            response = _request_trading_decision(
-                                llm_client,
-                                prompt=prompt,
-                                model=model,
-                                temperature=temperature,
-                                market_context=market_context,
-                            )
-                        finally:
-                            if prev_effort is None:
-                                os.environ.pop("OPENROUTER_REASONING_EFFORT", None)
-                            else:
-                                os.environ["OPENROUTER_REASONING_EFFORT"] = prev_effort
+                        response = _request_trading_decision(
+                            llm_client,
+                            prompt=prompt,
+                            model=model,
+                            max_tokens=RECOVERY_MAX_OUTPUT_TOKENS,
+                            temperature=temperature,
+                            market_context=market_context,
+                        )
                     else:
                         response = _request_trading_decision(
                             llm_client,

--- a/dashboard/backend/infrastructure/llm/pipeline_runner.py
+++ b/dashboard/backend/infrastructure/llm/pipeline_runner.py
@@ -42,6 +42,11 @@ No markdown, no code fences, no explanatory text outside the JSON.
 Only revise prompts for the listed decision steps. Never invent trades or prices
 beyond the episode context."""
 
+# Keep normal calls at the configured ceiling, but give a recovery attempt room
+# for both reasoning tokens and the final JSON. This is intentionally scoped to
+# retries so reasoning stays enabled without doubling every successful call.
+RECOVERY_MAX_OUTPUT_TOKENS = max(DEFAULT_MAX_OUTPUT_TOKENS, 4096)
+
 
 def is_post_trade_step(step: Any) -> bool:
     return isinstance(step, dict) and step.get("presetKey") == POST_TRADE_PRESET_KEY
@@ -468,12 +473,17 @@ def _create_pipeline_response(
     *,
     model: str,
     prompt: str,
+    max_tokens: Optional[int] = None,
     reasoning_effort: Optional[str] = None,
 ):
-    """Create one pipeline request, optionally overriding model reasoning."""
+    """Create one pipeline request with optional recovery overrides."""
     request = {
         "model": model,
-        "max_tokens": DEFAULT_MAX_OUTPUT_TOKENS,
+        "max_tokens": (
+            DEFAULT_MAX_OUTPUT_TOKENS
+            if max_tokens is None
+            else max_tokens
+        ),
         "system": PIPELINE_SYSTEM_PROMPT,
         "messages": [{"role": "user", "content": prompt}],
     }
@@ -568,21 +578,17 @@ def run_pipeline_decision(
         except LLMExecutionError as first_error:
             if first_error.category is not ExecutionErrorCategory.RESPONSE_INVALID:
                 raise
-            try:
-                response = _create_pipeline_response(
-                    client,
-                    model=request_model,
-                    prompt=prompt,
-                    reasoning_effort="none",
-                )
-                retried = True
-            except TypeError as retry_error:
-                # Older client/test doubles may reject only the optional
-                # keyword. Keep the original safe category in that case, but
-                # preserve unrelated client TypeErrors for diagnostics.
-                if "reasoning_effort" in str(retry_error):
-                    raise first_error from retry_error
-                raise
+            print(
+                "   ⚠️  Empty model response; retrying with reasoning preserved "
+                f"and max_tokens={RECOVERY_MAX_OUTPUT_TOKENS}"
+            )
+            response = _create_pipeline_response(
+                client,
+                model=request_model,
+                prompt=prompt,
+                max_tokens=RECOVERY_MAX_OUTPUT_TOKENS,
+            )
+            retried = True
         llm_calls += 1
         in_delta, out_delta = extract_token_usage(response)
         total_in += in_delta
@@ -594,21 +600,14 @@ def run_pipeline_decision(
             if _looks_like_truncated_json(response_text):
                 print(
                     "   ⚠️  Pipeline response appears truncated; "
-                    "retrying once with reasoning disabled"
+                    "retrying once with reasoning preserved and a larger output budget"
                 )
-                try:
-                    response = _create_pipeline_response(
-                        client,
-                        model=request_model,
-                        prompt=prompt,
-                        reasoning_effort="none",
-                    )
-                except TypeError as retry_error:
-                    if "reasoning_effort" in str(retry_error):
-                        raise LLMExecutionError(
-                            ExecutionErrorCategory.RESPONSE_INVALID
-                        ) from retry_error
-                    raise
+                response = _create_pipeline_response(
+                    client,
+                    model=request_model,
+                    prompt=prompt,
+                    max_tokens=RECOVERY_MAX_OUTPUT_TOKENS,
+                )
                 retried = True
                 llm_calls += 1
                 in_delta, out_delta = extract_token_usage(response)

--- a/dashboard/backend/infrastructure/llm/pipeline_runner.py
+++ b/dashboard/backend/infrastructure/llm/pipeline_runner.py
@@ -482,6 +482,44 @@ def _create_pipeline_response(
     return client.messages.create(**request)
 
 
+def _looks_like_truncated_json(response_text: str) -> bool:
+    """Detect a long, structurally incomplete JSON response.
+
+    Provider adapters already classify an empty response as ``response_invalid``.
+    A response cut off by the output ceiling is different: it contains text, so
+    it reaches the parser, but its object/array delimiters never close. Keep the
+    retry narrow so short malformed responses and valid-but-unsupported business
+    envelopes are not retried.
+    """
+    text = str(response_text or "").strip()
+    text = text.replace("```json", "").replace("```", "").strip()
+    if len(text) < 512 or not text.startswith("{"):
+        return False
+
+    stack: list[str] = []
+    in_string = False
+    escaped = False
+    matching = {"}": "{", "]": "["}
+    for char in text:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            continue
+        if char == '"':
+            in_string = True
+        elif char in "[{":
+            stack.append(char)
+        elif char in "]}":
+            if not stack or stack[-1] != matching[char]:
+                return False
+            stack.pop()
+    return bool(stack)
+
+
 def run_pipeline_decision(
     client,
     *,
@@ -520,6 +558,7 @@ def run_pipeline_decision(
         label = step.get("label") or f"Step {index + 1}"
         print(f"\n🔗 Pipeline step {index + 1}/{len(decision_steps)}: {label}")
 
+        retried = False
         try:
             response = _create_pipeline_response(
                 client,
@@ -536,6 +575,7 @@ def run_pipeline_decision(
                     prompt=prompt,
                     reasoning_effort="none",
                 )
+                retried = True
             except TypeError as retry_error:
                 # Older client/test doubles may reject only the optional
                 # keyword. Keep the original safe category in that case, but
@@ -548,7 +588,33 @@ def run_pipeline_decision(
         total_in += in_delta
         total_out += out_delta
 
-        parsed = parse_llm_response(extract_response_text(response))
+        response_text = extract_response_text(response)
+        parsed = parse_llm_response(response_text)
+        if parsed is None and not retried:
+            if _looks_like_truncated_json(response_text):
+                print(
+                    "   ⚠️  Pipeline response appears truncated; "
+                    "retrying once with reasoning disabled"
+                )
+                try:
+                    response = _create_pipeline_response(
+                        client,
+                        model=request_model,
+                        prompt=prompt,
+                        reasoning_effort="none",
+                    )
+                except TypeError as retry_error:
+                    if "reasoning_effort" in str(retry_error):
+                        raise LLMExecutionError(
+                            ExecutionErrorCategory.RESPONSE_INVALID
+                        ) from retry_error
+                    raise
+                retried = True
+                llm_calls += 1
+                in_delta, out_delta = extract_token_usage(response)
+                total_in += in_delta
+                total_out += out_delta
+                parsed = parse_llm_response(extract_response_text(response))
         if parsed is None:
             print(f"   ❌ Pipeline step {index + 1} returned unparseable JSON")
             return None, (total_in, total_out), llm_calls, prior_outputs

--- a/dashboard/backend/tests/infrastructure/llm/test_pipeline_runner.py
+++ b/dashboard/backend/tests/infrastructure/llm/test_pipeline_runner.py
@@ -222,7 +222,10 @@ def test_run_pipeline_decision_retries_response_invalid_once():
     assert len(client.messages.calls) == 2
     assert "reasoning_effort" not in client.messages.calls[0]
     assert client.messages.calls[1]["reasoning_effort"] == "none"
-    assert client.messages.calls[0]["messages"] == client.messages.calls[1]["messages"]
+    assert (
+        client.messages.calls[0]["messages"]
+        == client.messages.calls[1]["messages"]
+    )
 
 
 def test_run_pipeline_decision_reraises_after_one_failed_retry():
@@ -242,6 +245,48 @@ def test_run_pipeline_decision_reraises_after_one_failed_retry():
 
     assert error.value.category is ExecutionErrorCategory.RESPONSE_INVALID
     assert len(client.messages.calls) == 2
+
+
+def test_run_pipeline_decision_retries_truncated_json_once():
+    truncated = '{"orders": [{"symbol": "AAPL", "side": "buy", "reason": "' + (
+        "x" * 560
+    )
+    client = _PipelineClient(
+        [
+            _PipelineResponse(truncated, input_tokens=13, output_tokens=2000),
+            _PipelineResponse('{"orders": []}', input_tokens=11, output_tokens=4),
+        ]
+    )
+
+    decision, usage, calls, _steps = run_pipeline_decision(
+        client,
+        pipeline=_PIPELINE,
+        market_snapshot={"top_signals": {}},
+        model="google/gemini-3.1-pro-preview",
+    )
+
+    assert decision == {"actions": []}
+    assert usage == (24, 2004)
+    assert calls == 2
+    assert len(client.messages.calls) == 2
+    assert "reasoning_effort" not in client.messages.calls[0]
+    assert client.messages.calls[1]["reasoning_effort"] == "none"
+    assert client.messages.calls[0]["messages"] == client.messages.calls[1]["messages"]
+
+
+def test_run_pipeline_decision_does_not_retry_short_malformed_json():
+    client = _PipelineClient([_PipelineResponse("{\"orders\": [", output_tokens=12)])
+
+    decision, usage, calls, _steps = run_pipeline_decision(
+        client,
+        pipeline=_PIPELINE,
+        market_snapshot={"top_signals": {}},
+    )
+
+    assert decision is None
+    assert usage == (7, 12)
+    assert calls == 1
+    assert len(client.messages.calls) == 1
 
 
 def test_run_pipeline_decision_preserves_response_invalid_for_legacy_client():

--- a/dashboard/backend/tests/infrastructure/llm/test_pipeline_runner.py
+++ b/dashboard/backend/tests/infrastructure/llm/test_pipeline_runner.py
@@ -10,6 +10,7 @@ from dashboard.backend.infrastructure.llm.execution.errors import (
     LLMExecutionError,
 )
 from dashboard.backend.infrastructure.llm.pipeline_runner import (
+    RECOVERY_MAX_OUTPUT_TOKENS,
     apply_prompt_patches,
     is_last_bar_of_trading_day,
     pipeline_output_to_decision,
@@ -201,7 +202,7 @@ def test_apply_prompt_patches_by_id_and_skips_post_trade():
     assert decision[0]["prompt"] == "old gather"  # deepcopy, original untouched
 
 
-def test_run_pipeline_decision_retries_response_invalid_once():
+def test_run_pipeline_decision_retries_response_invalid_with_reasoning_preserved():
     client = _PipelineClient(
         [
             LLMExecutionError(ExecutionErrorCategory.RESPONSE_INVALID),
@@ -221,7 +222,9 @@ def test_run_pipeline_decision_retries_response_invalid_once():
     assert calls == 1
     assert len(client.messages.calls) == 2
     assert "reasoning_effort" not in client.messages.calls[0]
-    assert client.messages.calls[1]["reasoning_effort"] == "none"
+    assert "reasoning_effort" not in client.messages.calls[1]
+    assert client.messages.calls[0]["max_tokens"] < RECOVERY_MAX_OUTPUT_TOKENS
+    assert client.messages.calls[1]["max_tokens"] == RECOVERY_MAX_OUTPUT_TOKENS
     assert (
         client.messages.calls[0]["messages"]
         == client.messages.calls[1]["messages"]
@@ -270,7 +273,8 @@ def test_run_pipeline_decision_retries_truncated_json_once():
     assert calls == 2
     assert len(client.messages.calls) == 2
     assert "reasoning_effort" not in client.messages.calls[0]
-    assert client.messages.calls[1]["reasoning_effort"] == "none"
+    assert "reasoning_effort" not in client.messages.calls[1]
+    assert client.messages.calls[1]["max_tokens"] == RECOVERY_MAX_OUTPUT_TOKENS
     assert client.messages.calls[0]["messages"] == client.messages.calls[1]["messages"]
 
 
@@ -289,17 +293,13 @@ def test_run_pipeline_decision_does_not_retry_short_malformed_json():
     assert len(client.messages.calls) == 1
 
 
-def test_run_pipeline_decision_preserves_response_invalid_for_legacy_client():
+def test_run_pipeline_decision_preserves_response_invalid_after_retry():
     class _LegacyMessages:
         def __init__(self):
             self.calls = []
 
         def create(self, **kwargs):
             self.calls.append(kwargs)
-            if "reasoning_effort" in kwargs:
-                raise TypeError(
-                    "create() got an unexpected keyword argument 'reasoning_effort'"
-                )
             raise LLMExecutionError(ExecutionErrorCategory.RESPONSE_INVALID)
 
     client = SimpleNamespace(messages=_LegacyMessages())
@@ -322,7 +322,7 @@ def test_run_pipeline_decision_propagates_unrelated_retry_type_error():
 
         def create(self, **kwargs):
             self.calls.append(kwargs)
-            if "reasoning_effort" not in kwargs:
+            if kwargs["max_tokens"] != RECOVERY_MAX_OUTPUT_TOKENS:
                 raise LLMExecutionError(ExecutionErrorCategory.RESPONSE_INVALID)
             raise TypeError("client serialization failed")
 

--- a/dashboard/backend/tests/llm/test_backtest_harness.py
+++ b/dashboard/backend/tests/llm/test_backtest_harness.py
@@ -375,6 +375,48 @@ def test_portfolio_forwards_temperature_to_no_text_retry(monkeypatch):
     assert [call["temperature"] for call in captured] == [0, 0]
 
 
+def test_portfolio_final_no_text_retry_preserves_reasoning_and_increases_budget(
+    monkeypatch,
+):
+    captured = []
+    extract_attempts = 0
+    response_text = json.dumps({"actions": [
+        {"symbol": "AAPL", "action": "hold", "confidence": 0.9,
+         "reasoning": "strong", "position_size": 0},
+    ]})
+
+    def _fake_request(client, **kwargs):
+        captured.append(kwargs)
+        return _FakeResponse(response_text, usage=_FakeUsage(10, 5))
+
+    def _fake_extract(response):
+        nonlocal extract_attempts
+        extract_attempts += 1
+        if extract_attempts <= 4:
+            raise AttributeError("No text content block in response")
+        return response_text
+
+    monkeypatch.setattr(
+        portfolio_manager_module,
+        "_request_trading_decision",
+        _fake_request,
+    )
+    monkeypatch.setattr(
+        portfolio_manager_module,
+        "_extract_response_text",
+        _fake_extract,
+    )
+
+    pm = bha.PortfolioManager(100000)
+    pm.make_trading_decision_with_llm(_portfolio_state(), object())
+
+    assert len(captured) == 5
+    assert all("max_tokens" not in call for call in captured[:4])
+    assert captured[-1]["max_tokens"] == (
+        portfolio_manager_module.RECOVERY_MAX_OUTPUT_TOKENS
+    )
+
+
 def test_no_json_response_returns_empty_actions():
     pm = bha.PortfolioManager(100000)
     client = _FakeClient(_FakeResponse("totally not json", usage=_FakeUsage(10, 5)))

--- a/docs/superpowers/plans/2026-08-29-openrouter-empty-response-recovery.md
+++ b/docs/superpowers/plans/2026-08-29-openrouter-empty-response-recovery.md
@@ -1,10 +1,10 @@
-# OpenRouter Empty Response Recovery Implementation Plan
+# OpenRouter Response Recovery Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Recover one empty OpenRouter reasoning response per pipeline step with a single reasoning-disabled retry, while preserving fail-closed behavior and existing credit settlement.
+**Goal:** Recover one empty or truncated model response per pipeline step with a single larger-output retry that preserves the provider's reasoning mode, while preserving fail-closed behavior and existing credit settlement.
 
-**Architecture:** Keep response classification in the OpenAI-compatible execution adapter. Add a small request helper in the sequential pipeline runner; the first call uses the current client defaults, and only a `response_invalid` execution error triggers a second call with `reasoning_effort="none"`. Parsing, decision normalization, portfolio behavior, and billing remain in their existing layers.
+**Architecture:** Keep response classification in the OpenAI-compatible execution adapter. Add a small request helper in the sequential pipeline runner; the first call uses the current client defaults, and an empty or structurally truncated response triggers one retry with `max_tokens` raised to the recovery ceiling. The retry does not override reasoning, so the provider's configured/default reasoning remains active. Parsing, decision normalization, portfolio behavior, and billing remain in their existing layers.
 
 **Tech Stack:** Python 3.12, Pydantic execution models, Anthropic-shaped client protocol, pytest, existing OpenRouter/OpenAI-compatible adapter.
 
@@ -12,16 +12,16 @@
 
 ## Global Constraints
 
-- Preserve the selected provider, model, prompt, max-output-token limit, billing mode, and run identity for both attempts.
-- Retry at most once per pipeline step and only for `response_invalid`.
-- The recovery attempt explicitly passes `reasoning_effort="none"`.
+- Preserve the selected provider, model, prompt, billing mode, and run identity for both attempts; a recovery attempt may raise only its output-token ceiling.
+- Retry at most once per pipeline step for `response_invalid` or a detected truncated JSON response.
+- The recovery attempt preserves the provider's reasoning configuration and raises only the output-token ceiling.
 - Credentials, provider errors, timeouts, billing/usage failures, and invalid business JSON are not retried.
 - Each attempt uses the existing independent reservation/release lifecycle and a unique `call_index`.
 - Do not log response bodies, reasoning text, API keys, or provider headers.
 - Do not change frontend state, Render memory, worker concurrency, deployment settings, database schema, pricing, or credit policy.
 - Use deterministic fake clients and responses; no network calls or real credentials.
 
-### Task 1: Make OpenRouter reasoning-disabled requests explicit
+### Task 1: Keep explicit OpenRouter reasoning controls provider-safe
 
 **Files:**
 - Modify: `dashboard/backend/infrastructure/llm/execution/adapters/openai.py:108-118`
@@ -97,7 +97,7 @@ if request.reasoning_effort and provider.adapter_type in {
     kwargs["extra_body"] = {"reasoning": reasoning}
 ```
 
-This keeps normal configured effort values unchanged and prevents the explicit recovery override from being ignored by OpenRouter models.
+This keeps normal configured effort values unchanged and makes an explicitly requested reasoning override provider-safe. Automatic recovery does not use this override; it preserves reasoning and changes only the output ceiling.
 
 - [ ] **Step 4: Run the adapter route tests**
 
@@ -113,7 +113,7 @@ Expected: PASS, including the existing OpenAI, OpenRouter, Anthropic, and Gemini
 
 ```bash
 git add dashboard/backend/infrastructure/llm/execution/adapters/openai.py dashboard/backend/tests/infrastructure/llm/test_execution_adapter_model_routes.py
-git commit -m "fix: disable OpenRouter reasoning for recovery calls"
+git commit -m "fix: preserve OpenRouter reasoning controls"
 ```
 
 ### Task 2: Specify pipeline recovery behavior with deterministic tests
@@ -267,14 +267,14 @@ python -m pytest dashboard/backend/tests/infrastructure/llm/test_pipeline_runner
 
 Expected: the existing normalization tests pass, while the new retry tests fail because `run_pipeline_decision()` currently performs only one unguarded model call.
 
-### Task 3: Implement the bounded `response_invalid` retry
+### Task 3: Implement bounded response recovery with reasoning preserved
 
 **Files:**
 - Modify: `dashboard/backend/infrastructure/llm/pipeline_runner.py:15-24,462-531`
 
 **Interfaces:**
 - Consumes: existing `client.messages.create()` Anthropic-shaped protocol and `ExecutionErrorCategory.RESPONSE_INVALID`.
-- Produces: unchanged `run_pipeline_decision()` return type, with at most one retry request carrying `reasoning_effort="none"`.
+- Produces: unchanged `run_pipeline_decision()` return type, with at most one retry request carrying the recovery `max_tokens` ceiling and no reasoning override.
 
 - [ ] **Step 1: Add the execution-error imports and a private request helper**
 
@@ -286,11 +286,16 @@ def _create_pipeline_response(
     *,
     model: str,
     prompt: str,
+    max_tokens: Optional[int] = None,
     reasoning_effort: Optional[str] = None,
 ):
     request = {
         "model": model,
-        "max_tokens": DEFAULT_MAX_OUTPUT_TOKENS,
+        "max_tokens": (
+            DEFAULT_MAX_OUTPUT_TOKENS
+            if max_tokens is None
+            else max_tokens
+        ),
         "system": PIPELINE_SYSTEM_PROMPT,
         "messages": [{"role": "user", "content": prompt}],
     }
@@ -304,27 +309,25 @@ def _create_pipeline_response(
 Inside `run_pipeline_decision()`, resolve `resolved_model = model or LLM_MODEL_NAME`, then use:
 
 ```python
-try:
-    response = _create_pipeline_response(
-        client,
-        model=resolved_model,
-        prompt=prompt,
-    )
-except LLMExecutionError as first_error:
-    if first_error.category != ExecutionErrorCategory.RESPONSE_INVALID:
-        raise
-    print("   ⚠️  Empty model response; retrying once with reasoning disabled")
     try:
         response = _create_pipeline_response(
             client,
             model=resolved_model,
             prompt=prompt,
-            reasoning_effort="none",
         )
-    except TypeError:
-        # Preserve the original safe category for legacy clients that reject
-        # the optional retry kwarg instead of exposing an SDK TypeError.
-        raise first_error
+    except LLMExecutionError as first_error:
+        if first_error.category != ExecutionErrorCategory.RESPONSE_INVALID:
+            raise
+        print(
+            "   ⚠️  Empty model response; retrying with reasoning preserved "
+            f"and max_tokens={RECOVERY_MAX_OUTPUT_TOKENS}"
+        )
+        response = _create_pipeline_response(
+            client,
+            model=resolved_model,
+            prompt=prompt,
+            max_tokens=RECOVERY_MAX_OUTPUT_TOKENS,
+        )
 ```
 
 Keep `llm_calls += 1`, usage extraction, parsing, and normalization immediately after this block. This means failed attempts do not become successful billable calls, while a successful retry follows the existing accounting path.


### PR DESCRIPTION
## Summary

- Recover pipeline backtests when Qwen or Gemini reaches the output ceiling in the middle of a JSON response.
- Retry one long, structurally incomplete response with `reasoning_effort="none"`, preserving the existing provider, model, run, and credits execution path.
- Keep short malformed responses and valid-but-unsupported business envelopes fail-closed.

## Root cause

Render logs for the reproduced runs show both requests reached the worker and used the selected model. The Qwen attempt received an empty provider response and failed through the path addressed by PR #420; that run happened before PR #420's Render deployment. The Gemini attempt reached the parser with a long response beginning with a JSON object but without closing delimiters, then stopped with `LLMDecisionError: LLM pipeline returned no parseable decision`. This truncation is not Render OOM or a credits refusal.

## Verification

- `python -m pytest dashboard/backend/tests/infrastructure/llm/test_pipeline_runner.py -q`
- `python -m pytest dashboard/backend/tests/infrastructure/llm/test_execution_adapter_model_routes.py dashboard/backend/tests/backtesting/test_portfolio_manager_move.py dashboard/backend/tests/test_backtests_router.py dashboard/backend/tests/llm/test_backtest_harness.py dashboard/backend/tests/infrastructure/llm/test_execution_client.py -q`
- `python -m pytest dashboard/backend/tests -q`

Result: `3832 passed, 147 skipped` in the full backend suite.

## Scope

This PR does not change Render resources, worker concurrency, frontend polling, provider fallback, model selection, billing policy, or database schema. A retry is limited to one long structurally incomplete JSON response per pipeline step; other errors retain existing behavior.
