### PR TITLE
fix: recover short truncated pipeline responses

### DIFF
--- a/dashboard/backend/infrastructure/llm/pipeline_runner.py
+++ b/dashboard/backend/infrastructure/llm/pipeline_runner.py
@@ -503,7 +503,14 @@ def _looks_like_truncated_json(response_text: str) -> bool:
     """
     text = str(response_text or "").strip()
     text = text.replace("```json", "").replace("```", "").strip()
-    if len(text) < 512 or not text.startswith("{"):
+    # Reasoning can consume most of the provider output budget, leaving a
+    # surprisingly short JSON prefix (the production failure was ~170 chars).
+    # Keep a small floor to avoid retrying a bare ``{"orders": [`` typo, while
+    # requiring a known decision envelope so unrelated malformed JSON is not
+    # treated as a truncation.
+    if len(text) < 64 or not text.startswith("{"):
+        return False
+    if not any(f'"{key}"' in text for key in ("actions", "orders", "risk_actions")):
         return False
 
     stack: list[str] = []

--- a/dashboard/backend/tests/infrastructure/llm/test_pipeline_runner.py
+++ b/dashboard/backend/tests/infrastructure/llm/test_pipeline_runner.py
@@ -278,6 +278,34 @@ def test_run_pipeline_decision_retries_truncated_json_once():
     assert client.messages.calls[0]["messages"] == client.messages.calls[1]["messages"]
 
 
+def test_run_pipeline_decision_retries_short_reasoning_truncation_once():
+    """A reasoning-heavy response can be truncated below the old 512-char floor."""
+    truncated = (
+        '{"orders": [{"symbol": "BA", "side": "hold", "qty": 2, '
+        '"order_type": "market", "limit_price": null, "reason": "Experi'
+    )
+    assert len(truncated) >= 64
+    client = _PipelineClient(
+        [
+            _PipelineResponse(truncated, input_tokens=13, output_tokens=2000),
+            _PipelineResponse('{"orders": []}', input_tokens=11, output_tokens=4),
+        ]
+    )
+
+    decision, usage, calls, _steps = run_pipeline_decision(
+        client,
+        pipeline=_PIPELINE,
+        market_snapshot={"top_signals": {}},
+        model="qwen/qwen3.7-plus",
+    )
+
+    assert decision == {"actions": []}
+    assert usage == (24, 2004)
+    assert calls == 2
+    assert len(client.messages.calls) == 2
+    assert client.messages.calls[1]["max_tokens"] == RECOVERY_MAX_OUTPUT_TOKENS
+
+
 def test_run_pipeline_decision_does_not_retry_short_malformed_json():
     client = _PipelineClient([_PipelineResponse("{\"orders\": [", output_tokens=12)])
 

--- a/dashboard/backend/tests/test_market_data_errors.py
+++ b/dashboard/backend/tests/test_market_data_errors.py
@@ -70,3 +70,25 @@ def test_cli_entrypoints_translate_the_error_to_an_exit_code():
         assert "MarketDataUnavailableError" in source, (
             f"{name} must translate MarketDataUnavailableError to an exit code"
         )
+
+
+def test_backtest_cli_closes_pools_at_exit(monkeypatch):
+    """Short-lived backtest CLIs must return pooled workers before exit."""
+    from pathlib import Path
+
+    from dashboard.backend import db_pool
+    from dashboard.scripts import backtest_hourly_agent
+
+    calls = []
+    monkeypatch.setattr(db_pool, "close_all_pools", lambda: calls.append(True))
+
+    backtest_hourly_agent._close_pools()
+
+    assert calls == [True]
+
+    scripts_dir = Path(__file__).resolve().parents[2] / "scripts"
+    custom_source = (scripts_dir / "backtest_custom_algo.py").read_text(
+        encoding="utf-8"
+    )
+    assert "def _close_pools" in custom_source
+    assert "_close_pools()" in custom_source

--- a/dashboard/scripts/backtest_custom_algo.py
+++ b/dashboard/scripts/backtest_custom_algo.py
@@ -433,14 +433,24 @@ def main() -> int:
     return 0
 
 
+def _close_pools() -> None:
+    """Close shared Postgres pools before this short-lived CLI exits."""
+    pool_module = sys.modules.get("dashboard.backend.db_pool")
+    if pool_module is not None:
+        pool_module.close_all_pools()
+
+
 if __name__ == "__main__":
     from dashboard.backend.infrastructure.market_data.alpaca_bars import (
         MarketDataUnavailableError,
     )
 
     try:
-        sys.exit(main())
-    except MarketDataUnavailableError as exc:
-        # Library code raises; the CLI boundary owns the process exit.
-        print(f"ERROR: {exc}")
-        sys.exit(1)
+        try:
+            sys.exit(main())
+        except MarketDataUnavailableError as exc:
+            # Library code raises; the CLI boundary owns the process exit.
+            print(f"ERROR: {exc}")
+            sys.exit(1)
+    finally:
+        _close_pools()

--- a/dashboard/scripts/backtest_hourly_agent.py
+++ b/dashboard/scripts/backtest_hourly_agent.py
@@ -526,15 +526,27 @@ def main():
     print(f"\n📊 Dashboard: python3 dashboard/backend/app.py → http://localhost:8000")
 
 
+def _close_pools() -> None:
+    """Close shared Postgres pools before this short-lived CLI exits."""
+    # Avoid importing psycopg on paths that never selected a Postgres store.
+    # The registry is already loaded when a pooled store was used.
+    pool_module = sys.modules.get("dashboard.backend.db_pool")
+    if pool_module is not None:
+        pool_module.close_all_pools()
+
+
 if __name__ == "__main__":
     # Reached through the module alias bound at the top rather than a second
     # `from` import of the same module: importing one module both ways in one
     # file is its own CodeQL finding (py/import-and-import-from), and the alias
     # already exists.
     try:
-        main()
-    except _alpaca_bars.MarketDataUnavailableError as exc:
-        # Library code raises (so server threads can catch it); the CLI
-        # boundary is where the process exit belongs.
-        print(f"❌ {exc}")
-        sys.exit(1)
+        try:
+            main()
+        except _alpaca_bars.MarketDataUnavailableError as exc:
+            # Library code raises (so server threads can catch it); the CLI
+            # boundary is where the process exit belongs.
+            print(f"❌ {exc}")
+            sys.exit(1)
+    finally:
+        _close_pools()


### PR DESCRIPTION
## Summary
- retry reasoning-heavy pipeline responses that are truncated before the old 512-character detection floor
- keep reasoning enabled and use the existing 4096-token recovery budget
- explicitly close shared Postgres pools when short-lived backtest CLIs exit

## Root cause
Render run `agent_20260830_025336_90e4faad` reached the third Qwen pipeline decision with an incomplete `orders` JSON response. The response was shorter than the previous truncation detector threshold, so no recovery request was sent and strict LLM mode raised `LLMDecisionError`. The `psycopg_pool` worker/scheduler messages were shutdown warnings emitted after that failure.

## Verification
- `python -m compileall -q dashboard/backend/infrastructure/llm/pipeline_runner.py dashboard/scripts/backtest_hourly_agent.py dashboard/scripts/backtest_custom_algo.py`
- `pytest -q dashboard/backend/tests/infrastructure/llm/test_pipeline_runner.py dashboard/backend/tests/test_market_data_errors.py`
- `pytest -q dashboard/backend/tests`
- Result: 3835 passed, 147 skipped
