### PR TITLE
fix: align dashboard backtest timeout to 60 minutes

### DIFF
--- a/dashboard/backend/api/routers/backtests.py
+++ b/dashboard/backend/api/routers/backtests.py
@@ -1156,14 +1156,12 @@ def run_backtest_background(
         print("✋ Backtest background thread finished", flush=True)
 
 
-# The backtest subprocess budget. 30 minutes is right for a pipeline run, whose
-# per-step LLM call is seconds long. A hosted run instead spends one *upstream
-# subprocess* per trading day, each allowed AI_HEDGE_FUND_TIMEOUT_SECONDS -- so
-# a fixed parent cap silently becomes the binding constraint (1800s over ~21
-# decision days is ~85s per step, not the 300s configured) and kills the child
-# mid-run with no partial results. Size the parent from the same per-step number
-# the runtime reads, so the inner timeout is what fires.
-PIPELINE_SUBPROCESS_TIMEOUT_SECONDS = 1800
+# The dashboard pipeline parent has a bounded 60-minute wall-clock budget. A
+# hosted run instead spends one *upstream subprocess* per trading day, each
+# allowed AI_HEDGE_FUND_TIMEOUT_SECONDS, and is sized dynamically below.
+# Hosted runtimes below retain their own per-decision sizing; this fixed value
+# only applies to the normal pipeline subprocess.
+PIPELINE_SUBPROCESS_TIMEOUT_SECONDS = 3600
 # Data load, baseline generation and persistence sit outside the decision loop.
 SUBPROCESS_TIMEOUT_OVERHEAD_SECONDS = 600
 # Ceiling, so a long date range cannot pin a worker thread indefinitely.

--- a/dashboard/backend/domain/backtesting/algo_service.py
+++ b/dashboard/backend/domain/backtesting/algo_service.py
@@ -421,7 +421,7 @@ def execute_algo(
         "end_date": end,
         "message": (
             f"Real backtest started ({start} → {end}). "
-            "Uses Alpaca hourly bars + Claude hourly decisions; usually takes 3–10 minutes."
+            "Uses Alpaca hourly bars + Claude hourly decisions; multi-step runs can take several minutes."
         ),
     }
 

--- a/dashboard/backend/tests/domain/backtesting/test_algo_service_move.py
+++ b/dashboard/backend/tests/domain/backtesting/test_algo_service_move.py
@@ -163,6 +163,8 @@ def test_execute_algo_writes_config_and_forwards(monkeypatch, tmp_path):
     assert out["team_name"] == "My Team"
     assert out["start_date"] == "2026-05-04"
     assert out["end_date"] == "2026-05-12"
+    assert "multi-step runs can take several minutes" in out["message"]
+    assert "3–10 minutes" not in out["message"]
     assert captured.get("started") is True
 
     # Config file is written into the isolated CONFIG_DIR with forwarded values.

--- a/dashboard/backend/tests/test_app_copy_register.py
+++ b/dashboard/backend/tests/test_app_copy_register.py
@@ -197,7 +197,12 @@ def test_credential_storage_note_is_plain_language():
 
 
 def test_backtest_hint_uses_strategy_and_limit():
-    assert "Multi-step strategies can take several minutes (limit: 10 minutes)." in _HTML
+    assert "Multi-step strategies can take several minutes (limit: 60 minutes)." in _HTML
+    assert "Multi-step strategies can take several minutes (limit: 10 minutes)." not in _HTML
+    assert "Chat with Claude; backtests use Alpaca historical data and multi-step runs can take several minutes." in _HTML
+    assert "about 3–10 minutes" not in _HTML
+    assert "Timed out after 60 minutes." in _JS
+    assert "Timed out after 10 minutes." not in _JS
     assert "Multi-step agent pipelines" not in _HTML
 
 

--- a/dashboard/backend/tests/test_backtest_progress_card.py
+++ b/dashboard/backend/tests/test_backtest_progress_card.py
@@ -571,15 +571,33 @@ def test_run_panel_prefers_step_percent_over_the_elapsed_guess():
 
 def test_run_panel_falls_back_to_the_elapsed_guess():
     panel = _run_panel("{elapsedSeconds: 60, message: 'x'}")
-    assert panel["width"] == "10%"  # 60 / 600
+    assert panel["width"] == "2%"  # 60 / 3600
 
 
-def _resolve_entry(map_js: str, live_run_id: str, progress_js: str, agent: str) -> dict:
+def test_frontend_backtest_observation_window_is_sixty_minutes():
+    assert (
+        _node(
+            js_const("BACKTEST_POLL_MAX_SECONDS")
+            + "console.log(JSON.stringify(BACKTEST_POLL_MAX_SECONDS));"
+        )
+        == 3600
+    )
+
+
+def _resolve_entry(
+    map_js: str,
+    live_run_id: str,
+    progress_js: str,
+    agent: str,
+    now_ms: int | None = None,
+) -> dict:
     """Run the real getAgentBacktestRunning against a stubbed running map."""
+    clock = f"Date.now = () => {now_ms};" if now_ms is not None else ""
     script = "\n".join(
         [
             js_const("BACKTEST_POLL_MAX_SECONDS"),
             f"const MAP = {map_js};",
+            clock,
             "function readRunningBacktests() { return MAP; }",
             "function clearAgentBacktestRunning(id) { delete MAP[id]; }",
             f"let liveBacktestRunId = {live_run_id};",
@@ -587,6 +605,23 @@ def _resolve_entry(map_js: str, live_run_id: str, progress_js: str, agent: str) 
             "const liveBacktestProgressByRunId = Object.create(null);",
             fn_body("function getAgentBacktestRunning("),
             f"console.log(JSON.stringify(getAgentBacktestRunning('{agent}')));",
+        ]
+    )
+    return _node(script)
+
+
+def _list_entries(map_js: str, now_ms: int) -> dict:
+    """Run the real listRunningBacktests helper with a deterministic clock."""
+    script = "\n".join(
+        [
+            js_const("BACKTEST_POLL_MAX_SECONDS"),
+            f"const MAP = {map_js};",
+            f"Date.now = () => {now_ms};",
+            "function readRunningBacktests() { return MAP; }",
+            "function writeRunningBacktests(value) { WRITTEN = value; }",
+            "let WRITTEN = null;",
+            fn_body("function listRunningBacktests("),
+            "console.log(JSON.stringify({runs: listRunningBacktests(), map: MAP, written: WRITTEN}));",
         ]
     )
     return _node(script)
@@ -627,6 +662,40 @@ def test_progress_is_withheld_when_no_run_is_identified():
     assert entry.get("step") is None
 
 
+def test_running_entry_is_retained_until_the_sixty_minute_ceiling():
+    entry = _resolve_entry(
+        "{'agent-A': {runId: 'run-1', startedAt: 0}}",
+        "'run-1'",
+        "null",
+        "agent-A",
+        now_ms=3_599_000,
+    )
+    assert entry["runId"] == "run-1"
+    assert entry["elapsedSeconds"] == 3599
+
+
+def test_running_entry_is_cleared_after_the_sixty_minute_ceiling():
+    entry = _resolve_entry(
+        "{'agent-A': {runId: 'run-1', startedAt: 0}}",
+        "'run-1'",
+        "null",
+        "agent-A",
+        now_ms=3_600_001,
+    )
+    assert entry is None
+
+
+def test_running_list_sweeps_only_entries_past_the_ceiling():
+    result = _list_entries(
+        "{'keep': {runId: 'run-keep', startedAt: 1},"
+        " 'drop': {runId: 'run-drop', startedAt: -1}}",
+        now_ms=3_600_000,
+    )
+    assert [run["runId"] for run in result["runs"]] == ["run-keep"]
+    assert "drop" not in result["map"]
+    assert result["written"] is not None
+
+
 def test_progress_store_is_written_before_the_card_repaints():
     """Same poll response, two surfaces. refreshRunningAgentCards() reads
     per-run progress via getAgentBacktestRunning; the Backtest panel is
@@ -665,10 +734,10 @@ def test_timeout_branch_clears_the_running_map_and_the_progress_store():
     """The leak that makes one run render another run's numbers.
 
     Progress is stored per live_run_id. The finished path clears that entry;
-    the 10-minute timeout branch must wipe the whole map so an orphaned card
+    the 60-minute timeout branch must wipe the whole map so an orphaned card
     cannot pick up the NEXT run's step/percent.
 
-    Guarded by source slice rather than execution: reaching the branch takes 600
+    Guarded by source slice rather than execution: reaching the branch takes 3600
     poll ticks. Scoped to the branch itself, because both statements also appear
     in the finished branch a few lines above -- a whole-function search would
     pass with the timeout branch completely untouched.

--- a/dashboard/backend/tests/test_backtests_router.py
+++ b/dashboard/backend/tests/test_backtests_router.py
@@ -801,9 +801,8 @@ def test_ai_hedge_fund_backtest_rejects_run_when_runtime_not_installed(
 def test_hosted_backtest_timeout_covers_every_decision_step():
     """The parent timeout must not be the binding constraint on a hosted run.
 
-    A fixed 1800s cap over a month of trading days leaves ~85s per step while
-    the runtime is configured for 300s, so the parent kills the child mid-run
-    and discards every completed step.
+    A fixed 3600s cap gives a month-long run enough room for its decision steps
+    while keeping a bounded parent process lifetime.
     """
     step_seconds = bt.resolve_step_timeout_seconds()
     decision_days = bt._estimated_decision_days("2026-01-01", "2026-01-31")
@@ -815,10 +814,11 @@ def test_hosted_backtest_timeout_covers_every_decision_step():
     assert hosted >= step_seconds * decision_days
     assert hosted > bt.PIPELINE_SUBPROCESS_TIMEOUT_SECONDS
 
-    # Pipeline runs keep their established budget exactly.
+    # Pipeline runs use the shared 60-minute budget exactly.
+    assert bt.PIPELINE_SUBPROCESS_TIMEOUT_SECONDS == 3600
     assert (
         bt._backtest_subprocess_timeout("pipeline", "2026-01-01", "2026-01-31")
-        == bt.PIPELINE_SUBPROCESS_TIMEOUT_SECONDS
+        == 3600
     )
 
 

--- a/dashboard/backend/tests/test_backtests_router.py
+++ b/dashboard/backend/tests/test_backtests_router.py
@@ -9,6 +9,7 @@
 
 import inspect
 import json
+import subprocess
 import time
 import uuid
 from datetime import datetime
@@ -25,6 +26,9 @@ from dashboard.backend.domain.model_providers.execution_catalog import (
     UnsupportedExecutionModel,
 )
 import dashboard.backend.api.routers.backtests as bt
+
+
+_REAL_RUN_BACKTEST_BACKGROUND = bt.run_backtest_background
 
 
 # ===========================================================================
@@ -834,6 +838,63 @@ def test_hosted_backtest_timeout_is_capped_and_never_below_pipeline():
         bt._backtest_subprocess_timeout("ai_hedge_fund", "not-a-date", "also-bad")
         == bt.PIPELINE_SUBPROCESS_TIMEOUT_SECONDS
     )
+
+
+def test_pipeline_timeout_finalizes_execution_and_slot_once(monkeypatch):
+    """A parent timeout keeps the existing single-owner cleanup path."""
+    run_id = "agent_timeout_cleanup"
+    session_id = str(uuid.uuid4())
+    assert (
+        bt._try_acquire_backtest_slot(
+            live_run_id=run_id,
+            session_id=session_id,
+            user_id=None,
+        )
+        is None
+    )
+
+    subprocess_calls = []
+    finalized_slots = []
+    finalized_execution_runs = []
+
+    def fake_run(cmd, **kwargs):
+        subprocess_calls.append({"cmd": cmd, **kwargs})
+        raise subprocess.TimeoutExpired(cmd, kwargs["timeout"])
+
+    class FakeExecutionService:
+        def __init__(self, **_kwargs):
+            pass
+
+        def finalize_run(self, execution_run_id):
+            finalized_execution_runs.append(execution_run_id)
+
+    real_finalize_slot = bt._finalize_slot
+
+    def spy_finalize_slot(live_run_id, *, error, runs_count):
+        finalized_slots.append((live_run_id, runs_count))
+        return real_finalize_slot(live_run_id, error=error, runs_count=runs_count)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(bt, "LLMExecutionService", FakeExecutionService)
+    monkeypatch.setattr(bt, "get_model_provider_service", lambda: object())
+    monkeypatch.setattr(bt, "_finalize_slot", spy_finalize_slot)
+    monkeypatch.setattr(bt, "run_backtest_background", _REAL_RUN_BACKTEST_BACKGROUND)
+
+    bt.run_backtest_background(
+        start_date="2026-01-01",
+        end_date="2026-01-02",
+        session_id=session_id,
+        live_run_id=run_id,
+        decision_source="rule_based",
+        execution_handoff_payload="opaque-test-handoff",
+    )
+
+    assert len(subprocess_calls) == 1
+    assert subprocess_calls[0]["timeout"] == 3600
+    assert finalized_slots == [(run_id, 0)]
+    assert finalized_execution_runs == [run_id]
+    assert run_id not in bt._active_slots
+    assert bt._recent_slots[run_id]["running"] is False
 
 
 def test_ai_hedge_fund_requires_openrouter_not_direct_openai(client, monkeypatch):

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -1243,7 +1243,7 @@
                         <div id="backtestRunProgressBar" class="backtest-run-progress-bar"></div>
                     </div>
                     <p id="backtestRunProgressMessage" class="backtest-run-progress-message">Starting…</p>
-                    <p class="backtest-run-progress-hint">Multi-step strategies can take several minutes (limit: 10 minutes).</p>
+                    <p class="backtest-run-progress-hint">Multi-step strategies can take several minutes (limit: 60 minutes).</p>
                 </div>
             </section>
         </aside>
@@ -1389,7 +1389,7 @@
             <aside class="algo-chat-panel section-card">
                 <div class="algo-panel-header">
                     <h2>Strategy Assistant</h2>
-                    <p>Chat with Claude; backtests use Alpaca historical data (about 3–10 minutes)</p>
+                    <p>Chat with Claude; backtests use Alpaca historical data and multi-step runs can take several minutes.</p>
                 </div>
                 <div id="algoChatMessages" class="algo-chat-messages">
                     <div class="algo-chat-msg bot">

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -17,7 +17,7 @@ const SELECTED_BACKTEST_RUN_KEY = 'selected-backtest-run-id';
 // literal (no build step to share this constant across the landing/app split).
 const NAV_STATE_KEY = 'nav-state';
 const DISCORD_SERVER_URL = 'https://discord.gg/9HnQ6XDG98';
-const BACKTEST_POLL_MAX_SECONDS = 600; // 10 minutes at 1-second polling intervals
+const BACKTEST_POLL_MAX_SECONDS = 3600; // 60 minutes at 1-second polling intervals
 
 function initSession() {
   // Stable browser identity — never changes when switching agents.
@@ -7024,7 +7024,7 @@ function ensureBacktestPolling() {
                     showBacktestRunProgress(true, { isError: true });
                     updateBacktestRunProgress({
                         elapsedSeconds: maxAttempts,
-                        message: 'Timed out after 10 minutes. The backtest may still be running in the background.',
+                        message: 'Timed out after 60 minutes. The backtest may still be running in the background.',
                     });
                 }
                 liveBacktestChartActive = false;
@@ -8466,7 +8466,7 @@ async function runBacktest() {
 async function pollBacktestStatus(btn) {
     ensureBacktestPolling();
     // Legacy callers awaited this; keep a lightweight wait until the poller stops
-    // or the run leaves "running" (max ~10 min).
+    // or the run leaves "running" (max ~60 min).
     const maxAttempts = BACKTEST_POLL_MAX_SECONDS;
     for (let i = 0; i < maxAttempts; i += 1) {
         if (!backtestPollTimer) {

--- a/docs/superpowers/plans/2026-08-30-backtest-timeout-consistency.md
+++ b/docs/superpowers/plans/2026-08-30-backtest-timeout-consistency.md
@@ -1,0 +1,315 @@
+# Dashboard Backtest Timeout Consistency Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give dashboard backtests a consistent, bounded 60-minute observation and execution window without changing provider request timeouts or backtest semantics.
+
+**Architecture:** Keep the backend parent-process budget and frontend polling ceiling as two explicit 3600-second contract values because the shipped frontend has no build-time configuration channel. Reuse the existing status-slot, subprocess-finally, and shared frontend polling paths; only update their constants, copy, and focused tests.
+
+**Tech Stack:** Python 3, FastAPI background-thread backtest runner, `subprocess.run`, pytest, vanilla JavaScript, Node-based frontend source harnesses, static HTML.
+
+**Spec:** `docs/superpowers/specs/2026-08-30-backtest-timeout-consistency-design.md`
+
+## Global Constraints
+
+- Do not change provider HTTP request timeouts, database timeouts, email timeouts, or other unrelated network/runtime limits to 60 minutes.
+- Do not change OpenRouter/Qwen response handling, Gemini behavior, or model reasoning policy in this PR.
+- Do not make the backtest faster. LLM call count, hourly decision cadence, market-data loading, and pipeline semantics remain unchanged.
+- Do not remove the hard timeout or allow an unbounded background process.
+- Do not change the 31-day date-range validation in this PR. A 31-day run may still exceed the fixed 60-minute budget and must report a normal timeout.
+- Do not change the Render plan or the server-wide concurrent-run default in code. Free-tier rollout capacity is an operational setting, not a timeout contract.
+- Preserve sanitized errors, platform-credit settlement, backtest-slot release, and browser running-entry cleanup.
+- Do not include real API keys, database credentials, `.superpowers/`, or `work/` in changes.
+
+## File Map
+
+- Modify `dashboard/backend/api/routers/backtests.py`: set and document the fixed pipeline parent budget; preserve hosted-runtime dynamic sizing and timeout cleanup.
+- Modify `dashboard/frontend/app.js`: set the shared polling/lifetime ceiling to 3600 seconds and update the terminal timeout copy.
+- Modify `dashboard/frontend/app.html`: update the progress-card duration hint and remove the false exact 3-10 minute promise.
+- Modify `dashboard/backend/tests/test_backtests_router.py`: assert the 60-minute pipeline budget and preserve hosted-runtime sizing behavior.
+- Modify `dashboard/backend/tests/test_backtest_progress_card.py`: exercise 60-minute retention/sweep and shared fallback-bar behavior through the existing Node harness.
+- Modify `dashboard/backend/tests/test_app_copy_register.py`: assert that shipped HTML has the 60-minute hint and no stale ten-minute limit.
+
+## Implementation Tasks
+
+### Task 1: Lock the backend timeout contract with tests
+
+**Files:**
+- Modify: `dashboard/backend/tests/test_backtests_router.py` near `test_hosted_backtest_timeout_covers_every_decision_step`
+
+**Interfaces:**
+- Consumes: `backtests_router._backtest_subprocess_timeout(runtime_type, start_date, end_date)` and `PIPELINE_SUBPROCESS_TIMEOUT_SECONDS`.
+- Produces: deterministic assertions that the pipeline runtime uses exactly 3600 seconds while hosted runtime sizing remains dynamic and capped.
+
+- [ ] **Step 1: Add the failing pipeline-budget assertion**
+
+Update the test's pipeline branch to assert the explicit target and the fixed-range behavior:
+
+```python
+assert bt.PIPELINE_SUBPROCESS_TIMEOUT_SECONDS == 3600
+assert bt._backtest_subprocess_timeout(
+    "pipeline", "2026-01-01", "2026-01-31"
+) == 3600
+```
+
+Keep the hosted assertions checking `hosted >= step_seconds * decision_days` and `hosted > bt.PIPELINE_SUBPROCESS_TIMEOUT_SECONDS`; this proves hosted sizing still adapts instead of silently becoming a fixed 60-minute value.
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+cd dashboard
+pytest backend/tests/test_backtests_router.py::test_hosted_backtest_timeout_covers_every_decision_step -q
+```
+
+Expected: FAIL because the current pipeline constant is 1800 seconds.
+
+- [ ] **Step 3: Commit the test-only checkpoint**
+
+```bash
+git add dashboard/backend/tests/test_backtests_router.py
+git commit -m "test: lock the 60 minute pipeline timeout"
+```
+
+### Task 2: Raise the backend pipeline parent budget and verify cleanup ownership
+
+**Files:**
+- Modify: `dashboard/backend/api/routers/backtests.py` at the pipeline timeout constants and `run_backtest_background()` timeout path
+- Modify: `dashboard/backend/tests/test_backtests_router.py` for timeout cleanup coverage
+
+**Interfaces:**
+- Consumes: `PIPELINE_SUBPROCESS_TIMEOUT_SECONDS`, `_backtest_subprocess_timeout()`, `run_backtest_background()`, `_finalize_slot()`, and `LLMExecutionService.finalize_run()`.
+- Produces: a 3600-second pipeline parent budget; a timeout path that remains bounded and finalizes each resource once.
+
+- [ ] **Step 1: Add a deterministic timeout-cleanup test harness**
+
+Use the existing test fixtures/mocks around `run_backtest_background()` and replace the local `subprocess.run` dependency with a `TimeoutExpired` fake. Record calls to the slot finalizer and execution finalizer, then assert:
+
+```python
+assert subprocess_call.kwargs["timeout"] == 3600
+assert finalized_slots == [(run_id, 0)]
+assert finalized_execution_runs == [run_id]
+```
+
+The fake must not expose command arguments or credentials in assertions. Keep the test focused on the already-established exception/finally ownership; do not add a second cleanup mechanism.
+
+- [ ] **Step 2: Run the cleanup test and verify it fails or exposes the old budget**
+
+Run the new test by its node and run the existing slot/credit cleanup tests:
+
+```bash
+cd dashboard
+pytest backend/tests/test_backtests_router.py -k "timeout or finalize or slot" -q
+```
+
+Expected: the budget assertion fails at 1800 seconds before the implementation change; any cleanup regression must identify a duplicate or missing finalizer.
+
+- [ ] **Step 3: Change only the pipeline constant and its comments**
+
+Set:
+
+```python
+PIPELINE_SUBPROCESS_TIMEOUT_SECONDS = 3600
+```
+
+Rewrite the nearby comments to say "60-minute dashboard pipeline parent budget." Leave `SUBPROCESS_TIMEOUT_OVERHEAD_SECONDS`, `MAX_SUBPROCESS_TIMEOUT_SECONDS`, `resolve_step_timeout_seconds()`, provider HTTP timeouts, and hosted-runtime arithmetic unchanged.
+
+- [ ] **Step 4: Make the timeout test pass without broadening exception behavior**
+
+Run:
+
+```bash
+cd dashboard
+pytest backend/tests/test_backtests_router.py::test_hosted_backtest_timeout_covers_every_decision_step -q
+pytest backend/tests/test_backtests_router.py -k "timeout or finalize or slot" -q
+```
+
+Expected: PASS. A `subprocess.TimeoutExpired` must still enter the existing sanitized exception path, invoke execution finalization in `finally`, and release the slot once; no provider or credential details may be asserted or emitted.
+
+- [ ] **Step 5: Commit the backend change**
+
+```bash
+git add dashboard/backend/api/routers/backtests.py dashboard/backend/tests/test_backtests_router.py
+git commit -m "fix: extend dashboard pipeline timeout to 60 minutes"
+```
+
+### Task 3: Lock the frontend 60-minute observation contract
+
+**Files:**
+- Modify: `dashboard/backend/tests/test_backtest_progress_card.py` near the existing `js_const("BACKTEST_POLL_MAX_SECONDS")` harnesses
+- Modify: `dashboard/backend/tests/test_app_copy_register.py` near `test_backtest_hint_uses_strategy_and_limit`
+
+**Interfaces:**
+- Consumes: `BACKTEST_POLL_MAX_SECONDS`, `listRunningBacktests()`, `getAgentBacktestRunning()`, `updateBacktestRunProgress()`, and the shipped HTML source.
+- Produces: failing tests that pin 3600-second retention, 3600-second elapsed-bar fallback, and 60-minute copy.
+
+- [ ] **Step 1: Add the constant and copy assertions**
+
+Use the existing `js_const()`/Node harness to assert:
+
+```python
+assert _node(js_const("BACKTEST_POLL_MAX_SECONDS")) == 3600
+```
+
+Update the HTML copy assertion to require:
+
+```python
+"Multi-step strategies can take several minutes (limit: 60 minutes)."
+```
+
+and reject the stale 10-minute copy. Add a source assertion that the timeout branch says `Timed out after 60 minutes.`.
+
+- [ ] **Step 2: Add boundary tests for localStorage running entries**
+
+Exercise the real `getAgentBacktestRunning()`/`listRunningBacktests()` helpers with mocked `Date.now()` values. Assert an entry at 3599 seconds is retained and an entry older than 3600 seconds is removed. Keep the strict comparison aligned with the existing `elapsed > BACKTEST_POLL_MAX_SECONDS` behavior.
+
+- [ ] **Step 3: Add the elapsed-bar fallback assertion for the new denominator**
+
+Keep the existing panel test but change its expected width from `10% // 60 / 600` to approximately `2% // 60 / 3600`. This proves `updateBacktestRunProgress()` inherits the same shared constant instead of retaining a hidden 600-second denominator.
+
+- [ ] **Step 4: Run the frontend tests and verify they fail**
+
+Run:
+
+```bash
+cd dashboard
+pytest backend/tests/test_backtest_progress_card.py backend/tests/test_app_copy_register.py -q
+```
+
+Expected: FAIL on the 600-second constant, old 10-minute copy, and old elapsed-bar percentage.
+
+### Task 4: Apply the frontend timeout and copy changes
+
+**Files:**
+- Modify: `dashboard/frontend/app.js:20` and the timeout branch around line 7027
+- Modify: `dashboard/frontend/app.html:1246` and the general backtest description around line 1392
+
+**Interfaces:**
+- Consumes: the failing contract tests from Task 3 and every existing consumer of `BACKTEST_POLL_MAX_SECONDS`.
+- Produces: a 3600-second poll/lifetime ceiling shared by the poller, registry cleanup, progress fallback, and legacy wait helper.
+
+- [ ] **Step 1: Set the shared frontend ceiling**
+
+Change only the constant and comment:
+
+```javascript
+const BACKTEST_POLL_MAX_SECONDS = 3600; // 60 minutes at 1-second polling intervals
+```
+
+Do not introduce a second frontend timeout constant. Existing consumers must continue reading this value.
+
+- [ ] **Step 2: Update terminal and progress-card copy**
+
+Change the timeout branch to:
+
+```javascript
+message: 'Timed out after 60 minutes. The backtest may still be running in the background.',
+```
+
+Change the progress hint to:
+
+```html
+<p class="backtest-run-progress-hint">Multi-step strategies can take several minutes (limit: 60 minutes).</p>
+```
+
+Change the general product sentence to avoid a false exact promise while retaining the meaning that the workflow can be long:
+
+```html
+<p>Chat with Claude; backtests use Alpaca historical data and multi-step runs can take several minutes.</p>
+```
+
+Keep the existing HTML structure and typography unchanged.
+
+- [ ] **Step 3: Run the frontend contract tests**
+
+Run:
+
+```bash
+cd dashboard
+pytest backend/tests/test_backtest_progress_card.py backend/tests/test_app_copy_register.py -q
+```
+
+Expected: PASS, including 3599-second retention, post-ceiling cleanup, 2% elapsed fallback at 60 seconds, and the absence of stale ten-minute copy.
+
+- [ ] **Step 4: Commit the frontend change**
+
+```bash
+git add dashboard/frontend/app.js dashboard/frontend/app.html dashboard/backend/tests/test_backtest_progress_card.py dashboard/backend/tests/test_app_copy_register.py
+git commit -m "fix: align dashboard backtest polling with 60 minute budget"
+```
+
+### Task 5: Run the complete focused verification suite
+
+**Files:**
+- No new files; verify all files changed in Tasks 1-4.
+
+**Interfaces:**
+- Consumes: backend and frontend contract changes from the previous tasks.
+- Produces: a clean, reviewable branch ready for the pull request.
+
+- [ ] **Step 1: Run all focused tests**
+
+Run:
+
+```bash
+cd dashboard
+pytest backend/tests/test_backtests_router.py backend/tests/test_backtest_progress_card.py backend/tests/test_app_copy_register.py -q
+```
+
+Expected: PASS with no unrelated test skips beyond the existing Node availability marker.
+
+- [ ] **Step 2: Run Python syntax checks for touched backend modules**
+
+Run:
+
+```bash
+python -m py_compile dashboard/backend/api/routers/backtests.py
+```
+
+Expected: exit code 0 and no generated bytecode tracked by git.
+
+- [ ] **Step 3: Check for stale timeout copy and unrelated constant changes**
+
+Run:
+
+```bash
+rg -n "10 minutes|3.?10 minutes|BACKTEST_POLL_MAX_SECONDS = 600|PIPELINE_SUBPROCESS_TIMEOUT_SECONDS = 1800" dashboard/frontend dashboard/backend
+git diff --check
+git diff --stat origin/main...HEAD
+```
+
+Expected: no stale dashboard backtest-limit copy or old constants; `git diff --check` is clean; the diff contains only the specified backend/frontend files and tests.
+
+- [ ] **Step 4: Inspect cleanup-sensitive diff and status**
+
+Run:
+
+```bash
+git diff origin/main...HEAD -- dashboard/backend/api/routers/backtests.py dashboard/frontend/app.js dashboard/frontend/app.html
+git status --short --branch
+```
+
+Confirm no provider timeout, database timeout, Render config, credential, `.superpowers/`, or `work/` changes are present.
+
+- [ ] **Step 5: Commit any final test-only adjustments**
+
+If the verification step required a test correction, commit only that correction:
+
+```bash
+git add dashboard/backend/tests/test_backtests_router.py dashboard/backend/tests/test_backtest_progress_card.py dashboard/backend/tests/test_app_copy_register.py
+git commit -m "test: verify the 60 minute backtest timeout contract"
+```
+
+Otherwise leave the existing task commits intact and report the commit list in the PR description.
+
+## Pull Request Acceptance Checklist
+
+- [ ] Pipeline dashboard parent timeout is exactly 3600 seconds.
+- [ ] Hosted runtime timeout calculation and 14400-second ceiling are unchanged.
+- [ ] Frontend polling, running-entry cleanup, legacy wait helper, and elapsed fallback all use 3600 seconds.
+- [ ] User-visible dashboard copy consistently says 60 minutes or avoids an exact duration promise.
+- [ ] Timeout cleanup releases subprocess/slot/credits resources without double finalization.
+- [ ] Focused tests, syntax check, and `git diff --check` pass.
+- [ ] No real credentials, `.superpowers/`, or `work/` files are included.
+- [ ] Render deployment is separately verified against the merged commit because the service uses manual deployment.

--- a/docs/superpowers/specs/2026-08-30-backtest-timeout-consistency-design.md
+++ b/docs/superpowers/specs/2026-08-30-backtest-timeout-consistency-design.md
@@ -1,0 +1,174 @@
+# Dashboard Backtest Timeout Consistency
+
+**Status:** Draft for user review
+
+**Date:** 2026-08-30
+
+## Context
+
+Dashboard backtests currently expose three different time boundaries. The
+browser stops polling after 600 seconds, the pipeline worker parent is allowed
+1800 seconds, and some hosted runtimes calculate a separate budget from their
+per-decision timeout. A backtest can therefore still be running on Render after
+the browser says it timed out, or the browser can stop showing progress before
+the backend has reached its own limit.
+
+The dashboard backtest loop performs one decision for each hourly market bar.
+Longer ranges and reasoning-enabled models can legitimately exceed ten minutes.
+The requested behavior is a fixed 60-minute wall-clock budget for the normal
+dashboard pipeline run, with matching browser status visibility.
+
+## Goals
+
+1. Raise the dashboard pipeline subprocess hard limit from 30 minutes to 60
+   minutes (3600 seconds).
+2. Raise the browser's dashboard backtest polling and local running-entry
+   lifetime from 10 minutes to 60 minutes (3600 seconds).
+3. Update every user-visible dashboard backtest duration message that currently
+   promises or reports ten minutes.
+4. Preserve terminal cleanup: a timeout must terminate the child process,
+   release platform-credit reservations, release the backtest slot, and expose a
+   terminal status instead of leaving a permanent running state.
+5. Cover the backend/frontend timeout contract with deterministic tests.
+
+## Non-goals
+
+- Do not change provider HTTP request timeouts, database timeouts, email
+  timeouts, or other unrelated network/runtime limits to 60 minutes.
+- Do not change OpenRouter/Qwen response handling, Gemini behavior, or model
+  reasoning policy in this PR.
+- Do not make the backtest faster. LLM call count, hourly decision cadence,
+  market-data loading, and pipeline semantics remain unchanged.
+- Do not remove the hard timeout or allow an unbounded background process.
+- Do not change the 31-day date-range validation in this PR. A 31-day run may
+  still exceed the fixed 60-minute budget and must report a normal timeout.
+- Do not change the Render plan or the server-wide concurrent-run default in
+  code. Free-tier rollout capacity is an operational setting, not a timeout
+  contract.
+
+## Design
+
+### 1. Backend wall-clock budget
+
+Set `PIPELINE_SUBPROCESS_TIMEOUT_SECONDS` in
+`dashboard/backend/api/routers/backtests.py` to `3600`. The existing
+`_backtest_subprocess_timeout()` behavior remains otherwise unchanged:
+
+- `runtime_type == "pipeline"` receives the fixed 3600-second parent budget;
+- hosted runtime types retain their existing per-decision calculation and
+  14400-second ceiling;
+- the timeout passed to each provider HTTP client remains its existing short
+  request timeout, so one stalled provider call does not pin a worker for an
+  hour by itself.
+
+When `subprocess.run(..., timeout=3600)` expires, the current background-worker
+exception/finally path remains the owner of cleanup. The implementation must
+verify that the child is terminated and that both `finalize_run()` and slot
+finalization still run exactly once. The user-facing error remains sanitized;
+it must not include provider prompts, responses, or credentials.
+
+The constant name can remain stable to minimize downstream churn. Comments and
+tests must describe the value as a 60-minute pipeline budget rather than a
+generic provider timeout.
+
+### 2. Frontend observation window
+
+Set `BACKTEST_POLL_MAX_SECONDS` in `dashboard/frontend/app.js` to `3600`.
+Every existing consumer of this constant must inherit the same value:
+
+- the shared status poller;
+- the localStorage running-backtest registry cleanup;
+- per-agent running-card cleanup;
+- the legacy `pollBacktestStatus()` wait helper;
+- progress-bar fallback calculations.
+
+The poller continues to treat a failed status request as inconclusive and keeps
+watching until the existing failure budget is exhausted. At the 60-minute
+client ceiling it stops polling and shows a clear message that the run may
+still be running in the background. It clears only the browser's local mirror;
+it must not claim a successful result or silently replace the run with another
+one. The backend remains authoritative for final status and cleanup.
+
+Update `dashboard/frontend/app.html` and the timeout message in `app.js` so the
+visible copy consistently says 60 minutes. General product copy should avoid a
+false exact promise such as "3-10 minutes" and instead say that longer
+multi-step backtests can take several minutes.
+
+### 3. Contract and resource boundaries
+
+The two 3600-second values are intentionally duplicated because this dashboard
+has no frontend build-time configuration channel. A focused contract test will
+assert that both values and the visible timeout copy agree. No provider or
+database timeout is allowed to inherit this constant.
+
+The longer budget increases the time each run can hold a loaded bar window and
+an active slot. The existing server-wide concurrency guard remains in place.
+Before deploying to the 512 MB free Render instance, operators should use a
+conservative `MAX_ACTIVE_DASHBOARD_BACKTESTS` value (one or two) if live memory
+measurements show contention. That operational decision is deliberately outside
+this code PR.
+
+### 4. Failure and status sequence
+
+The expected lifecycle is:
+
+1. The API accepts the run and returns its `live_run_id` immediately.
+2. The browser polls the run status for up to 3600 seconds and continues to
+   render progress/staleness notices from the server payload.
+3. A completed or failed worker publishes its terminal status; the browser
+   loads or displays that status and removes the local running entry.
+4. If the parent subprocess reaches 3600 seconds first, it terminates the
+   worker, finalizes the execution run, releases any open reservation and slot,
+   and records a sanitized timeout error.
+5. If the browser reaches 3600 seconds first because of a network or process
+   discrepancy, it displays the background-running message and does not invent
+   a result. Reloading can discover the server's terminal status.
+
+The fixed limit is a protection against orphaned work, not a performance
+guarantee. It prevents the current 10-minute/30-minute mismatch while keeping a
+bounded failure mode for unusually long ranges.
+
+## Testing strategy
+
+### Backend
+
+Extend `dashboard/backend/tests/test_backtests_router.py` to verify:
+
+1. A pipeline run resolves to 3600 seconds.
+2. Hosted runtime sizing remains dynamic and still respects the existing
+   14400-second ceiling.
+3. A timeout path releases the worker execution run and backtest slot without
+   double-finalizing them.
+4. Existing date-range and concurrency validations are unchanged.
+
+### Frontend
+
+Extend `dashboard/backend/tests/test_backtest_progress_card.py` to verify:
+
+1. `BACKTEST_POLL_MAX_SECONDS` is 3600.
+2. Running entries are retained through 3599 seconds and swept after the
+   3600-second ceiling.
+3. The poller, legacy wait helper, and progress-bar fallback use the same
+   ceiling.
+4. The terminal copy reports 60 minutes, and no visible copy still reports a
+   ten-minute backtest limit.
+5. A server terminal error/result still wins over the client timeout branch.
+
+Run the focused backend/frontend tests, the existing backtest router tests,
+`git diff --check`, and the relevant Python syntax checks before opening the PR.
+
+## Rollout and acceptance
+
+The PR is accepted when:
+
+- all targeted tests pass;
+- no unrelated timeout constants change;
+- `git diff --check` is clean;
+- a deployed test run that lasts longer than ten minutes remains visible in the
+  browser and can still reach a terminal result before 60 minutes;
+- a forced timeout leaves no active slot, open platform-credit reservation, or
+  stale browser running card.
+
+The deployment must be verified against the new commit. Render's current
+service uses manual deployment, so merging or pushing alone is not evidence that
+the 60-minute backend budget is live.


### PR DESCRIPTION
## Summary
- extend the dashboard pipeline parent subprocess budget from 30 to 60 minutes
- keep frontend polling, running-entry cleanup, legacy wait, and elapsed fallback on the shared 60-minute ceiling
- replace stale 10-minute and 3–10 minute user-facing copy
- add deterministic timeout cleanup and frontend boundary contract tests

## Verification
- `pytest -q dashboard/backend/tests/test_backtests_router.py dashboard/backend/tests/test_backtest_progress_card.py dashboard/backend/tests/test_app_copy_register.py dashboard/backend/tests/domain/backtesting/test_algo_service_move.py`
- 173 passed
- `python -m py_compile ...`
- `node --check dashboard/frontend/app.js`
- `git diff --check`

## Scope
Provider HTTP timeouts, hosted-runtime dynamic sizing, LLM behavior, concurrency limits, date-range validation, and Render plan settings are unchanged.