### PR TITLE
fix(llm): pipeline retry accounting and stop reasons

### DIFF
--- a/dashboard/backend/infrastructure/llm/backtest_harness.py
+++ b/dashboard/backend/infrastructure/llm/backtest_harness.py
@@ -336,9 +336,12 @@ def parse_llm_response(llm_response: str) -> Optional[Dict]:
                     close_count = json_str_fixed.count('}')
                     if open_count != close_count:
                         print(f"   Bracket mismatch: {open_count} open, {close_count} close")
-                        # Remove extra closing brackets from the end
+                        # Remove extra closing brackets from the end. Drop one
+                        # ``}`` per pass: the old form re-appended the brace it
+                        # had just cut, so the counts never changed and this
+                        # loop spun forever on a reply with one stray ``}``.
                         while json_str_fixed.count('}') > json_str_fixed.count('{'):
-                            json_str_fixed = json_str_fixed.rsplit('}', 1)[0] + '}'
+                            json_str_fixed = json_str_fixed.rsplit('}', 1)[0]
                         print(f"   Removed extra closing brackets")
 
                     decision = json.loads(json_str_fixed)

--- a/dashboard/backend/infrastructure/llm/execution/adapters/anthropic.py
+++ b/dashboard/backend/infrastructure/llm/execution/adapters/anthropic.py
@@ -18,6 +18,7 @@ from .base import (
     ProviderExecutionError,
     build_safe_http_client,
     map_provider_error,
+    normalize_finish_reason,
     optional_nonnegative_float,
     usage_from_fields,
     value_at,
@@ -98,6 +99,9 @@ class AnthropicExecutionAdapter:
                 usage=normalized_usage,
                 provider_cost_usd=optional_nonnegative_float(
                     value_at(response, "cost", value_at(usage, "cost"))
+                ),
+                finish_reason=normalize_finish_reason(
+                    value_at(response, "stop_reason")
                 ),
             )
         except ProviderExecutionError:

--- a/dashboard/backend/infrastructure/llm/execution/adapters/base.py
+++ b/dashboard/backend/infrastructure/llm/execution/adapters/base.py
@@ -33,12 +33,45 @@ class CredentialMaterial(Protocol):
     secret: str
 
 
+# Provider spellings of "the reply stopped at the output ceiling", folded to
+# one value so callers above the adapters never see the vendor vocabulary.
+_OUTPUT_CEILING_FINISH_REASONS = frozenset({"length", "max_tokens"})
+FINISH_REASON_MAX_TOKENS = "max_tokens"
+# ``LLMExecutionResult.finish_reason`` is bounded; an OpenAI-compatible
+# provider may put anything in this field, and a long value must not turn a
+# successful call into ``response_invalid`` when the result model rejects it.
+_FINISH_REASON_MAX_LENGTH = 32
+
+
+def normalize_finish_reason(value: Any) -> str | None:
+    """Fold a provider stop/finish reason into a lowercase, vendor-neutral tag.
+
+    ``length`` (OpenAI / OpenRouter), ``MAX_TOKENS`` (Gemini) and
+    ``max_tokens`` (Anthropic) all become ``"max_tokens"``; any other string is
+    passed through lowercased (and clamped to the result model's length bound)
+    so it stays inspectable; anything else is ``None``.
+    """
+    if not isinstance(value, str):
+        return None
+    reason = value.strip().lower()
+    if not reason:
+        return None
+    if reason in _OUTPUT_CEILING_FINISH_REASONS:
+        return FINISH_REASON_MAX_TOKENS
+    return reason[:_FINISH_REASON_MAX_LENGTH]
+
+
 @dataclass(frozen=True)
 class AdapterResponse:
     text: str
     model_id: str
     usage: LLMUsage | None
     provider_cost_usd: float | None = None
+    # Why the provider stopped generating, via ``normalize_finish_reason``.
+    # ``"max_tokens"`` is the one value callers act on: the reply was cut at
+    # the output ceiling, so an unparseable body is a truncation, not a
+    # malformed answer. ``None`` when the provider reported nothing.
+    finish_reason: str | None = None
 
 
 class ProviderExecutionError(LLMExecutionError):
@@ -51,7 +84,8 @@ class ProviderExecutionAdapter(Protocol):
         request: LLMExecutionRequest,
         credential: CredentialMaterial,
         provider: ProviderRecord,
-    ) -> AdapterResponse: ...
+    ) -> AdapterResponse:
+        """Run one completion against ``provider`` and return its normalised reply."""
 
 
 def value_at(value: Any, name: str, default: Any = None) -> Any:
@@ -132,6 +166,7 @@ ClientFactory = Callable[..., Any]
 
 
 __all__ = [
+    "FINISH_REASON_MAX_TOKENS",
     "AdapterResponse",
     "ClientFactory",
     "CredentialMaterial",
@@ -139,6 +174,7 @@ __all__ = [
     "ProviderExecutionError",
     "build_safe_http_client",
     "map_provider_error",
+    "normalize_finish_reason",
     "optional_nonnegative_float",
     "usage_from_fields",
     "value_at",

--- a/dashboard/backend/infrastructure/llm/execution/adapters/gemini.py
+++ b/dashboard/backend/infrastructure/llm/execution/adapters/gemini.py
@@ -17,6 +17,7 @@ from .base import (
     ProviderExecutionError,
     build_safe_http_client,
     map_provider_error,
+    normalize_finish_reason,
     optional_nonnegative_float,
     usage_from_fields,
     value_at,
@@ -102,6 +103,9 @@ class GeminiExecutionAdapter:
                 usage=usage,
                 provider_cost_usd=optional_nonnegative_float(
                     value_at(data, "cost")
+                ),
+                finish_reason=normalize_finish_reason(
+                    value_at(first, "finishReason")
                 ),
             )
         except ProviderExecutionError:

--- a/dashboard/backend/infrastructure/llm/execution/adapters/openai.py
+++ b/dashboard/backend/infrastructure/llm/execution/adapters/openai.py
@@ -18,6 +18,7 @@ from .base import (
     ProviderExecutionError,
     build_safe_http_client,
     map_provider_error,
+    normalize_finish_reason,
     optional_nonnegative_float,
     usage_from_fields,
     value_at,
@@ -32,9 +33,13 @@ def _default_client_factory(**kwargs: Any) -> Any:
     return OpenAI(**kwargs)
 
 
-def _response_text(response: Any) -> str:
+def _first_choice(response: Any) -> Any:
     choices = value_at(response, "choices", ())
-    first = choices[0] if choices else None
+    return choices[0] if choices else None
+
+
+def _response_text(response: Any) -> str:
+    first = _first_choice(response)
     message = value_at(first, "message")
     content = value_at(message, "content")
     if isinstance(content, str):
@@ -137,6 +142,9 @@ class OpenAIExecutionAdapter:
                 model_id=request.model_id,
                 usage=usage,
                 provider_cost_usd=provider_cost_usd,
+                finish_reason=normalize_finish_reason(
+                    value_at(_first_choice(response), "finish_reason")
+                ),
             )
         except ProviderExecutionError:
             raise

--- a/dashboard/backend/infrastructure/llm/execution/client.py
+++ b/dashboard/backend/infrastructure/llm/execution/client.py
@@ -140,6 +140,10 @@ class AnthropicCompatibleExecutionClient:
                 input_tokens=result.usage.input_tokens,
                 output_tokens=result.usage.output_tokens,
             ),
+            # Same attribute the raw Anthropic SDK exposes, so callers can
+            # tell a reply cut at the output ceiling from a malformed one
+            # without knowing which client built the response.
+            stop_reason=getattr(result, "finish_reason", None),
         )
 
     def execution_summary(self) -> LLMRunEvidence | None:

--- a/dashboard/backend/infrastructure/llm/execution/models.py
+++ b/dashboard/backend/infrastructure/llm/execution/models.py
@@ -151,6 +151,9 @@ class LLMExecutionResult(BaseModel):
     credential_key_last_four: str | None = Field(default=None, min_length=4, max_length=4)
     usage: LLMUsage
     billing: BillingEvidence
+    # Normalised provider stop reason (``"max_tokens"`` when the reply was cut
+    # at the output ceiling); ``None`` when the provider reported none.
+    finish_reason: str | None = Field(default=None, max_length=32)
 
 
 class LLMRunEvidence(BaseModel):

--- a/dashboard/backend/infrastructure/llm/execution/service.py
+++ b/dashboard/backend/infrastructure/llm/execution/service.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable
-from typing import Any
 
 from dashboard.backend.domain.credits.models import LLMSettlementResult
 from dashboard.backend.domain.credits.service import CreditsService
@@ -127,6 +126,7 @@ class LLMExecutionService:
                     usage=usage,
                     billing=billing,
                     text=response.text,
+                    finish_reason=response.finish_reason,
                 )
             else:
                 result = self._execute_platform(
@@ -286,6 +286,7 @@ class LLMExecutionService:
                 usage=usage,
                 billing=billing,
                 text=response.text,
+                finish_reason=response.finish_reason,
             )
         except LLMExecutionError as exc:
             self._release_after_failure(reservation_id, exc.category)
@@ -435,6 +436,7 @@ class LLMExecutionService:
         usage: LLMUsage,
         billing: BillingEvidence,
         text: str,
+        finish_reason: str | None = None,
     ) -> LLMExecutionResult:
         try:
             return LLMExecutionResult(
@@ -445,6 +447,7 @@ class LLMExecutionService:
                 credential_key_last_four=credential.key_last_four,
                 usage=usage,
                 billing=billing,
+                finish_reason=finish_reason,
             )
         except Exception as exc:  # noqa: BLE001 - preserve the fixed public contract
             raise LLMExecutionError(ExecutionErrorCategory.RESPONSE_INVALID) from exc

--- a/dashboard/backend/infrastructure/llm/pipeline_runner.py
+++ b/dashboard/backend/infrastructure/llm/pipeline_runner.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import copy
 import json
+import re
 from typing import Any, Dict, List, Optional, Tuple
 
 from dashboard.backend.infrastructure.llm.backtest_harness import (
@@ -474,9 +475,8 @@ def _create_pipeline_response(
     model: str,
     prompt: str,
     max_tokens: Optional[int] = None,
-    reasoning_effort: Optional[str] = None,
 ):
-    """Create one pipeline request with optional recovery overrides."""
+    """Create one pipeline request, optionally with a recovery output budget."""
     request = {
         "model": model,
         "max_tokens": (
@@ -487,30 +487,121 @@ def _create_pipeline_response(
         "system": PIPELINE_SYSTEM_PROMPT,
         "messages": [{"role": "user", "content": prompt}],
     }
-    if reasoning_effort is not None:
-        request["reasoning_effort"] = reasoning_effort
     return client.messages.create(**request)
 
 
-def _looks_like_truncated_json(response_text: str) -> bool:
-    """Detect a long, structurally incomplete JSON response.
+def _retry_with_recovery_budget(client, *, model: str, prompt: str):
+    """Second attempt for a step whose first attempt was unusable.
 
-    Provider adapters already classify an empty response as ``response_invalid``.
-    A response cut off by the output ceiling is different: it contains text, so
-    it reaches the parser, but its object/array delimiters never close. Keep the
-    retry narrow so short malformed responses and valid-but-unsupported business
-    envelopes are not retried.
+    The same request, reasoning preserved, with the output ceiling raised to
+    ``RECOVERY_MAX_OUTPUT_TOKENS`` so a reasoning-heavy model has room for
+    both its thinking and the final JSON. Both recovery paths send exactly
+    this, which is why a step never gets a third attempt: a reply that is
+    still unusable after it has nothing different left to ask for.
     """
-    text = str(response_text or "").strip()
-    text = text.replace("```json", "").replace("```", "").strip()
-    # Reasoning can consume most of the provider output budget, leaving a
-    # surprisingly short JSON prefix (the production failure was ~170 chars).
-    # Keep a small floor to avoid retrying a bare ``{"orders": [`` typo, while
-    # requiring a known decision envelope so unrelated malformed JSON is not
-    # treated as a truncation.
-    if len(text) < 64 or not text.startswith("{"):
+    return _create_pipeline_response(
+        client,
+        model=model,
+        prompt=prompt,
+        max_tokens=RECOVERY_MAX_OUTPUT_TOKENS,
+    )
+
+
+class _StepUsage:
+    """Calls and token deltas for the responses a pipeline actually received.
+
+    Only responses that came back are recorded — an attempt that raised was
+    released by the execution service and never billed.
+    """
+
+    __slots__ = ("calls", "input_tokens", "output_tokens")
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self.input_tokens = 0
+        self.output_tokens = 0
+
+    def record(self, response) -> int:
+        """Count one received response; returns its output-token delta."""
+        self.calls += 1
+        in_delta, out_delta = extract_token_usage(response)
+        self.input_tokens += in_delta
+        self.output_tokens += out_delta
+        return out_delta
+
+    @property
+    def totals(self) -> Tuple[int, int]:
+        return self.input_tokens, self.output_tokens
+
+
+# Provider-neutral spellings of "the reply stopped because it hit the output
+# ceiling": Anthropic ``stop_reason``, OpenAI/OpenRouter ``finish_reason`` and
+# Gemini ``finishReason`` (the execution adapters normalise the last two).
+_OUTPUT_CEILING_STOP_REASONS = frozenset({"max_tokens", "length"})
+
+# Below this many characters a structurally unclosed reply is treated as an
+# ordinary malformed answer rather than a truncation, so short garbage does
+# not buy a second billed call. Reasoning can consume most of the output
+# budget and leave a surprisingly short JSON prefix (a production failure was
+# ~170 chars), so the floor is small; it only applies to the structural
+# fallback — a provider-reported stop reason or an output-token count at the
+# ceiling fires regardless of length (and of script: CJK output reaches the
+# ceiling at a fraction of these characters).
+_TRUNCATION_MIN_CHARS = 64
+
+# A structurally unclosed reply is only worth a retry when it had started the
+# decision envelope, so unrelated malformed JSON is not treated as a truncation.
+_DECISION_ENVELOPE_KEYS = ("actions", "orders", "risk_actions")
+
+_CODE_FENCE = re.compile(r"```(?:json)?", re.IGNORECASE)
+# The first brace that actually opens an object. A ``{`` inside a prose
+# preamble ("Analysis {see below") would otherwise count as an unclosed
+# delimiter and buy a retry for a reply that is complete.
+_OBJECT_START = re.compile(r'\{\s*"')
+
+
+def _hit_output_ceiling(response, output_tokens: int, max_tokens: int) -> bool:
+    """True when the provider itself says the reply stopped at ``max_tokens``.
+
+    Prefers the explicit stop/finish reason where the response carries one
+    (the raw Anthropic SDK and the execution client both expose
+    ``stop_reason``); falls back to the reported output-token count reaching
+    the ceiling the request asked for. Either signal is exact where the
+    structural scan below is a guess.
+    """
+    stop_reason = getattr(response, "stop_reason", None)
+    if stop_reason is None:
+        stop_reason = getattr(response, "finish_reason", None)
+    if isinstance(stop_reason, str):
+        if stop_reason.strip().lower() in _OUTPUT_CEILING_STOP_REASONS:
+            return True
+    return output_tokens >= max_tokens
+
+
+def _looks_like_truncated_json(response_text: str) -> bool:
+    """Structural fallback: a decision object whose delimiters never close.
+
+    Provider adapters already classify an empty response as
+    ``response_invalid``, and ``_hit_output_ceiling`` covers every response
+    that reports its own stop reason or usage. This scan is for the rest: a
+    reply that reaches the parser with text, begins a decision envelope, and
+    stops before the delimiters close. It tolerates exactly what
+    ``parse_llm_response`` tolerates — code fences of any case and prose
+    before the object — so a truncation the parser would have seen is not
+    hidden from the retry by its preamble; the scan starts at the first
+    ``{"`` so a brace *inside* that preamble is not mistaken for the object.
+    A *mismatched* closer (``}`` closing a ``[``) is a malformed reply, not a
+    cut-off one, and is deliberately not retried; neither is a short unclosed
+    fragment or one that never named a decision key.
+    """
+    text = _CODE_FENCE.sub("", response_text)
+    opener = _OBJECT_START.search(text)
+    if opener is None:
         return False
-    if not any(f'"{key}"' in text for key in ("actions", "orders", "risk_actions")):
+    text = text[opener.start():].strip()
+    if len(text) < _TRUNCATION_MIN_CHARS:
+        return False
+    if not any(f'"{key}"' in text for key in _DECISION_ENVELOPE_KEYS):
         return False
 
     stack: list[str] = []
@@ -537,6 +628,30 @@ def _looks_like_truncated_json(response_text: str) -> bool:
     return bool(stack)
 
 
+def _truncation_reason(response, output_tokens: int, response_text: str) -> Optional[str]:
+    """Why an unparseable first reply is worth one more attempt, or ``None``."""
+    if _hit_output_ceiling(response, output_tokens, DEFAULT_MAX_OUTPUT_TOKENS):
+        return "stopped at the output ceiling"
+    if _looks_like_truncated_json(response_text):
+        return "is structurally incomplete"
+    return None
+
+
+def _response_text_or_none(response) -> Optional[str]:
+    """Text of a response, or ``None`` when it carries no text block.
+
+    A reasoning model can spend the whole reply on a thinking block; that is
+    an unparseable reply, not a fault, so it must not raise past the usage
+    the step has already recorded for it.
+    """
+    try:
+        return extract_response_text(response)
+    except AttributeError as exc:
+        if "No text content" not in str(exc):
+            raise
+        return None
+
+
 def run_pipeline_decision(
     client,
     *,
@@ -548,22 +663,35 @@ def run_pipeline_decision(
 
     Post-trade steps are ignored here. Returns
     ``(decision_dict_or_none, (input_tokens, output_tokens), llm_calls, step_outputs)``.
+
+    Each step gets at most **one** second attempt (``_retry_with_recovery_budget``),
+    and only when the first attempt was unusable: the provider rejected it as
+    ``response_invalid``, or it came back unparseable *and* truncated (see
+    ``_truncation_reason``). A reply with no text block at all is unparseable
+    by definition: it is retried when the provider reports the ceiling, and
+    otherwise ends the step cleanly with its usage intact. The two triggers
+    share that single budget on
+    purpose — the recovery attempt is the same request either way, so a
+    truncated recovery reply has nothing different left to send. A truncation
+    retry that fails in a way the provider would also have classified as an
+    unusable reply degrades to the first attempt's outcome (``None`` for this
+    step) rather than raising an error the provider never produced, so the
+    usage already recorded for the step — a real, billed call — is returned to
+    the caller instead of being lost with the exception.
     """
     decision_steps, _post_trade_steps = split_pipeline(pipeline)
     if not decision_steps:
         return None, (0, 0), 0, []
 
     prior_outputs: List[Dict[str, Any]] = []
-    total_in = 0
-    total_out = 0
-    llm_calls = 0
+    usage = _StepUsage()
     last_parsed: Optional[Dict[str, Any]] = None
     request_model = model or LLM_MODEL_NAME
 
     for index, step in enumerate(decision_steps):
         if not isinstance(step, dict):
             print(f"   ⚠️  Pipeline step {index + 1} is invalid; aborting pipeline")
-            return None, (total_in, total_out), llm_calls, prior_outputs
+            return None, usage.totals, usage.calls, prior_outputs
 
         prompt = _build_step_prompt(
             step_index=index,
@@ -589,41 +717,48 @@ def run_pipeline_decision(
                 "   ⚠️  Empty model response; retrying with reasoning preserved "
                 f"and max_tokens={RECOVERY_MAX_OUTPUT_TOKENS}"
             )
-            response = _create_pipeline_response(
-                client,
-                model=request_model,
-                prompt=prompt,
-                max_tokens=RECOVERY_MAX_OUTPUT_TOKENS,
+            response = _retry_with_recovery_budget(
+                client, model=request_model, prompt=prompt
             )
             retried = True
-        llm_calls += 1
-        in_delta, out_delta = extract_token_usage(response)
-        total_in += in_delta
-        total_out += out_delta
+        out_delta = usage.record(response)
 
-        response_text = extract_response_text(response)
-        parsed = parse_llm_response(response_text)
+        response_text = _response_text_or_none(response)
+        if response_text is None:
+            print("   ⚠️  Pipeline response carried no text block")
+            parsed = None
+        else:
+            parsed = parse_llm_response(response_text)
+        reason = None
         if parsed is None and not retried:
-            if _looks_like_truncated_json(response_text):
-                print(
-                    "   ⚠️  Pipeline response appears truncated; "
-                    "retrying once with reasoning preserved and a larger output budget"
+            reason = _truncation_reason(response, out_delta, response_text or "")
+        if reason is not None:
+            print(
+                f"   ⚠️  Pipeline response {reason}; retrying once with reasoning "
+                f"preserved and max_tokens={RECOVERY_MAX_OUTPUT_TOKENS}"
+            )
+            retry_response = None
+            try:
+                retry_response = _retry_with_recovery_budget(
+                    client, model=request_model, prompt=prompt
                 )
-                response = _create_pipeline_response(
-                    client,
-                    model=request_model,
-                    prompt=prompt,
-                    max_tokens=RECOVERY_MAX_OUTPUT_TOKENS,
-                )
-                retried = True
-                llm_calls += 1
-                in_delta, out_delta = extract_token_usage(response)
-                total_in += in_delta
-                total_out += out_delta
-                parsed = parse_llm_response(extract_response_text(response))
+            except LLMExecutionError as retry_error:
+                # An empty second reply is the same class of outcome as the
+                # truncated first one; anything else is an infrastructure
+                # failure the first attempt would have raised too.
+                if retry_error.category is not ExecutionErrorCategory.RESPONSE_INVALID:
+                    raise
+                print("   ⚠️  Retry returned no usable response; keeping the first attempt")
+            if retry_response is not None:
+                usage.record(retry_response)
+                retry_text = _response_text_or_none(retry_response)
+                if retry_text is None:
+                    print("   ⚠️  Retry returned no text block; keeping the first attempt")
+                else:
+                    parsed = parse_llm_response(retry_text)
         if parsed is None:
             print(f"   ❌ Pipeline step {index + 1} returned unparseable JSON")
-            return None, (total_in, total_out), llm_calls, prior_outputs
+            return None, usage.totals, usage.calls, prior_outputs
 
         prior_outputs.append(
             {
@@ -639,6 +774,6 @@ def run_pipeline_decision(
     decision = pipeline_output_to_decision(last_parsed or {})
     if decision is None:
         print("   ❌ Final pipeline output could not be converted to trading actions")
-        return None, (total_in, total_out), llm_calls, prior_outputs
+        return None, usage.totals, usage.calls, prior_outputs
 
-    return decision, (total_in, total_out), llm_calls, prior_outputs
+    return decision, usage.totals, usage.calls, prior_outputs

--- a/dashboard/backend/tests/infrastructure/llm/test_execution_adapter_model_routes.py
+++ b/dashboard/backend/tests/infrastructure/llm/test_execution_adapter_model_routes.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
 import dashboard.backend.infrastructure.llm.execution.adapters.anthropic as anthropic_module
 import dashboard.backend.infrastructure.llm.execution.adapters.gemini as gemini_module
 import dashboard.backend.infrastructure.llm.execution.adapters.openai as openai_module
@@ -57,13 +59,12 @@ def _request(
     )
 
 
-def _openai_response(model: str):
+def _openai_response(model: str, finish_reason: str | None = None):
+    choice = SimpleNamespace(message=SimpleNamespace(content="ok"))
+    if finish_reason is not None:
+        choice.finish_reason = finish_reason
     return SimpleNamespace(
-        choices=[
-            SimpleNamespace(
-                message=SimpleNamespace(content="ok"),
-            )
-        ],
+        choices=[choice],
         usage=SimpleNamespace(prompt_tokens=2, completion_tokens=1),
         model=model,
     )
@@ -260,3 +261,119 @@ def test_gemini_uses_native_model_in_endpoint_and_keeps_canonical_result(
         "/models/gemini-3.1-pro-preview:generateContent"
     )
     assert result.model_id == "google/gemini-3.1-pro-preview"
+
+
+def _openai_client(create):
+    return SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create)),
+        close=lambda: None,
+    )
+
+
+@pytest.mark.parametrize(
+    ("finish_reason", "expected"),
+    [("length", "max_tokens"), ("stop", "stop"), (None, None)],
+)
+def test_openai_reports_normalised_finish_reason(monkeypatch, finish_reason, expected):
+    monkeypatch.setattr(
+        openai_module,
+        "build_safe_http_client",
+        lambda *_args, **_kwargs: _Closable(),
+    )
+    client = _openai_client(lambda **_kwargs: _openai_response("gpt-5.5", finish_reason))
+    adapter = openai_module.OpenAIAdapter(client_factory=lambda **_kwargs: client)
+
+    result = adapter.complete(
+        _request("openai", "openai/gpt-5.5"),
+        _credential("openai"),
+        _provider("openai", "openai", "https://api.openai.com/v1"),
+    )
+
+    assert result.finish_reason == expected
+
+
+def test_gemini_reports_max_tokens_finish_reason(monkeypatch):
+    class _Response:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {
+                "candidates": [
+                    {
+                        "content": {"parts": [{"text": "{\"orders\": ["}]},
+                        "finishReason": "MAX_TOKENS",
+                    }
+                ],
+                "usageMetadata": {"promptTokenCount": 2, "candidatesTokenCount": 1},
+            }
+
+    class _HTTPClient(_Closable):
+        def post(self, url, *, headers, json):
+            return _Response()
+
+    monkeypatch.setattr(
+        gemini_module,
+        "build_safe_http_client",
+        lambda *_args, **_kwargs: _HTTPClient(),
+    )
+
+    result = gemini_module.GeminiExecutionAdapter().complete(
+        _request("gemini", "google/gemini-3.1-pro-preview"),
+        _credential("gemini"),
+        _provider("gemini", "gemini", "https://generativelanguage.googleapis.com/v1beta"),
+    )
+
+    assert result.finish_reason == "max_tokens"
+
+
+@pytest.mark.parametrize(
+    ("stop_reason", "expected"),
+    [("max_tokens", "max_tokens"), ("end_turn", "end_turn"), (None, None)],
+)
+def test_anthropic_reports_normalised_stop_reason(monkeypatch, stop_reason, expected):
+    def create(**_kwargs):
+        return SimpleNamespace(
+            content=[SimpleNamespace(type="text", text="ok")],
+            usage=SimpleNamespace(input_tokens=2, output_tokens=1),
+            model="claude-sonnet-4-6",
+            stop_reason=stop_reason,
+        )
+
+    client = SimpleNamespace(
+        messages=SimpleNamespace(create=create),
+        close=lambda: None,
+    )
+    monkeypatch.setattr(
+        anthropic_module,
+        "build_safe_http_client",
+        lambda *_args, **_kwargs: _Closable(),
+    )
+    adapter = anthropic_module.AnthropicExecutionAdapter(
+        client_factory=lambda **_kwargs: client,
+    )
+
+    result = adapter.complete(
+        _request("anthropic", "anthropic/claude-sonnet-4-6"),
+        _credential("anthropic"),
+        _provider("anthropic", "anthropic", "https://api.anthropic.com"),
+    )
+
+    assert result.finish_reason == expected
+
+
+def test_normalize_finish_reason_folds_vendor_spellings_and_stays_bounded():
+    from dashboard.backend.infrastructure.llm.execution.adapters.base import (
+        normalize_finish_reason,
+    )
+
+    assert normalize_finish_reason("length") == "max_tokens"
+    assert normalize_finish_reason("MAX_TOKENS") == "max_tokens"
+    assert normalize_finish_reason(" max_tokens ") == "max_tokens"
+    assert normalize_finish_reason("STOP") == "stop"
+    assert normalize_finish_reason("") is None
+    assert normalize_finish_reason(None) is None
+    assert normalize_finish_reason(3) is None
+    # An OpenAI-compatible provider may put anything here; it must never
+    # exceed the result model's bound and fail a successful call.
+    assert len(normalize_finish_reason("x" * 80)) == 32

--- a/dashboard/backend/tests/infrastructure/llm/test_execution_client.py
+++ b/dashboard/backend/tests/infrastructure/llm/test_execution_client.py
@@ -45,6 +45,7 @@ def _result(
     estimated_cost_usd=0.009,
     debited_micro=9_000,
     outstanding_micro=0,
+    finish_reason=None,
 ):
     snapshot = PricingSnapshot(
         provider_id="openrouter",
@@ -76,6 +77,7 @@ def _result(
             debited_credits_micro=debited_micro,
             outstanding_credits_micro=outstanding_micro,
         ),
+        finish_reason=finish_reason,
     )
 
 
@@ -112,6 +114,7 @@ def test_client_preserves_compatibility_response_and_aggregates_evidence():
     assert response.model == "openai/gpt-5.5"
     assert response.usage.input_tokens == 10
     assert response.usage.output_tokens == 5
+    assert response.stop_reason is None
     assert [request.call_index for request in service.requests] == [0, 1]
     assert summary.billing_mode is BillingMode.PLATFORM_CREDITS
     assert summary.provider_id == "openrouter"
@@ -155,3 +158,15 @@ def test_byok_summary_does_not_report_missing_usage_as_zero():
     assert summary.estimated_cost_usd is None
     assert summary.outcome == "unavailable"
 
+
+
+def test_client_exposes_provider_stop_reason_like_the_sdk():
+    service = _FakeExecutionService([_result(finish_reason="max_tokens")])
+    client = AnthropicCompatibleExecutionClient(
+        execution_service=service,
+        handoff=_handoff(),
+    )
+
+    response = _create(client)
+
+    assert response.stop_reason == "max_tokens"

--- a/dashboard/backend/tests/infrastructure/llm/test_pipeline_runner.py
+++ b/dashboard/backend/tests/infrastructure/llm/test_pipeline_runner.py
@@ -10,7 +10,10 @@ from dashboard.backend.infrastructure.llm.execution.errors import (
     LLMExecutionError,
 )
 from dashboard.backend.infrastructure.llm.pipeline_runner import (
+    DEFAULT_MAX_OUTPUT_TOKENS,
     RECOVERY_MAX_OUTPUT_TOKENS,
+    _TRUNCATION_MIN_CHARS,
+    _looks_like_truncated_json,
     apply_prompt_patches,
     is_last_bar_of_trading_day,
     pipeline_output_to_decision,
@@ -23,12 +26,27 @@ from dashboard.backend.infrastructure.llm.pipeline_runner import (
 
 
 class _PipelineResponse:
-    def __init__(self, text, input_tokens=7, output_tokens=3):
+    def __init__(self, text, input_tokens=7, output_tokens=3, stop_reason=None):
         self.content = [SimpleNamespace(type="text", text=text)]
         self.usage = SimpleNamespace(
             input_tokens=input_tokens,
             output_tokens=output_tokens,
         )
+        if stop_reason is not None:
+            self.stop_reason = stop_reason
+
+
+class _ThinkingOnlyResponse(_PipelineResponse):
+    """A reasoning model that spent the whole reply on a thinking block."""
+
+    def __init__(self, input_tokens=5, output_tokens=7):
+        super().__init__("", input_tokens=input_tokens, output_tokens=output_tokens)
+        self.content = [SimpleNamespace(type="thinking", thinking="...")]
+
+
+def _truncated_json(pad: int = 560) -> str:
+    """A reply cut off inside a string value, long enough for the structural scan."""
+    return '{"orders": [{"symbol": "AAPL", "side": "buy", "reason": "' + ("x" * pad)
 
 
 class _SequencedMessages:
@@ -251,12 +269,9 @@ def test_run_pipeline_decision_reraises_after_one_failed_retry():
 
 
 def test_run_pipeline_decision_retries_truncated_json_once():
-    truncated = '{"orders": [{"symbol": "AAPL", "side": "buy", "reason": "' + (
-        "x" * 560
-    )
     client = _PipelineClient(
         [
-            _PipelineResponse(truncated, input_tokens=13, output_tokens=2000),
+            _PipelineResponse(_truncated_json(), input_tokens=13, output_tokens=2000),
             _PipelineResponse('{"orders": []}', input_tokens=11, output_tokens=4),
         ]
     )
@@ -303,6 +318,34 @@ def test_run_pipeline_decision_retries_short_reasoning_truncation_once():
     assert usage == (24, 2004)
     assert calls == 2
     assert len(client.messages.calls) == 2
+    assert client.messages.calls[1]["max_tokens"] == RECOVERY_MAX_OUTPUT_TOKENS
+
+
+def test_run_pipeline_decision_retries_short_truncation_below_the_ceiling():
+    # Same ~110-char reply as the test above, but with usage well under the
+    # ceiling so only the structural scan can justify the retry: this is what
+    # pins #422's 64-char floor (a 512-char floor would ship green otherwise).
+    truncated = (
+        '{"orders": [{"symbol": "BA", "side": "hold", "qty": 2, '
+        '"order_type": "market", "limit_price": null, "reason": "Experi'
+    )
+    assert _TRUNCATION_MIN_CHARS <= len(truncated) < 512
+    client = _PipelineClient(
+        [
+            _PipelineResponse(truncated, input_tokens=13, output_tokens=900),
+            _PipelineResponse('{"orders": []}', input_tokens=11, output_tokens=4),
+        ]
+    )
+
+    decision, usage, calls, _steps = run_pipeline_decision(
+        client,
+        pipeline=_PIPELINE,
+        market_snapshot={"top_signals": {}},
+    )
+
+    assert decision == {"actions": []}
+    assert usage == (24, 904)
+    assert calls == 2
     assert client.messages.calls[1]["max_tokens"] == RECOVERY_MAX_OUTPUT_TOKENS
 
 
@@ -419,3 +462,258 @@ def test_trading_day_boundary_helpers():
     assert is_last_bar_of_trading_day(day1, 2) is True
     assert is_last_bar_of_trading_day(day2, 2) is True
     assert is_last_bar_of_trading_day(day2, 3) is True
+
+
+def test_run_pipeline_decision_retries_short_reply_when_provider_reports_ceiling():
+    # A provider-reported stop reason is exact: it fires below the structural
+    # scan's length floor, and regardless of script (CJK output reaches the
+    # ceiling at a fraction of the characters).
+    client = _PipelineClient(
+        [
+            _PipelineResponse(
+                '{"orders": [{"symbol": "600519.SH", "reason": "茅台强势',
+                input_tokens=9,
+                output_tokens=40,
+                stop_reason="max_tokens",
+            ),
+            _PipelineResponse('{"orders": []}', input_tokens=11, output_tokens=4),
+        ]
+    )
+
+    decision, usage, calls, _steps = run_pipeline_decision(
+        client,
+        pipeline=_PIPELINE,
+        market_snapshot={"top_signals": {}},
+    )
+
+    assert decision == {"actions": []}
+    assert usage == (20, 44)
+    assert calls == 2
+    assert client.messages.calls[1]["max_tokens"] == RECOVERY_MAX_OUTPUT_TOKENS
+
+
+def test_run_pipeline_decision_retries_when_output_tokens_reach_the_ceiling():
+    # No stop reason on the response (the execution client's compatibility
+    # shape), but usage says the reply used every output token it was allowed.
+    client = _PipelineClient(
+        [
+            _PipelineResponse(
+                '{"orders": [',
+                input_tokens=9,
+                output_tokens=DEFAULT_MAX_OUTPUT_TOKENS,
+            ),
+            _PipelineResponse('{"orders": []}', input_tokens=11, output_tokens=4),
+        ]
+    )
+
+    decision, _usage, calls, _steps = run_pipeline_decision(
+        client,
+        pipeline=_PIPELINE,
+        market_snapshot={"top_signals": {}},
+    )
+
+    assert decision == {"actions": []}
+    assert calls == 2
+    assert len(client.messages.calls) == 2
+    assert client.messages.calls[1]["max_tokens"] == RECOVERY_MAX_OUTPUT_TOKENS
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        "Here is my trading decision:\n",
+        "```JSON\n",
+        "\ufeff",
+    ],
+)
+def test_run_pipeline_decision_retries_truncated_json_behind_a_preamble(prefix):
+    # The structural scan tolerates what parse_llm_response tolerates — prose
+    # before the object, code fences of any case, a BOM — so a truncation the
+    # parser would have seen is not hidden from the retry by its preamble.
+    client = _PipelineClient(
+        [
+            _PipelineResponse(prefix + _truncated_json(), output_tokens=900),
+            _PipelineResponse('{"orders": []}', input_tokens=11, output_tokens=4),
+        ]
+    )
+
+    decision, _usage, calls, _steps = run_pipeline_decision(
+        client,
+        pipeline=_PIPELINE,
+        market_snapshot={"top_signals": {}},
+    )
+
+    assert decision == {"actions": []}
+    assert calls == 2
+
+
+def test_looks_like_truncated_json_scope():
+    assert _looks_like_truncated_json(_truncated_json()) is True
+    assert _looks_like_truncated_json("```json\n" + _truncated_json() + "\n```") is True
+    # Complete objects, short fragments, mismatched delimiters (a malformed
+    # reply, not a cut-off one), arrays and objects that never named a
+    # decision key are not retried.
+    assert _looks_like_truncated_json('{"orders": [], "note": "' + "x" * 600 + '"}') is False
+    assert _looks_like_truncated_json('{"orders": [') is False
+    assert _looks_like_truncated_json('{"orders": [1, 2}, "b": "' + "x" * 600) is False
+    assert _looks_like_truncated_json("[" + "x" * 600) is False
+    assert _looks_like_truncated_json('{"summary": "' + "x" * 600) is False
+    # The length floor is exact.
+    prefix = '{"orders": [{"symbol": "AAPL", "reason": "'
+    at_floor = prefix + "x" * (_TRUNCATION_MIN_CHARS - len(prefix))
+    assert _looks_like_truncated_json(at_floor) is True
+    assert _looks_like_truncated_json(at_floor[:-1]) is False
+    # A brace inside a prose preamble is not the object: this reply is
+    # complete, and a retry would only buy a second billed call.
+    complete = '{"orders": [{"symbol": "AAPL", "side": "buy", "reason": "' + "x" * 600 + '"}]}'
+    assert _looks_like_truncated_json("Analysis {see below}\n" + complete) is False
+    assert _looks_like_truncated_json("Analysis {see below\n" + complete) is False
+
+
+def test_run_pipeline_decision_truncation_retry_degrades_when_retry_is_invalid():
+    # The first reply was real and billed; a second reply the provider rejects
+    # as invalid must not turn that into an exception that loses its usage.
+    client = _PipelineClient(
+        [
+            _PipelineResponse(_truncated_json(), input_tokens=13, output_tokens=2000),
+            LLMExecutionError(ExecutionErrorCategory.RESPONSE_INVALID),
+        ]
+    )
+
+    decision, usage, calls, _steps = run_pipeline_decision(
+        client,
+        pipeline=_PIPELINE,
+        market_snapshot={"top_signals": {}},
+    )
+
+    assert decision is None
+    assert usage == (13, 2000)
+    assert calls == 1
+    assert len(client.messages.calls) == 2
+
+
+def test_run_pipeline_decision_truncation_retry_degrades_when_retry_has_no_text():
+    client = _PipelineClient(
+        [
+            _PipelineResponse(_truncated_json(), input_tokens=13, output_tokens=2000),
+            _ThinkingOnlyResponse(input_tokens=5, output_tokens=7),
+        ]
+    )
+
+    decision, usage, calls, _steps = run_pipeline_decision(
+        client,
+        pipeline=_PIPELINE,
+        market_snapshot={"top_signals": {}},
+    )
+
+    assert decision is None
+    assert usage == (18, 2007)
+    assert calls == 2
+
+
+@pytest.mark.parametrize(
+    "category",
+    [
+        ExecutionErrorCategory.CREDENTIAL_INVALID,
+        ExecutionErrorCategory.PROVIDER_UNAVAILABLE,
+        ExecutionErrorCategory.BILLING_FAILED,
+    ],
+)
+def test_run_pipeline_decision_truncation_retry_propagates_infrastructure_errors(
+    category,
+):
+    client = _PipelineClient(
+        [
+            _PipelineResponse(_truncated_json(), output_tokens=2000),
+            LLMExecutionError(category),
+        ]
+    )
+
+    with pytest.raises(LLMExecutionError) as error:
+        run_pipeline_decision(
+            client,
+            pipeline=_PIPELINE,
+            market_snapshot={"top_signals": {}},
+        )
+
+    assert error.value.category is category
+    assert len(client.messages.calls) == 2
+
+
+def test_run_pipeline_decision_truncation_retry_propagates_client_faults():
+    # Only a provider-classified unusable reply degrades; a client fault on
+    # the retry is a real error and must surface for diagnostics.
+    client = _PipelineClient(
+        [
+            _PipelineResponse(_truncated_json(), output_tokens=2000),
+            TypeError("client serialization failed"),
+        ]
+    )
+
+    with pytest.raises(TypeError, match="client serialization failed"):
+        run_pipeline_decision(
+            client,
+            pipeline=_PIPELINE,
+            market_snapshot={"top_signals": {}},
+        )
+
+
+def test_run_pipeline_decision_retries_at_most_once_per_step():
+    # The response_invalid retry already ran with the recovery budget; a
+    # truncated reply from it has nothing different left to send.
+    client = _PipelineClient(
+        [
+            LLMExecutionError(ExecutionErrorCategory.RESPONSE_INVALID),
+            _PipelineResponse(_truncated_json(), input_tokens=13, output_tokens=2000),
+        ]
+    )
+
+    decision, usage, calls, _steps = run_pipeline_decision(
+        client,
+        pipeline=_PIPELINE,
+        market_snapshot={"top_signals": {}},
+    )
+
+    assert decision is None
+    assert usage == (13, 2000)
+    assert calls == 1
+    assert len(client.messages.calls) == 2
+
+
+def test_run_pipeline_decision_retries_thinking_only_reply_at_the_ceiling():
+    # A reasoning model that spent the whole first reply thinking, and hit the
+    # ceiling doing it, is exactly what the provider's stop reason is for.
+    client = _PipelineClient(
+        [
+            _ThinkingOnlyResponse(input_tokens=13, output_tokens=2000),
+            _PipelineResponse('{"orders": []}', input_tokens=11, output_tokens=4),
+        ]
+    )
+
+    decision, usage, calls, _steps = run_pipeline_decision(
+        client,
+        pipeline=_PIPELINE,
+        market_snapshot={"top_signals": {}},
+    )
+
+    assert decision == {"actions": []}
+    assert usage == (24, 2004)
+    assert calls == 2
+    assert client.messages.calls[1]["max_tokens"] == RECOVERY_MAX_OUTPUT_TOKENS
+
+
+def test_run_pipeline_decision_thinking_only_reply_below_the_ceiling_ends_cleanly():
+    # No text and no ceiling: nothing to retry, but the call was real and
+    # billed, so the step ends with None and its usage rather than raising.
+    client = _PipelineClient([_ThinkingOnlyResponse(input_tokens=13, output_tokens=40)])
+
+    decision, usage, calls, _steps = run_pipeline_decision(
+        client,
+        pipeline=_PIPELINE,
+        market_snapshot={"top_signals": {}},
+    )
+
+    assert decision is None
+    assert usage == (13, 40)
+    assert calls == 1
+    assert len(client.messages.calls) == 1

--- a/dashboard/backend/tests/llm/test_backtest_harness.py
+++ b/dashboard/backend/tests/llm/test_backtest_harness.py
@@ -8,6 +8,7 @@ external service is ever called.
 """
 
 import json
+import threading
 from datetime import datetime
 
 from dashboard.backend.domain.backtesting import (
@@ -795,3 +796,22 @@ def test_llm_nonfinite_position_size_skipped_safely(capsys):
         _portfolio_state(), _FakeClient(_FakeResponse(resp_text, _FakeUsage(1, 1))))
     assert out["actions"] == []
     assert "unparseable position_size" in capsys.readouterr().out
+
+
+def test_parse_llm_response_trims_a_stray_closing_brace_without_hanging():
+    # One extra ``}`` used to spin the bracket-trim loop forever: it cut the
+    # last brace and re-appended it, so the counts never changed. Run it on a
+    # thread so a regression fails the test instead of hanging the suite.
+    outcome = {}
+
+    def parse():
+        outcome["decision"] = harness.parse_llm_response(
+            '{"actions": [{"symbol": "AAPL", "action": "buy"}]}}'
+        )
+
+    worker = threading.Thread(target=parse, daemon=True)
+    worker.start()
+    worker.join(timeout=10)
+
+    assert not worker.is_alive(), "parse_llm_response did not terminate"
+    assert outcome["decision"] == {"actions": [{"symbol": "AAPL", "action": "buy"}]}

--- a/docs/superpowers/specs/2026-08-29-openrouter-empty-response-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-29-openrouter-empty-response-recovery-design.md
@@ -1,8 +1,40 @@
 # OpenRouter Empty Response Recovery Design
 
 **Date:** 2026-08-29
-**Status:** Proposed
+**Status:** Shipped (PR #420), amended by PRs #421, #422 and the #421 review
+follow-ups — see *Amendments* below; the sections after it describe the
+original design.
 **Scope:** Recover platform-credits backtests when OpenRouter returns no text
+
+## Amendments (what actually shipped)
+
+- **The recovery lever is a larger output budget, not disabled reasoning.**
+  PR #421's follow-up commit and PR #422 replaced `reasoning_effort="none"`
+  with re-sending the identical request at
+  `max_tokens=RECOVERY_MAX_OUTPUT_TOKENS` (`max(LLM_MAX_OUTPUT_TOKENS, 4096)`)
+  with reasoning preserved. Every adapter honours `max_tokens`; the native
+  Gemini/Anthropic/OpenAI adapters had silently dropped `reasoning_effort`, so
+  on those routes the earlier lever was a byte-identical second request.
+- **A second trigger: a truncated first reply.** Besides `response_invalid`,
+  a first reply that parses to nothing *and* was cut at the output ceiling
+  earns the same single recovery attempt. Truncation is decided by the
+  provider's own signal first — the normalised `stop_reason`/`finish_reason`
+  (`max_tokens`, threaded from every adapter through `LLMExecutionResult`
+  to the compatibility client's response) or `output_tokens` reaching the
+  request's ceiling — and only then by the structural scan
+  (`_looks_like_truncated_json`: an unclosed decision envelope of ≥64 chars,
+  fences and preamble tolerated).
+- **One recovery attempt per step, whichever trigger fires.** Both triggers
+  send the same request, so a still-unusable recovery reply has nothing
+  different left to ask for.
+- **A failed truncation retry degrades; it does not raise.** The first reply
+  was a real, billed call, so a retry the provider rejects as
+  `response_invalid`, or that returns no text block, leaves the step at the
+  first attempt's `None` and returns the usage already recorded — the caller
+  side-effects those deltas into `llm_calls` (the billing counter) only from
+  a normal return. Other error categories still propagate. The
+  `response_invalid`-first path keeps its original contract: a second
+  `response_invalid` re-raises.
 
 ## Incident
 


### PR DESCRIPTION
Review follow-ups for #421, rebased onto the `max_tokens` recovery lever from its second commit and #422 (the PR merged before these could land there).

**Verified findings fixed**
- Truncation retry lost billed usage on failure: a retry the provider rejects (`response_invalid`) or that returns no text block now degrades to the first attempt's `None` with usage intact; other categories and client faults still raise.
- Retry gate ignored the provider's own truncation signal: `stop_reason`/`finish_reason == max_tokens` (now threaded from every adapter → `LLMExecutionResult` → the compatibility client) and `output_tokens` at the ceiling are checked before the structural scan.
- Structural scan missed truncations behind a prose/BOM preamble or an uppercase fence; #422's 64-char floor and envelope-key rule are kept.
- `parse_llm_response` bracket-trim loop spun forever on one stray `}` (pre-existing, `d59c192f`; also reachable from the live-trading thread).
- A first reply with no text block (thinking-only) raised past its billed usage and never got the retry; it now ends the step cleanly, or retries when the provider reports the ceiling.
- Duplicated retry/accounting blocks folded into `_StepUsage` + one recovery helper; the once-per-step budget is documented and pinned by a test; dead `reasoning_effort` kwarg removed.

**Not changed (out of scope, noting for follow-up)**
- The non-pipeline decision path (`portfolio_manager.py` `_parse_llm_response`) still has no truncation recovery.
- `parse_llm_response`'s brace-count repair is string-blind (a `}` inside a string value still miscounts); the loop now terminates, which is strictly better than the hang, but a quote-aware repair is a separate change.
- `py/cyclic-import` on `execution/models.py` ↔ `token_cost.py` predates #421 and needs a pricing-table module split.
- `reasoning_effort="none"` being a no-op on native adapters is moot now that retries raise `max_tokens` instead.

**Also**: closes two pre-existing CodeQL quality alerts in touched files (unused `typing.Any`; Protocol stub body) and records the shipped amendments on the #420 design spec.

Tests: full backend suite 3854 passed / 148 skipped locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDCS8B3PDn5BCrqHB8XJWg
