### PR TITLE
fix(llm): quote-aware brace repair; close CodeQL #1283

### DIFF
--- a/dashboard/backend/infrastructure/llm/backtest_harness.py
+++ b/dashboard/backend/infrastructure/llm/backtest_harness.py
@@ -27,7 +27,7 @@ import is optional and there is no import-time network or credential access).
 
 import json
 import os
-from typing import Dict, Optional
+from typing import Dict, Iterator, Optional, Tuple
 
 from dashboard.backend.infrastructure.llm.decision_parsing import fix_json_formatting
 from dashboard.backend.infrastructure.llm.providers import (
@@ -267,6 +267,48 @@ def extract_token_usage(response):
     )
 
 
+def _structural_braces(text: str) -> Iterator[Tuple[int, str]]:
+    """Yield ``(index, brace)`` for each ``{`` / ``}`` outside a string literal.
+
+    Tracks JSON string boundaries, including backslash-escaped quotes, so a
+    brace inside a ``reason`` value counts as data rather than structure.
+    """
+    in_string = False
+    escaped = False
+    for index, char in enumerate(text):
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+        elif char == '"':
+            in_string = True
+        elif char in "{}":
+            yield index, char
+
+
+def _structural_brace_counts(text: str) -> Tuple[int, int]:
+    """``(open, close)`` counts of the braces that are actually structure."""
+    braces = [brace for _, brace in _structural_braces(text)]
+    open_count = braces.count("{")
+    return open_count, len(braces) - open_count
+
+
+def _trim_extra_closing_braces(text: str) -> str:
+    """Cut at the last structural ``}`` until closers no longer outnumber openers.
+
+    Each pass removes at least one closer, so the loop always terminates.
+    """
+    while True:
+        braces = list(_structural_braces(text))
+        closers = [index for index, brace in braces if brace == "}"]
+        if len(closers) <= len(braces) - len(closers):
+            return text
+        text = text[: closers[-1]]
+
+
 def parse_llm_response(llm_response: str) -> Optional[Dict]:
     """Parse the LLM response into a decision dict, or ``None`` on failure.
 
@@ -331,17 +373,18 @@ def parse_llm_response(llm_response: str) -> Optional[Dict]:
                 # Try one more aggressive fix
                 print(f"\n   Attempting second fix attempt (validate structure)...")
                 try:
-                    # Count opening vs closing brackets
-                    open_count = json_str_fixed.count('{')
-                    close_count = json_str_fixed.count('}')
+                    # Count opening vs closing braces outside string values:
+                    # ``str.count`` also saw a ``}`` inside a "reason", and
+                    # the trim below then stripped a real closer with the
+                    # stray one, turning a parseable decision into None.
+                    open_count, close_count = _structural_brace_counts(json_str_fixed)
                     if open_count != close_count:
                         print(f"   Bracket mismatch: {open_count} open, {close_count} close")
-                        # Remove extra closing brackets from the end. Drop one
-                        # ``}`` per pass: the old form re-appended the brace it
-                        # had just cut, so the counts never changed and this
-                        # loop spun forever on a reply with one stray ``}``.
-                        while json_str_fixed.count('}') > json_str_fixed.count('{'):
-                            json_str_fixed = json_str_fixed.rsplit('}', 1)[0]
+                        # Remove extra closing braces from the end, one per
+                        # pass. (An older form re-appended the brace it had
+                        # just cut, so the counts never changed and the loop
+                        # spun forever on a reply with one stray ``}``.)
+                        json_str_fixed = _trim_extra_closing_braces(json_str_fixed)
                         print(f"   Removed extra closing brackets")
 
                     decision = json.loads(json_str_fixed)

--- a/dashboard/backend/tests/infrastructure/llm/test_pipeline_runner.py
+++ b/dashboard/backend/tests/infrastructure/llm/test_pipeline_runner.py
@@ -26,8 +26,12 @@ from dashboard.backend.infrastructure.llm.pipeline_runner import (
 
 
 class _PipelineResponse:
-    def __init__(self, text, input_tokens=7, output_tokens=3, stop_reason=None):
-        self.content = [SimpleNamespace(type="text", text=text)]
+    def __init__(
+        self, text, input_tokens=7, output_tokens=3, stop_reason=None, content=None
+    ):
+        if content is None:
+            content = [SimpleNamespace(type="text", text=text)]
+        self.content = content
         self.usage = SimpleNamespace(
             input_tokens=input_tokens,
             output_tokens=output_tokens,
@@ -40,8 +44,12 @@ class _ThinkingOnlyResponse(_PipelineResponse):
     """A reasoning model that spent the whole reply on a thinking block."""
 
     def __init__(self, input_tokens=5, output_tokens=7):
-        super().__init__("", input_tokens=input_tokens, output_tokens=output_tokens)
-        self.content = [SimpleNamespace(type="thinking", thinking="...")]
+        super().__init__(
+            "",
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            content=[SimpleNamespace(type="thinking", thinking="...")],
+        )
 
 
 def _truncated_json(pad: int = 560) -> str:

--- a/dashboard/backend/tests/llm/test_backtest_harness.py
+++ b/dashboard/backend/tests/llm/test_backtest_harness.py
@@ -11,6 +11,8 @@ import json
 import threading
 from datetime import datetime
 
+import pytest
+
 from dashboard.backend.domain.backtesting import (
     portfolio_manager as portfolio_manager_module,
 )
@@ -815,3 +817,26 @@ def test_parse_llm_response_trims_a_stray_closing_brace_without_hanging():
 
     assert not worker.is_alive(), "parse_llm_response did not terminate"
     assert outcome["decision"] == {"actions": [{"symbol": "AAPL", "action": "buy"}]}
+
+
+@pytest.mark.parametrize(
+    "reason_json, reason",
+    [
+        ('"close}"', "close}"),
+        ('"say \\"}\\" now"', 'say "}" now'),
+    ],
+    ids=["brace-in-string", "brace-after-escaped-quote"],
+)
+def test_parse_llm_response_keeps_closing_braces_inside_string_values(reason_json, reason):
+    # The bracket-trim repair used to count every ``}`` in the text, so a brace
+    # inside a string value made it strip a real closer along with the stray
+    # one and a parseable decision came back as None.
+    response = (
+        '{"actions": [{"symbol": "AAPL", "action": "buy", "reason": '
+        + reason_json
+        + "}]}}"
+    )
+
+    assert harness.parse_llm_response(response) == {
+        "actions": [{"symbol": "AAPL", "action": "buy", "reason": reason}]
+    }


### PR DESCRIPTION
Amends #423, which merged before its CodeQL scan had finished.

- `parse_llm_response`: the brace-count repair was string-blind — a `}` inside a `"reason"` value made the trim strip a real closer and return `None` for a parseable reply. It now counts and trims only structural braces (escape-aware). Listed as a follow-up in #423.
- Closes CodeQL #1283 (`py/overwritten-inherited-attribute`), the one alert #423 introduced: the `_ThinkingOnlyResponse` fixture passes its content through the base constructor instead of overwriting it.

Still deferred, unchanged here: the non-pipeline decision path (`portfolio_manager._parse_llm_response`) has no truncation recovery; `py/cyclic-import` #1263/#1264 (`execution/models.py` ↔ `token_cost.py`) predates #421.

Tests: full backend suite green locally (3861 passed, 148 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDCS8B3PDn5BCrqHB8XJWg
