### PR TITLE
fix(llm): single-call truncation recovery; pricing import cycle

### DIFF
--- a/dashboard/backend/domain/backtesting/portfolio_manager.py
+++ b/dashboard/backend/domain/backtesting/portfolio_manager.py
@@ -56,7 +56,9 @@ from dashboard.backend.infrastructure.llm.backtest_harness import (
 )
 from dashboard.backend.infrastructure.llm.pipeline_runner import (
     RECOVERY_MAX_OUTPUT_TOKENS,
+    response_text_or_none,
     run_pipeline_decision,
+    truncation_reason,
 )
 
 
@@ -477,6 +479,13 @@ class PortfolioManager:
                 # not tank H6 coverage on intermittent empty responses.
                 llm_response = None
                 no_text_retries = 4
+                # One recovery budget (``RECOVERY_MAX_OUTPUT_TOKENS``) per
+                # step, spent by whichever unusable reply claims it first: the
+                # final rescue call below, or the truncation retry after the
+                # parse. A reply still unusable at that budget has nothing
+                # different left to ask for.
+                recovery_spent = False
+                output_delta = 0
                 for attempt in range(no_text_retries + 1):
                     if attempt == no_text_retries:
                         # Final rescue: preserve the provider's reasoning mode,
@@ -485,6 +494,7 @@ class PortfolioManager:
                             "   ⚠️  Final rescue call with reasoning preserved "
                             f"and max_tokens={RECOVERY_MAX_OUTPUT_TOKENS}"
                         )
+                        recovery_spent = True
                         response = _request_trading_decision(
                             llm_client,
                             prompt=prompt,
@@ -501,13 +511,7 @@ class PortfolioManager:
                             temperature=temperature,
                             market_context=market_context,
                         )
-                    try:
-                        input_delta, output_delta = _extract_token_usage(response)
-                        self.input_tokens += input_delta
-                        self.output_tokens += output_delta
-                        self.llm_calls += 1
-                    except Exception as usage_err:
-                        print(f"   ⚠️  Could not read token usage: {usage_err}")
+                    output_delta = self._record_llm_usage(response)
                     try:
                         llm_response = _extract_response_text(response)
                         break
@@ -526,6 +530,38 @@ class PortfolioManager:
                 # STEP 3: Parse and validate LLM response
                 # ================================================================
                 decision = _parse_llm_response(llm_response)
+                if decision is None and not recovery_spent:
+                    # The same single recovery attempt the pipeline path makes:
+                    # a reply the provider cut at the output ceiling, or one
+                    # that opened the decision envelope and never closed it,
+                    # gets the same request once more with room for reasoning
+                    # plus the JSON. Without it the leaderboard ``llm_agent`` —
+                    # which never runs a pipeline — turned every over-long
+                    # reasoning burst into a billed step with no H6 decision.
+                    reason = truncation_reason(response, output_delta, llm_response)
+                    if reason is not None:
+                        print(
+                            f"   ⚠️  LLM response {reason}; retrying once with "
+                            "reasoning preserved and "
+                            f"max_tokens={RECOVERY_MAX_OUTPUT_TOKENS}"
+                        )
+                        retry_response = _request_trading_decision(
+                            llm_client,
+                            prompt=prompt,
+                            model=model,
+                            max_tokens=RECOVERY_MAX_OUTPUT_TOKENS,
+                            temperature=temperature,
+                            market_context=market_context,
+                        )
+                        self._record_llm_usage(retry_response)
+                        retry_text = response_text_or_none(retry_response)
+                        if retry_text is None:
+                            print(
+                                "   ⚠️  Retry returned no text block; "
+                                "keeping the first attempt"
+                            )
+                        else:
+                            decision = _parse_llm_response(retry_text)
                 if decision is None:
                     if strict_llm:
                         raise LLMDecisionError(
@@ -737,6 +773,22 @@ class PortfolioManager:
             print(f"\n❌ LLM decision error: {e}")
             print(f"   Falling back to rule-based logic\n")
             return self.make_trading_decision(portfolio_state)
+
+    def _record_llm_usage(self, response) -> int:
+        """Bill one received response; returns its output-token delta.
+
+        A response whose usage cannot be read is logged and not counted as a
+        call — ``llm_calls`` is "billed API calls (any response with usage)".
+        """
+        try:
+            input_delta, output_delta = _extract_token_usage(response)
+        except Exception as usage_err:
+            print(f"   ⚠️  Could not read token usage: {usage_err}")
+            return 0
+        self.input_tokens += input_delta
+        self.output_tokens += output_delta
+        self.llm_calls += 1
+        return output_delta
 
     def strict_llm_fallback_budget(self) -> int:
         """How many unusable model responses this strict run may absorb."""

--- a/dashboard/backend/infrastructure/llm/execution/models.py
+++ b/dashboard/backend/infrastructure/llm/execution/models.py
@@ -7,6 +7,11 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from dashboard.backend.infrastructure.llm.pricing import (
+    PRICING_SOURCE_VERSION,
+    price_for_model,
+)
+
 
 class BillingMode(StrEnum):
     PLATFORM_CREDITS = "platform_credits"
@@ -109,10 +114,8 @@ class PricingSnapshot(BaseModel):
         model_id: str,
         provider_id: str = "unknown",
         *,
-        source_version: str = "pricing-table-2026-08-24",
+        source_version: str = PRICING_SOURCE_VERSION,
     ) -> "PricingSnapshot":
-        from dashboard.backend.infrastructure.llm.token_cost import price_for_model
-
         input_price, output_price = price_for_model(model_id)
         return cls(
             provider_id=provider_id,

--- a/dashboard/backend/infrastructure/llm/pipeline_runner.py
+++ b/dashboard/backend/infrastructure/llm/pipeline_runner.py
@@ -628,8 +628,13 @@ def _looks_like_truncated_json(response_text: str) -> bool:
     return bool(stack)
 
 
-def _truncation_reason(response, output_tokens: int, response_text: str) -> Optional[str]:
-    """Why an unparseable first reply is worth one more attempt, or ``None``."""
+def truncation_reason(response, output_tokens: int, response_text: str) -> Optional[str]:
+    """Why an unparseable first reply is worth one more attempt, or ``None``.
+
+    Shared with the non-pipeline decision path in
+    ``domain/backtesting/portfolio_manager.py``, which spends the same single
+    recovery budget on the same two signals.
+    """
     if _hit_output_ceiling(response, output_tokens, DEFAULT_MAX_OUTPUT_TOKENS):
         return "stopped at the output ceiling"
     if _looks_like_truncated_json(response_text):
@@ -637,7 +642,7 @@ def _truncation_reason(response, output_tokens: int, response_text: str) -> Opti
     return None
 
 
-def _response_text_or_none(response) -> Optional[str]:
+def response_text_or_none(response) -> Optional[str]:
     """Text of a response, or ``None`` when it carries no text block.
 
     A reasoning model can spend the whole reply on a thinking block; that is
@@ -667,7 +672,7 @@ def run_pipeline_decision(
     Each step gets at most **one** second attempt (``_retry_with_recovery_budget``),
     and only when the first attempt was unusable: the provider rejected it as
     ``response_invalid``, or it came back unparseable *and* truncated (see
-    ``_truncation_reason``). A reply with no text block at all is unparseable
+    ``truncation_reason``). A reply with no text block at all is unparseable
     by definition: it is retried when the provider reports the ceiling, and
     otherwise ends the step cleanly with its usage intact. The two triggers
     share that single budget on
@@ -723,7 +728,7 @@ def run_pipeline_decision(
             retried = True
         out_delta = usage.record(response)
 
-        response_text = _response_text_or_none(response)
+        response_text = response_text_or_none(response)
         if response_text is None:
             print("   ⚠️  Pipeline response carried no text block")
             parsed = None
@@ -731,7 +736,7 @@ def run_pipeline_decision(
             parsed = parse_llm_response(response_text)
         reason = None
         if parsed is None and not retried:
-            reason = _truncation_reason(response, out_delta, response_text or "")
+            reason = truncation_reason(response, out_delta, response_text or "")
         if reason is not None:
             print(
                 f"   ⚠️  Pipeline response {reason}; retrying once with reasoning "
@@ -751,7 +756,7 @@ def run_pipeline_decision(
                 print("   ⚠️  Retry returned no usable response; keeping the first attempt")
             if retry_response is not None:
                 usage.record(retry_response)
-                retry_text = _response_text_or_none(retry_response)
+                retry_text = response_text_or_none(retry_response)
                 if retry_text is None:
                     print("   ⚠️  Retry returned no text block; keeping the first attempt")
                 else:

--- a/dashboard/backend/infrastructure/llm/pricing.py
+++ b/dashboard/backend/infrastructure/llm/pricing.py
@@ -1,0 +1,85 @@
+"""Model price table and the free-model sentinels — a leaf module.
+
+Both ``token_cost`` (estimation and billing evidence) and
+``execution/models.py`` (``PricingSnapshot.from_model``) need the table, and
+``token_cost`` also needs the pydantic models from ``execution/models`` — so
+the table lives here, below both, rather than in either. Keep this module free
+of ``dashboard`` imports: the cycle it replaced (CodeQL ``py/cyclic-import``)
+only held together because one side imported lazily inside a method.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+# Approximate USD pricing per 1,000,000 tokens (input, output).
+# Matched by substring against the run's model name (longest/most specific first).
+# "Local" / rule-based models incur no API cost.
+_PRICING_TABLE: list[Tuple[str, float, float]] = [
+    # CommonStack-verified slugs (provider/model), rates from GET /v1/models on
+    # 2026-06-24. Listed first so the specific slug wins over generic needles.
+    ("openai/gpt-5.5", 5.0, 30.0),
+    ("google/gemini-3.1-pro", 2.0, 12.0),
+    ("anthropic/claude-sonnet-4-6", 3.0, 15.0),
+    ("deepseek/deepseek-v4-pro", 0.435, 0.87),
+    ("qwen/qwen3.7-plus", 0.40, 1.60),
+    ("x-ai/grok-4.20-reasoning", 1.25, 2.50),  # listed but unavailable on our account (no channel)
+    # OpenRouter-listed (provider/model). Rates from openrouter.ai model pages.
+    ("nvidia/nemotron-3-nano-30b-a3b", 0.05, 0.20),
+    ("claude-opus-4", 15.0, 75.0),
+    ("claude-sonnet-4", 3.0, 15.0),
+    ("claude-haiku-4", 1.0, 5.0),
+    ("claude-3-7-sonnet", 3.0, 15.0),
+    ("claude-3-5-sonnet", 3.0, 15.0),
+    ("claude-3-5-haiku", 0.80, 4.0),
+    ("claude-3-opus", 15.0, 75.0),
+    ("claude-3-haiku", 0.25, 1.25),
+    ("opus", 15.0, 75.0),
+    ("sonnet", 3.0, 15.0),
+    ("haiku", 1.0, 5.0),
+    ("gpt-4o-mini", 0.15, 0.60),
+    ("gpt-4o", 2.50, 10.0),
+    ("gpt-4.1-mini", 0.40, 1.60),
+    ("gpt-4.1", 2.0, 8.0),
+    ("o3-mini", 1.10, 4.40),
+    ("o3", 2.0, 8.0),
+    ("gpt-4-turbo", 10.0, 30.0),
+    ("gpt-4", 30.0, 60.0),
+    ("gpt-3.5", 0.50, 1.50),
+]
+
+# Model names that represent no paid LLM call (cost = 0).
+_FREE_MODEL_MARKERS = ("rule-based", "local-model", "local", "demo", "baseline", "none")
+
+# Fallback pricing when a real-looking model name is not in the table.
+_DEFAULT_PRICING: Tuple[float, float] = (1.0, 5.0)
+
+# Stamped on every ``PricingSnapshot`` so a stored cost can be traced to the
+# table that priced it. Bump it whenever the rates above change.
+PRICING_SOURCE_VERSION = "pricing-table-2026-08-24"
+
+
+def is_free_model(model: str | None) -> bool:
+    """True when ``model`` names no real paid LLM: a sentinel / rule-based /
+    local marker (e.g. ``'local-model'``, ``'rule-based'``) or nothing at all.
+
+    Callers use this to treat such values as "no explicit model" rather than a
+    real model id — e.g. the Discord bot must not forward the default
+    ``'local-model'`` sentinel to the hosted-model API as if it were a model."""
+    name = (model or "").strip().lower()
+    if not name:
+        return True
+    return any(marker in name for marker in _FREE_MODEL_MARKERS)
+
+
+def price_for_model(model: str | None) -> Tuple[float, float]:
+    """Return (input_usd_per_mtok, output_usd_per_mtok) for a model name."""
+    name = (model or "").strip().lower()
+    if not name:
+        return _DEFAULT_PRICING
+    if any(marker in name for marker in _FREE_MODEL_MARKERS):
+        return (0.0, 0.0)
+    for needle, in_price, out_price in _PRICING_TABLE:
+        if needle in name:
+            return (in_price, out_price)
+    return _DEFAULT_PRICING

--- a/dashboard/backend/infrastructure/llm/token_cost.py
+++ b/dashboard/backend/infrastructure/llm/token_cost.py
@@ -16,8 +16,9 @@ from __future__ import annotations
 import json
 import math
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
-from typing import Any, Mapping, Tuple
+from typing import Any, Mapping
 
+from dashboard.backend.infrastructure.llm import pricing as _pricing
 from dashboard.backend.infrastructure.llm.execution.models import (
     BillingEvidence,
     BillingMode,
@@ -29,63 +30,19 @@ from dashboard.backend.infrastructure.llm.execution.models import (
 # ~3.8 chars/token tracks Claude + GPT tokenizers well for this payload shape.
 CHARS_PER_TOKEN = 3.8
 
-# Approximate USD pricing per 1,000,000 tokens (input, output).
-# Matched by substring against the run's model name (longest/most specific first).
-# "Local" / rule-based models incur no API cost.
-_PRICING_TABLE: list[Tuple[str, float, float]] = [
-    # CommonStack-verified slugs (provider/model), rates from GET /v1/models on
-    # 2026-06-24. Listed first so the specific slug wins over generic needles.
-    ("openai/gpt-5.5", 5.0, 30.0),
-    ("google/gemini-3.1-pro", 2.0, 12.0),
-    ("anthropic/claude-sonnet-4-6", 3.0, 15.0),
-    ("deepseek/deepseek-v4-pro", 0.435, 0.87),
-    ("qwen/qwen3.7-plus", 0.40, 1.60),
-    ("x-ai/grok-4.20-reasoning", 1.25, 2.50),  # listed but unavailable on our account (no channel)
-    # OpenRouter-listed (provider/model). Rates from openrouter.ai model pages.
-    ("nvidia/nemotron-3-nano-30b-a3b", 0.05, 0.20),
-    ("claude-opus-4", 15.0, 75.0),
-    ("claude-sonnet-4", 3.0, 15.0),
-    ("claude-haiku-4", 1.0, 5.0),
-    ("claude-3-7-sonnet", 3.0, 15.0),
-    ("claude-3-5-sonnet", 3.0, 15.0),
-    ("claude-3-5-haiku", 0.80, 4.0),
-    ("claude-3-opus", 15.0, 75.0),
-    ("claude-3-haiku", 0.25, 1.25),
-    ("opus", 15.0, 75.0),
-    ("sonnet", 3.0, 15.0),
-    ("haiku", 1.0, 5.0),
-    ("gpt-4o-mini", 0.15, 0.60),
-    ("gpt-4o", 2.50, 10.0),
-    ("gpt-4.1-mini", 0.40, 1.60),
-    ("gpt-4.1", 2.0, 8.0),
-    ("o3-mini", 1.10, 4.40),
-    ("o3", 2.0, 8.0),
-    ("gpt-4-turbo", 10.0, 30.0),
-    ("gpt-4", 30.0, 60.0),
-    ("gpt-3.5", 0.50, 1.50),
-]
+# The price table and the free-model sentinels live in ``pricing`` — a leaf —
+# so ``execution/models`` can price a snapshot without importing this module
+# back (CodeQL ``py/cyclic-import``). Explicit assignments rather than a bare
+# ``from … import``: the names stay part of this module's public surface
+# (``discord_bot`` imports ``is_free_model`` from here), and an assignment
+# counts as a *use*, so CodeQL does not report the re-export as
+# ``py/unused-import`` (see PR #213).
+PRICING_SOURCE_VERSION = _pricing.PRICING_SOURCE_VERSION
+is_free_model = _pricing.is_free_model
+price_for_model = _pricing.price_for_model
 
-# Model names that represent no paid LLM call (cost = 0).
-_FREE_MODEL_MARKERS = ("rule-based", "local-model", "local", "demo", "baseline", "none")
-
-# Fallback pricing when a real-looking model name is not in the table.
-_DEFAULT_PRICING: Tuple[float, float] = (1.0, 5.0)
-PRICING_SOURCE_VERSION = "pricing-table-2026-08-24"
 USD_PER_CREDIT = Decimal("1")
 CREDITS_MICRO_PER_CREDIT = 1_000_000
-
-
-def is_free_model(model: str | None) -> bool:
-    """True when ``model`` names no real paid LLM: a sentinel / rule-based /
-    local marker (e.g. ``'local-model'``, ``'rule-based'``) or nothing at all.
-
-    Callers use this to treat such values as "no explicit model" rather than a
-    real model id — e.g. the Discord bot must not forward the default
-    ``'local-model'`` sentinel to the hosted-model API as if it were a model."""
-    name = (model or "").strip().lower()
-    if not name:
-        return True
-    return any(marker in name for marker in _FREE_MODEL_MARKERS)
 
 
 def estimate_tokens(value: Any) -> int:
@@ -102,19 +59,6 @@ def estimate_tokens(value: Any) -> int:
     if not text:
         return 0
     return max(1, math.ceil(len(text) / CHARS_PER_TOKEN))
-
-
-def price_for_model(model: str | None) -> Tuple[float, float]:
-    """Return (input_usd_per_mtok, output_usd_per_mtok) for a model name."""
-    name = (model or "").strip().lower()
-    if not name:
-        return _DEFAULT_PRICING
-    if any(marker in name for marker in _FREE_MODEL_MARKERS):
-        return (0.0, 0.0)
-    for needle, in_price, out_price in _PRICING_TABLE:
-        if needle in name:
-            return (in_price, out_price)
-    return _DEFAULT_PRICING
 
 
 def estimate_cost_usd(model: str | None, input_tokens: int, output_tokens: int) -> float:

--- a/dashboard/backend/tests/infrastructure/llm/test_pricing.py
+++ b/dashboard/backend/tests/infrastructure/llm/test_pricing.py
@@ -1,0 +1,58 @@
+"""Guards for the pricing leaf module (CodeQL #1263 / #1264 ``py/cyclic-import``).
+
+``execution/models.py`` used to import ``token_cost.price_for_model`` inside
+``PricingSnapshot.from_model`` while ``token_cost`` imported the pydantic
+usage/billing models from ``execution/models`` at module scope — a cycle that
+only held together because one side was function-local. The price table now
+lives in ``pricing.py``, a leaf that both sides import.
+"""
+
+import ast
+from pathlib import Path
+
+from dashboard.backend.infrastructure.llm import pricing, token_cost
+from dashboard.backend.infrastructure.llm.execution.models import PricingSnapshot
+
+_LLM = Path(__file__).resolve().parents[3] / "infrastructure" / "llm"
+
+
+def _imported_modules(path: Path) -> set[str]:
+    # ``ast.walk`` reaches function-local imports too — the cycle hid in one.
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                modules.add(alias.name)
+    return modules
+
+
+def test_pricing_is_a_leaf_module():
+    mods = _imported_modules(_LLM / "pricing.py")
+    assert not any(m.startswith("dashboard") for m in mods), mods
+
+
+def test_execution_models_never_import_token_cost():
+    mods = _imported_modules(_LLM / "execution" / "models.py")
+    assert "dashboard.backend.infrastructure.llm.token_cost" not in mods
+
+
+def test_token_cost_reexports_the_pricing_api():
+    # ``discord_bot`` imports ``is_free_model`` from ``token_cost`` (pinned by
+    # test_discord_wiring); the split must keep one object behind both names.
+    assert token_cost.price_for_model is pricing.price_for_model
+    assert token_cost.is_free_model is pricing.is_free_model
+    assert token_cost.PRICING_SOURCE_VERSION == pricing.PRICING_SOURCE_VERSION
+
+
+def test_snapshot_default_source_version_follows_the_table():
+    # ``from_model`` used to carry its own copy of the version string, so a bump
+    # to the table left every snapshot claiming the old version.
+    snapshot = PricingSnapshot.from_model("gpt-4o", "openai")
+    assert snapshot.source_version == pricing.PRICING_SOURCE_VERSION
+    assert (
+        snapshot.input_usd_per_million_tokens,
+        snapshot.output_usd_per_million_tokens,
+    ) == (2.50, 10.0)

--- a/dashboard/backend/tests/llm/test_backtest_harness.py
+++ b/dashboard/backend/tests/llm/test_backtest_harness.py
@@ -36,9 +36,11 @@ class _FakeBlock:
 
 
 class _FakeResponse:
-    def __init__(self, text, usage=None):
-        self.content = [_FakeBlock(text)]
+    def __init__(self, text, usage=None, stop_reason=None):
+        # ``text=None`` models a reply with no text block (thinking only).
+        self.content = [] if text is None else [_FakeBlock(text)]
         self.usage = usage
+        self.stop_reason = stop_reason
 
 
 class _FakeMessages:
@@ -55,6 +57,25 @@ class _FakeClient:
     def __init__(self, response):
         self.captured = {}
         self.messages = _FakeMessages(response, self.captured)
+
+
+class _QueuedMessages:
+    def __init__(self, responses, calls):
+        self._responses = list(responses)
+        self._calls = calls
+
+    def create(self, **kwargs):
+        self._calls.append(kwargs)
+        assert self._responses, "LLM called more times than responses were queued"
+        return self._responses.pop(0)
+
+
+class _SequenceClient:
+    """One queued response per call, in order; ``calls`` holds each request."""
+
+    def __init__(self, *responses):
+        self.calls = []
+        self.messages = _QueuedMessages(responses, self.calls)
 
 
 # ---------------------------------------------------------------------------
@@ -418,6 +439,142 @@ def test_portfolio_final_no_text_retry_preserves_reasoning_and_increases_budget(
     assert captured[-1]["max_tokens"] == (
         portfolio_manager_module.RECOVERY_MAX_OUTPUT_TOKENS
     )
+
+
+# ---------------------------------------------------------------------------
+# Truncation recovery on the non-pipeline path (the leaderboard llm_agent
+# route). A reply cut at the output ceiling gets ONE retry with reasoning
+# preserved and max_tokens=RECOVERY_MAX_OUTPUT_TOKENS — the same single budget
+# the pipeline path spends — so one over-long reasoning burst does not silently
+# cost an H6 decision while billing in full.
+# ---------------------------------------------------------------------------
+
+# A decision envelope cut mid-string: parseable by nobody, but clearly the
+# start of a decision (>= 64 chars, names "actions", every delimiter open).
+_TRUNCATED_DECISION = (
+    '{"actions": [{"symbol": "AAPL", "action": "buy", "confidence": 0.9, '
+    '"reasoning": "RSI oversold with MACD turning up; entering a starter'
+)
+_COMPLETE_DECISION = json.dumps({"actions": [
+    {"symbol": "AAPL", "action": "buy", "confidence": 0.9,
+     "reasoning": "strong", "position_size": 10},
+]})
+
+
+def test_reply_stopped_at_output_ceiling_is_retried_with_recovery_budget():
+    client = _SequenceClient(
+        _FakeResponse(_TRUNCATED_DECISION, usage=_FakeUsage(10, 300),
+                      stop_reason="max_tokens"),
+        _FakeResponse(_COMPLETE_DECISION, usage=_FakeUsage(11, 40)),
+    )
+    pm = bha.PortfolioManager(100000)
+    out = pm.make_trading_decision_with_llm(_portfolio_state(), client)
+
+    assert [call["max_tokens"] for call in client.calls] == [
+        harness.DEFAULT_MAX_OUTPUT_TOKENS,
+        portfolio_manager_module.RECOVERY_MAX_OUTPUT_TOKENS,
+    ]
+    assert [(a["symbol"], a["action"], a["shares"]) for a in out["actions"]] == [
+        ("AAPL", "buy", 10),
+    ]
+    assert pm.llm_calls == 2
+    assert (pm.input_tokens, pm.output_tokens) == (21, 340)
+    assert pm.llm_decisions == 1
+
+
+def test_structurally_truncated_reply_is_retried_without_a_provider_signal():
+    # No stop_reason and usage well under the ceiling: only the structural scan
+    # can see this one, so the fixture pins it independently of the exact
+    # signal (a ceiling-count fixture would pass with the scan deleted).
+    client = _SequenceClient(
+        _FakeResponse(_TRUNCATED_DECISION, usage=_FakeUsage(10, 300)),
+        _FakeResponse(_COMPLETE_DECISION, usage=_FakeUsage(11, 40)),
+    )
+    pm = bha.PortfolioManager(100000)
+    pm.make_trading_decision_with_llm(_portfolio_state(), client)
+
+    assert len(client.calls) == 2
+    assert client.calls[1]["max_tokens"] == (
+        portfolio_manager_module.RECOVERY_MAX_OUTPUT_TOKENS
+    )
+    assert pm.llm_decisions == 1
+
+
+def test_truncated_reply_gets_exactly_one_recovery_attempt():
+    # Recovery is the same request with a bigger budget; a second truncated
+    # reply has nothing different left to ask for, so the step ends as it
+    # would have without the retry: billed twice, no decision.
+    client = _SequenceClient(
+        _FakeResponse(_TRUNCATED_DECISION, usage=_FakeUsage(10, 300),
+                      stop_reason="max_tokens"),
+        _FakeResponse(_TRUNCATED_DECISION, usage=_FakeUsage(10, 300),
+                      stop_reason="max_tokens"),
+        # Must never be requested: a third call would turn this into a decision.
+        _FakeResponse(_COMPLETE_DECISION, usage=_FakeUsage(1, 1)),
+    )
+    pm = bha.PortfolioManager(100000)
+    out = pm.make_trading_decision_with_llm(_portfolio_state(), client)
+
+    assert out == {"actions": []}
+    assert len(client.calls) == 2
+    assert pm.llm_calls == 2
+    assert pm.llm_decisions == 0
+
+
+def test_recovery_reply_with_no_text_block_keeps_the_first_outcome():
+    # A reasoning model can spend the whole recovery budget on thinking. That
+    # is an unusable reply, not a fault: the step ends as the first attempt
+    # left it (empty actions) instead of raising into the rule-based fallback,
+    # which for this state would be a 20-share buy the model never made.
+    client = _SequenceClient(
+        _FakeResponse(_TRUNCATED_DECISION, usage=_FakeUsage(10, 300),
+                      stop_reason="max_tokens"),
+        _FakeResponse(None, usage=_FakeUsage(10, 4000)),
+    )
+    pm = bha.PortfolioManager(100000)
+    out = pm.make_trading_decision_with_llm(_portfolio_state(), client)
+
+    assert out == {"actions": []}
+    assert pm.llm_calls == 2
+    assert pm.llm_decisions == 0
+
+
+def test_truncation_after_the_final_rescue_call_is_not_retried_again():
+    # The rescue call that ends a run of no-text replies already spends the
+    # recovery budget; a truncated rescue reply must not buy a sixth call.
+    no_text = [_FakeResponse(None, usage=_FakeUsage(10, 50)) for _ in range(4)]
+    client = _SequenceClient(
+        *no_text,
+        _FakeResponse(_TRUNCATED_DECISION, usage=_FakeUsage(10, 4096),
+                      stop_reason="max_tokens"),
+        # Must never be requested.
+        _FakeResponse(_COMPLETE_DECISION, usage=_FakeUsage(1, 1)),
+    )
+    pm = bha.PortfolioManager(100000)
+    out = pm.make_trading_decision_with_llm(_portfolio_state(), client)
+
+    assert out == {"actions": []}
+    assert len(client.calls) == 5
+    assert client.calls[-1]["max_tokens"] == (
+        portfolio_manager_module.RECOVERY_MAX_OUTPUT_TOKENS
+    )
+    assert pm.llm_calls == 5
+
+
+def test_strict_llm_recovers_a_truncated_reply_before_spending_a_strike():
+    client = _SequenceClient(
+        _FakeResponse(_TRUNCATED_DECISION, usage=_FakeUsage(10, 300),
+                      stop_reason="max_tokens"),
+        _FakeResponse(_COMPLETE_DECISION, usage=_FakeUsage(11, 40)),
+    )
+    pm = bha.PortfolioManager(100000)
+    out = pm.make_trading_decision_with_llm(
+        _portfolio_state(), client, strict_llm=True
+    )
+
+    assert [a["symbol"] for a in out["actions"]] == ["AAPL"]
+    assert pm.strict_llm_fallbacks == 0
+    assert pm.llm_decisions == 1
 
 
 def test_no_json_response_returns_empty_actions():

--- a/docs/architecture/dashboard-target-structure.md
+++ b/docs/architecture/dashboard-target-structure.md
@@ -55,7 +55,7 @@ dashboard/
 │   └── infrastructure/
 │       ├── ai_hedge_fund/      # adapter, bridge: subprocess-isolated hosted-runtime bridge
 │       ├── brokers/            # alpaca_paper
-│       ├── llm/                # validator, prompts, token_cost, decision_parsing, backtest_harness
+│       ├── llm/                # validator, prompts, pricing, token_cost, decision_parsing, backtest_harness
 │       └── market_data/        # quotes, alpaca_bars
 ├── scripts/                    # thin entrypoints; _bootstrap.ensure_repo_root() is the ONLY sys.path mutation
 └── integrations/ (backend)     # discord_bot (import-safe, lazy token/client)
@@ -186,6 +186,7 @@ dashboard/
 │   │   └── llm/
 │   │       ├── validator.py           # (was llm_validator.py validation core)
 │   │       ├── prompts.py             # (was algo_prompt.py + prompt builders)
+│   │       ├── pricing.py             # price table leaf shared by token_cost + execution/models
 │   │       ├── token_cost.py
 │   │       ├── backtest_harness.py    # make_trading_decision_with_llm + Anthropic wiring
 │   │       └── decision_parsing.py    # fix_json_formatting + parsing

--- a/docs/superpowers/specs/2026-08-29-openrouter-empty-response-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-29-openrouter-empty-response-recovery-design.md
@@ -1,9 +1,9 @@
 # OpenRouter Empty Response Recovery Design
 
 **Date:** 2026-08-29
-**Status:** Shipped (PR #420), amended by PRs #421, #422 and the #421 review
-follow-ups — see *Amendments* below; the sections after it describe the
-original design.
+**Status:** Shipped (PR #420), amended by PRs #421, #422, the #421 review
+follow-ups (#423, #425) and the non-pipeline recovery follow-up — see
+*Amendments* below; the sections after it describe the original design.
 **Scope:** Recover platform-credits backtests when OpenRouter returns no text
 
 ## Amendments (what actually shipped)
@@ -35,6 +35,15 @@ original design.
   a normal return. Other error categories still propagate. The
   `response_invalid`-first path keeps its original contract: a second
   `response_invalid` re-raises.
+- **The non-pipeline path recovers too.** The single-call route in
+  `PortfolioManager.make_trading_decision_with_llm` — the one the leaderboard
+  `llm_agent` drives, which never runs a pipeline — originally had no
+  truncation recovery at all: a reply cut at the ceiling parsed to `None`
+  and the step ended as a billed call with no H6 decision. It now applies the
+  same two signals through the shared `pipeline_runner.truncation_reason`
+  and spends the same single budget; that budget is also what the final
+  rescue call for a run of no-text replies uses, so a truncated rescue reply
+  does not buy a sixth call.
 
 ## Incident
 


### PR DESCRIPTION
Second amending PR for the #421 review; closes the two follow-ups deferred in #423 / #425.

**Non-pipeline truncation recovery** — `PortfolioManager.make_trading_decision_with_llm` (the leaderboard `llm_agent` route, no pipeline) had no truncation recovery: a reply cut at the output ceiling parsed to `None` → billed call, no H6 decision. It now reuses the pipeline's `truncation_reason` (provider `stop_reason` / tokens at ceiling, then the structural scan) and the same single `RECOVERY_MAX_OUTPUT_TOKENS` budget, shared with the no-text rescue call. Six tests pin: retry on each signal, exactly one attempt, no-text recovery keeps the first outcome, no sixth call after the rescue, strict mode retries before spending a strike. Mutation-checked (dropping the budget guard / the structural branch each fails exactly one test).

**CodeQL #1263 / #1264 `py/cyclic-import`** — `token_cost` ↔ `execution/models`. Price table + `is_free_model` / `price_for_model` / `PRICING_SOURCE_VERSION` move to a stdlib-only leaf `infrastructure/llm/pricing.py`; `token_cost` re-exports by explicit assignment (bare re-exports are a `py/unused-import` FP here, PR #213), so `discord_bot`'s import is unchanged. `from_model` drops its private copy of the version string. `test_pricing.py` guards the leaf and that `execution/models` never imports `token_cost` (AST walk, so a function-local import cannot hide again).

Also: `pipeline_runner._truncation_reason` / `_response_text_or_none` made public (now shared), spec Amendments + architecture doc updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDCS8B3PDn5BCrqHB8XJWg
