### PR TITLE
fix(billing): recover restricted Credit accounts safely

### DIFF
--- a/dashboard/backend/api/routers/admin_credits.py
+++ b/dashboard/backend/api/routers/admin_credits.py
@@ -84,7 +84,10 @@ def _raise_grant_http_error(exc: Exception) -> None:
     if isinstance(exc, CreditAccountRestrictedStoreError):
         raise HTTPException(
             status_code=422,
-            detail="The target account cannot receive Grant Credits.",
+            detail=(
+                "The target account is paused for payment refund review; "
+                "an administrator must reinstate it before assigning Credits."
+            ),
         ) from exc
     if isinstance(exc, ValueError):
         raise HTTPException(status_code=422, detail="Invalid Grant Credits request.") from exc
@@ -188,15 +191,39 @@ def list_grant_users(
     user_ids = [int(user["id"]) for user in identities]
     projections = credits_service.get_balance_projections(user_ids)
     users = []
+    state_reader = getattr(credits_service.store, "get_account_billing_state", None)
     for identity in identities:
         user_id = int(identity["id"])
+        balance = projections[user_id].model_dump()
+        account = (
+            state_reader(user_id)
+            if callable(state_reader)
+            else credits_service.get_balance(user_id)
+        )
+        balance.update(
+            account_status=(
+                account.get("account_status", "active")
+                if isinstance(account, dict)
+                else account.account_status
+            ),
+            restriction_reason=(
+                account.get("restriction_reason")
+                if isinstance(account, dict)
+                else account.restriction_reason
+            ),
+            outstanding_credits_micro=(
+                int(account.get("outstanding_credits_micro", 0) or 0)
+                if isinstance(account, dict)
+                else account.outstanding_credits_micro
+            ),
+        )
         users.append(
             {
                 "id": user_id,
                 "email": identity["email"],
                 "display_name": identity["display_name"],
                 "role": identity["role"],
-                "balance": projections[user_id].model_dump(),
+                "balance": balance,
             }
         )
     return {

--- a/dashboard/backend/domain/credits/models.py
+++ b/dashboard/backend/domain/credits/models.py
@@ -16,6 +16,7 @@ from pydantic import (
 
 
 CreditPackageId = Literal["usd_0_50", "usd_1", "usd_2", "usd_5"]
+RestrictionReason = Literal["llm_overage", "refund_reconciliation"]
 
 FIXED_PACKAGES_USD_CENTS: dict[str, int] = {
     "usd_0_50": 50,
@@ -213,6 +214,8 @@ class BalanceResult(BaseModel):
     spending_enabled: Literal[False] = False
     account_status: str
     billing_available: bool
+    restriction_reason: RestrictionReason | None = None
+    outstanding_credits_micro: StrictInt = Field(default=0, ge=0)
 
     @model_validator(mode="before")
     @classmethod
@@ -291,6 +294,15 @@ class GrantPoolSummary(BaseModel):
         return self
 
 
+class CreditRecoveryResult(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    recovered_micro: StrictInt = Field(ge=0)
+    outstanding_micro: StrictInt = Field(ge=0)
+    account_status: str
+    restriction_reason: RestrictionReason | None = None
+
+
 class GrantMutationResult(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
@@ -306,6 +318,7 @@ class GrantMutationResult(BaseModel):
     user_balance: BalanceProjection | None = None
     pool_ledger_entry_id: StrictInt | None = None
     user_ledger_entry_id: StrictInt | None = None
+    recovery: CreditRecoveryResult | None = None
 
 
 class CheckoutResult(BaseModel):
@@ -338,6 +351,8 @@ class WebhookResult(BaseModel):
     reason: str | None = None
     balance_micro: int | None = None
     account_restricted: bool = False
+    recovered_micro: int = 0
+    outstanding_micro: int = 0
 
 
 class LLMReservation(BaseModel):
@@ -351,6 +366,7 @@ class LLMReservation(BaseModel):
     settled_micro: StrictInt
     actual_micro: StrictInt = Field(default=0, ge=0)
     outstanding_micro: StrictInt = Field(default=0, ge=0)
+    outstanding_recovered_micro: StrictInt = Field(default=0, ge=0)
     status: Literal["open", "settled", "released"]
     created_at: str
     updated_at: str
@@ -367,6 +383,7 @@ class LLMSettlementResult(BaseModel):
     settled_micro: StrictInt
     actual_micro: StrictInt = Field(default=0, ge=0)
     outstanding_micro: StrictInt = Field(default=0, ge=0)
+    outstanding_recovered_micro: StrictInt = Field(default=0, ge=0)
     released_micro: StrictInt
     status: Literal["open", "settled", "released"]
     grant_debited_micro: StrictInt = 0

--- a/dashboard/backend/domain/credits/repository.py
+++ b/dashboard/backend/domain/credits/repository.py
@@ -124,6 +124,8 @@ CREATE TABLE IF NOT EXISTS credit_llm_reservations (
     settled_micro INTEGER NOT NULL DEFAULT 0 CHECK (settled_micro >= 0),
     actual_micro INTEGER NOT NULL DEFAULT 0 CHECK (actual_micro >= 0),
     outstanding_micro INTEGER NOT NULL DEFAULT 0 CHECK (outstanding_micro >= 0),
+    outstanding_recovered_micro INTEGER NOT NULL DEFAULT 0
+        CHECK (outstanding_recovered_micro >= 0),
     status TEXT NOT NULL DEFAULT 'open'
         CHECK (status IN ('open', 'settled', 'released')),
     operation_key TEXT NOT NULL UNIQUE CHECK (length(trim(operation_key)) > 0),
@@ -283,6 +285,10 @@ class CreditsStore:
                     user_id INTEGER PRIMARY KEY,
                     status TEXT NOT NULL DEFAULT 'active'
                         CHECK (status IN ('active', 'restricted')),
+                    restriction_reason TEXT
+                        CHECK (restriction_reason IN (
+                            'llm_overage', 'refund_reconciliation'
+                        ) OR restriction_reason IS NULL),
                     created_at TEXT NOT NULL,
                     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
                 );
@@ -470,6 +476,17 @@ class CreditsStore:
                 "ADD COLUMN outstanding_micro INTEGER NOT NULL DEFAULT 0 "
                 "CHECK (outstanding_micro >= 0)"
             )
+        if "outstanding_recovered_micro" not in reservation_columns:
+            conn.execute(
+                "ALTER TABLE credit_llm_reservations "
+                "ADD COLUMN outstanding_recovered_micro INTEGER NOT NULL DEFAULT 0 "
+                "CHECK (outstanding_recovered_micro >= 0)"
+            )
+        account_columns = cls._table_columns(conn, "credit_accounts")
+        if "restriction_reason" not in account_columns:
+            conn.execute(
+                "ALTER TABLE credit_accounts ADD COLUMN restriction_reason TEXT"
+            )
         conn.execute(
             """
             UPDATE credit_llm_reservations
@@ -641,6 +658,37 @@ class CreditsStore:
                 "SELECT * FROM credit_accounts WHERE user_id = ?", (user_id,)
             ).fetchone()
             return dict(row)
+
+    def get_account_billing_state(self, user_id: int) -> dict[str, Any]:
+        _positive_integer(user_id, "user_id")
+        with self._get_connection() as conn:
+            self._begin(conn)
+            self._ensure_account_in_transaction(conn, user_id)
+            account = conn.execute(
+                "SELECT status, restriction_reason FROM credit_accounts WHERE user_id = ?",
+                (user_id,),
+            ).fetchone()
+            outstanding = conn.execute(
+                """
+                SELECT COALESCE(SUM(
+                    MAX(outstanding_micro - outstanding_recovered_micro, 0)
+                ), 0) AS outstanding_micro
+                FROM credit_llm_reservations
+                WHERE user_id = ? AND status = 'settled'
+                """,
+                (user_id,),
+            ).fetchone()
+            reason = account["restriction_reason"]
+            if account["status"] == "restricted" and reason not in {
+                "llm_overage",
+                "refund_reconciliation",
+            }:
+                reason = "refund_reconciliation"
+            return {
+                "account_status": account["status"],
+                "restriction_reason": reason,
+                "outstanding_credits_micro": int(outstanding["outstanding_micro"]),
+            }
 
     @staticmethod
     def _balance_projection_in_transaction(
@@ -926,7 +974,7 @@ class CreditsStore:
             """
             SELECT id, bucket, amount_micro
             FROM credit_llm_usage_entries
-            WHERE reservation_id = ?
+            WHERE reservation_id = ? AND operation_key NOT LIKE '%:recovery:%'
             ORDER BY id
             """,
             (reservation["reservation_id"],),
@@ -945,6 +993,9 @@ class CreditsStore:
         row.update(
             released_micro=(
                 int(row["reserved_micro"]) - int(row["settled_micro"])
+            ),
+            outstanding_recovered_micro=int(
+                row["outstanding_recovered_micro"] or 0
             ),
             grant_debited_micro=grant_debited,
             purchased_debited_micro=purchased_debited,
@@ -1149,7 +1200,11 @@ class CreditsStore:
             )
             if outstanding_micro > 0:
                 conn.execute(
-                    "UPDATE credit_accounts SET status = 'restricted' WHERE user_id = ?",
+                    """
+                    UPDATE credit_accounts
+                    SET status = 'restricted', restriction_reason = 'llm_overage'
+                    WHERE user_id = ? AND status <> 'restricted'
+                    """,
                     (reservation["user_id"],),
                 )
             settled = conn.execute(
@@ -1157,6 +1212,213 @@ class CreditsStore:
                 (reservation_id,),
             ).fetchone()
             return self._llm_reservation_result_in_transaction(conn, settled)
+
+    def recover_llm_overage(
+        self, user_id: int, *, source_operation_key: str
+    ) -> dict[str, Any]:
+        """Apply newly available Credits to an LLM overage atomically."""
+        _positive_integer(user_id, "user_id")
+        source_operation_key = _required_text(
+            source_operation_key, "source_operation_key", max_length=200
+        )
+        with self._get_connection() as conn:
+            self._begin(conn)
+            return self._recover_llm_overage_in_transaction(
+                conn, user_id, source_operation_key=source_operation_key
+            )
+
+    @staticmethod
+    def _recovery_result_for_source_operation_in_transaction(
+        conn: sqlite3.Connection,
+        user_id: int,
+        *,
+        source_operation_key: str,
+    ) -> dict[str, Any] | None:
+        rows = conn.execute(
+            "SELECT amount_micro, evidence_json FROM credit_llm_usage_entries "
+            "WHERE user_id = ?",
+            (user_id,),
+        ).fetchall()
+        recovered = 0
+        for row in rows:
+            try:
+                evidence = json.loads(row["evidence_json"])
+            except (TypeError, ValueError):
+                continue
+            if not isinstance(evidence, dict):
+                continue
+            if evidence.get("recovery_source") == source_operation_key:
+                recovered += max(-int(row["amount_micro"]), 0)
+        if recovered <= 0:
+            return None
+
+        account = conn.execute(
+            "SELECT status, restriction_reason FROM credit_accounts WHERE user_id = ?",
+            (user_id,),
+        ).fetchone()
+        remaining = conn.execute(
+            """
+            SELECT COALESCE(SUM(
+                MAX(outstanding_micro - outstanding_recovered_micro, 0)
+            ), 0) AS outstanding_micro
+            FROM credit_llm_reservations
+            WHERE user_id = ? AND status = 'settled'
+            """,
+            (user_id,),
+        ).fetchone()
+        reason = account["restriction_reason"]
+        if account["status"] == "restricted" and reason not in {
+            "llm_overage",
+            "refund_reconciliation",
+        }:
+            reason = "refund_reconciliation"
+        return {
+            "recovered_micro": recovered,
+            "outstanding_micro": int(remaining["outstanding_micro"]),
+            "account_status": account["status"],
+            "restriction_reason": reason,
+        }
+
+    @staticmethod
+    def _recover_llm_overage_in_transaction(
+        conn: sqlite3.Connection,
+        user_id: int,
+        *,
+        source_operation_key: str,
+    ) -> dict[str, Any]:
+        CreditsStore._ensure_account_in_transaction(conn, user_id)
+        previous = CreditsStore._recovery_result_for_source_operation_in_transaction(
+            conn, user_id, source_operation_key=source_operation_key
+        )
+        if previous is not None:
+            return previous
+        account = conn.execute(
+            "SELECT status, restriction_reason FROM credit_accounts WHERE user_id = ?",
+            (user_id,),
+        ).fetchone()
+        reason = account["restriction_reason"]
+        if account["status"] != "restricted" or reason != "llm_overage":
+            return {
+                "recovered_micro": 0,
+                "outstanding_micro": 0,
+                "account_status": account["status"],
+                "restriction_reason": reason,
+            }
+
+        projection = CreditsStore._balance_projection_in_transaction(conn, user_id)
+        grant_available = max(int(projection["grant_available_micro"]), 0)
+        purchased_available = max(int(projection["purchased_available_micro"]), 0)
+        remaining_funds = grant_available + purchased_available
+        recovered_total = 0
+        reservations = conn.execute(
+            """
+            SELECT * FROM credit_llm_reservations
+            WHERE user_id = ? AND status = 'settled'
+              AND outstanding_micro > outstanding_recovered_micro
+            ORDER BY created_at, reservation_id
+            """,
+            (user_id,),
+        ).fetchall()
+        for reservation in reservations:
+            debt = max(
+                int(reservation["outstanding_micro"])
+                - int(reservation["outstanding_recovered_micro"]),
+                0,
+            )
+            amount = min(debt, remaining_funds)
+            if amount <= 0:
+                break
+            grant_debit = min(amount, grant_available)
+            purchased_debit = amount - grant_debit
+            evidence_json = json.dumps(
+                {
+                    "recovery_source": source_operation_key,
+                    "reservation_id": reservation["reservation_id"],
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=True,
+            )
+            for bucket, debit in (
+                ("grant", grant_debit),
+                ("purchased", purchased_debit),
+            ):
+                if debit <= 0:
+                    continue
+                operation_key = (
+                    f"{reservation['operation_key']}:recovery:"
+                    f"{source_operation_key}:{bucket}"
+                )
+                existing = conn.execute(
+                    "SELECT amount_micro FROM credit_llm_usage_entries WHERE operation_key = ?",
+                    (operation_key,),
+                ).fetchone()
+                if existing is None:
+                    conn.execute(
+                        """
+                        INSERT INTO credit_llm_usage_entries (
+                            user_id, reservation_id, run_id, call_index,
+                            bucket, amount_micro, operation_key,
+                            evidence_json, created_at
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        (
+                            user_id,
+                            reservation["reservation_id"],
+                            reservation["run_id"],
+                            reservation["call_index"],
+                            bucket,
+                            -debit,
+                            operation_key,
+                            evidence_json,
+                            _utcnow_iso(),
+                        ),
+                    )
+            conn.execute(
+                """
+                UPDATE credit_llm_reservations
+                SET outstanding_recovered_micro =
+                    outstanding_recovered_micro + ?, updated_at = ?
+                WHERE reservation_id = ?
+                """,
+                (amount, _utcnow_iso(), reservation["reservation_id"]),
+            )
+            grant_available -= grant_debit
+            purchased_available -= purchased_debit
+            remaining_funds -= amount
+            recovered_total += amount
+
+        remaining = conn.execute(
+            """
+            SELECT COALESCE(SUM(
+                MAX(outstanding_micro - outstanding_recovered_micro, 0)
+            ), 0) AS outstanding_micro
+            FROM credit_llm_reservations
+            WHERE user_id = ? AND status = 'settled'
+            """,
+            (user_id,),
+        ).fetchone()
+        outstanding = int(remaining["outstanding_micro"])
+        if outstanding == 0:
+            conn.execute(
+                """
+                UPDATE credit_accounts
+                SET status = 'active', restriction_reason = NULL
+                WHERE user_id = ? AND status = 'restricted'
+                  AND restriction_reason = 'llm_overage'
+                """,
+                (user_id,),
+            )
+            account_status = "active"
+            reason = None
+        else:
+            account_status = "restricted"
+        return {
+            "recovered_micro": recovered_total,
+            "outstanding_micro": outstanding,
+            "account_status": account_status,
+            "restriction_reason": reason,
+        }
 
     def release_llm_credits(
         self,
@@ -1652,9 +1914,13 @@ class CreditsStore:
                 """,
                 (payment_intent_id, checkout_session_id, now, now, order_id),
             )
+            recovery = self._recover_llm_overage_in_transaction(
+                conn, order["user_id"], source_operation_key=operation_key
+            )
             return {
                 "outcome": "processed",
                 "balance_micro": self._balance_in_transaction(conn, order["user_id"]),
+                **recovery,
             }
 
     @staticmethod
@@ -1714,14 +1980,25 @@ class CreditsStore:
             ).fetchone()
             return _dict(row)
 
-    def restrict_account(self, user_id: int) -> dict[str, Any]:
+    def restrict_account(
+        self,
+        user_id: int,
+        *,
+        reason: str = "refund_reconciliation",
+    ) -> dict[str, Any]:
         _positive_integer(user_id, "user_id")
+        if reason not in {"llm_overage", "refund_reconciliation"}:
+            raise ValueError("invalid account restriction reason")
         with self._get_connection() as conn:
             self._begin(conn)
             self._ensure_account_in_transaction(conn, user_id)
             conn.execute(
-                "UPDATE credit_accounts SET status = 'restricted' WHERE user_id = ?",
-                (user_id,),
+                """
+                UPDATE credit_accounts
+                SET status = 'restricted', restriction_reason = ?
+                WHERE user_id = ?
+                """,
+                (reason, user_id),
             )
             row = conn.execute(
                 "SELECT * FROM credit_accounts WHERE user_id = ?", (user_id,)
@@ -1743,7 +2020,7 @@ class CreditsStore:
             self._begin(conn)
             self._ensure_account_in_transaction(conn, user_id)
             conn.execute(
-                "UPDATE credit_accounts SET status = 'active' WHERE user_id = ?",
+                "UPDATE credit_accounts SET status = 'active', restriction_reason = NULL WHERE user_id = ?",
                 (user_id,),
             )
             row = conn.execute(
@@ -1824,7 +2101,7 @@ class CreditsStore:
                            COUNT(DISTINCT call_index) AS model_call_count,
                            NULL AS evidence_json
                     FROM credit_llm_usage_entries
-                    WHERE user_id = ?
+                    WHERE user_id = ? AND operation_key NOT LIKE '%:recovery:%'
                     GROUP BY user_id, run_id
                 ),
                 promotion_activity AS (
@@ -1879,6 +2156,7 @@ class CreditsStore:
                     SELECT DISTINCT run_id, evidence_json
                     FROM credit_llm_usage_entries
                     WHERE user_id = ? AND run_id IN ({placeholders})
+                      AND operation_key NOT LIKE '%:recovery:%'
                     """,
                     [user_id, *run_ids],
                 ).fetchall()
@@ -2668,7 +2946,14 @@ class CreditsStore:
                     raise IdempotencyConflictError(
                         "Grant idempotency key conflicts with an existing operation"
                     )
-                return self._grant_mutation_result_in_transaction(conn, existing)
+                result = self._grant_mutation_result_in_transaction(conn, existing)
+                if operation_type == "assign":
+                    recovery = self._recovery_result_for_source_operation_in_transaction(
+                        conn, int(user_id), source_operation_key=operation_id
+                    )
+                    if recovery is not None:
+                        result["recovery"] = recovery
+                return result
 
             pool_balance = self._pool_balance_in_transaction(conn, pool_id)
             if operation_type in {"reduce", "assign"} and pool_balance < amount_micro:
@@ -2681,12 +2966,15 @@ class CreditsStore:
             if operation_type == "assign":
                 self._ensure_account_in_transaction(conn, int(user_id))
                 account = conn.execute(
-                    "SELECT status FROM credit_accounts WHERE user_id = ?",
+                    "SELECT status, restriction_reason FROM credit_accounts WHERE user_id = ?",
                     (user_id,),
                 ).fetchone()
-                if account["status"] == "restricted":
+                if (
+                    account["status"] == "restricted"
+                    and account["restriction_reason"] != "llm_overage"
+                ):
                     raise CreditAccountRestrictedStoreError(
-                        "restricted credit account cannot receive Grant Credits"
+                        "refund-review credit account requires administrator review"
                     )
                 user_entry_id = self._insert_user_grant_entry_in_transaction(
                     conn,
@@ -2746,7 +3034,16 @@ class CreditsStore:
                 "SELECT * FROM credit_grant_pool_ledger_entries WHERE id = ?",
                 (pool_entry_id,),
             ).fetchone()
-            return self._grant_mutation_result_in_transaction(conn, pool_entry)
+            if operation_type == "assign":
+                recovery = self._recover_llm_overage_in_transaction(
+                    conn, int(user_id), source_operation_key=operation_id
+                )
+            else:
+                recovery = {}
+            result = self._grant_mutation_result_in_transaction(conn, pool_entry)
+            if recovery.get("recovered_micro", 0) > 0:
+                result["recovery"] = recovery
+            return result
 
     def fund_grant_pool(self, **kwargs: Any) -> dict[str, Any]:
         return self._grant_mutation(operation_type="fund", **kwargs)

--- a/dashboard/backend/domain/credits/repository_postgres.py
+++ b/dashboard/backend/domain/credits/repository_postgres.py
@@ -36,6 +36,9 @@ CREATE TABLE IF NOT EXISTS credit_accounts (
     user_id INTEGER PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
     status TEXT NOT NULL DEFAULT 'active'
         CHECK (status IN ('active', 'restricted')),
+    restriction_reason TEXT
+        CHECK (restriction_reason IN ('llm_overage', 'refund_reconciliation')
+               OR restriction_reason IS NULL),
     created_at TEXT NOT NULL
 );
 
@@ -255,6 +258,8 @@ CREATE TABLE IF NOT EXISTS credit_llm_reservations (
     settled_micro BIGINT NOT NULL DEFAULT 0 CHECK (settled_micro >= 0),
     actual_micro BIGINT NOT NULL DEFAULT 0 CHECK (actual_micro >= 0),
     outstanding_micro BIGINT NOT NULL DEFAULT 0 CHECK (outstanding_micro >= 0),
+    outstanding_recovered_micro BIGINT NOT NULL DEFAULT 0
+        CHECK (outstanding_recovered_micro >= 0),
     status TEXT NOT NULL DEFAULT 'open'
         CHECK (status IN ('open', 'settled', 'released')),
     operation_key TEXT NOT NULL UNIQUE CHECK (length(trim(operation_key)) > 0),
@@ -317,6 +322,10 @@ ALTER TABLE credit_llm_reservations
 ADD COLUMN IF NOT EXISTS actual_micro BIGINT NOT NULL DEFAULT 0;
 ALTER TABLE credit_llm_reservations
 ADD COLUMN IF NOT EXISTS outstanding_micro BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE credit_llm_reservations
+ADD COLUMN IF NOT EXISTS outstanding_recovered_micro BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE credit_accounts
+ADD COLUMN IF NOT EXISTS restriction_reason TEXT;
 UPDATE credit_llm_reservations
 SET actual_micro = settled_micro
 WHERE status = 'settled' AND actual_micro = 0;
@@ -527,6 +536,41 @@ class PostgresCreditsStore:
                     "SELECT * FROM credit_accounts WHERE user_id = %s", (user_id,)
                 )
                 return dict(cur.fetchone())
+
+    def get_account_billing_state(self, user_id: int) -> dict[str, Any]:
+        _positive_integer(user_id, "user_id")
+        with self._get_connection() as conn:
+            with conn.cursor() as cur:
+                self._ensure_account_in_transaction(cur, user_id)
+                cur.execute(
+                    "SELECT status, restriction_reason FROM credit_accounts WHERE user_id = %s",
+                    (user_id,),
+                )
+                account = cur.fetchone()
+                cur.execute(
+                    """
+                    SELECT COALESCE(SUM(
+                        GREATEST(outstanding_micro - outstanding_recovered_micro, 0)
+                    ), 0) AS outstanding_micro
+                    FROM credit_llm_reservations
+                    WHERE user_id = %s AND status = 'settled'
+                    """,
+                    (user_id,),
+                )
+                outstanding = cur.fetchone()
+                reason = account["restriction_reason"]
+                if account["status"] == "restricted" and reason not in {
+                    "llm_overage",
+                    "refund_reconciliation",
+                }:
+                    reason = "refund_reconciliation"
+                return {
+                    "account_status": account["status"],
+                    "restriction_reason": reason,
+                    "outstanding_credits_micro": int(
+                        outstanding["outstanding_micro"]
+                    ),
+                }
 
     def get_balance_projection(self, user_id: int) -> dict[str, int]:
         _positive_integer(user_id, "user_id")
@@ -739,7 +783,8 @@ class PostgresCreditsStore:
             """
             SELECT id, bucket, amount_micro
             FROM credit_llm_usage_entries
-            WHERE reservation_id = %s ORDER BY id
+            WHERE reservation_id = %s AND operation_key NOT LIKE '%%:recovery:%%'
+            ORDER BY id
             """,
             (reservation["reservation_id"],),
         )
@@ -747,6 +792,9 @@ class PostgresCreditsStore:
         row = dict(reservation)
         row.update(
             released_micro=int(row["reserved_micro"]) - int(row["settled_micro"]),
+            outstanding_recovered_micro=int(
+                row.get("outstanding_recovered_micro") or 0
+            ),
             grant_debited_micro=sum(-int(e["amount_micro"]) for e in entries if e["bucket"] == "grant"),
             purchased_debited_micro=sum(-int(e["amount_micro"]) for e in entries if e["bucket"] == "purchased"),
             ledger_entry_ids=tuple(int(e["id"]) for e in entries),
@@ -785,10 +833,15 @@ class PostgresCreditsStore:
                             or existing["operation_key"] != operation_key or existing["request_digest"] != request_digest):
                         raise LLMReservationConflictError("reservation key already represents different input")
                     return dict(existing)
-                cur.execute("SELECT status FROM credit_accounts WHERE user_id = %s FOR UPDATE", (user_id,))
+                cur.execute("SELECT status, restriction_reason FROM credit_accounts WHERE user_id = %s FOR UPDATE", (user_id,))
                 account = cur.fetchone()
                 if account["status"] == "restricted":
-                    raise CreditAccountRestrictedStoreError("restricted credit account cannot reserve model usage")
+                    detail = (
+                        "refund-review credit account requires administrator review"
+                        if account.get("restriction_reason") != "llm_overage"
+                        else "credit account has an unpaid model-usage overage"
+                    )
+                    raise CreditAccountRestrictedStoreError(detail)
                 projection = self._balance_projection_in_transaction(cur, user_id)
                 if projection["total_available_micro"] < reserved_micro:
                     raise InsufficientCreditsError("insufficient available Credits")
@@ -853,10 +906,220 @@ class PostgresCreditsStore:
                 settled = cur.fetchone()
                 if outstanding_micro > 0:
                     cur.execute(
-                        "UPDATE credit_accounts SET status = 'restricted' WHERE user_id = %s",
+                        """
+                        UPDATE credit_accounts
+                        SET status = 'restricted', restriction_reason = 'llm_overage'
+                        WHERE user_id = %s AND status <> 'restricted'
+                        """,
                         (reservation["user_id"],),
                     )
                 return self._llm_reservation_result(cur, settled)
+
+    def recover_llm_overage(
+        self, user_id: int, *, source_operation_key: str
+    ) -> dict[str, Any]:
+        _positive_integer(user_id, "user_id")
+        source_operation_key = _required_text(
+            source_operation_key, "source_operation_key", max_length=200
+        )
+        with self._get_connection() as conn:
+            with conn.cursor() as cur:
+                return self._recover_llm_overage_in_transaction(
+                    cur, user_id, source_operation_key=source_operation_key
+                )
+
+    @staticmethod
+    def _recovery_result_for_source_operation_in_transaction(
+        cur, user_id: int, *, source_operation_key: str
+    ) -> dict[str, Any] | None:
+        cur.execute(
+            "SELECT amount_micro, evidence_json FROM credit_llm_usage_entries "
+            "WHERE user_id = %s",
+            (user_id,),
+        )
+        recovered = 0
+        for row in cur.fetchall():
+            try:
+                evidence = json.loads(row["evidence_json"])
+            except (TypeError, ValueError):
+                continue
+            if not isinstance(evidence, dict):
+                continue
+            if evidence.get("recovery_source") == source_operation_key:
+                recovered += max(-int(row["amount_micro"]), 0)
+        if recovered <= 0:
+            return None
+
+        cur.execute(
+            "SELECT status, restriction_reason FROM credit_accounts WHERE user_id = %s",
+            (user_id,),
+        )
+        account = cur.fetchone()
+        cur.execute(
+            """
+            SELECT COALESCE(SUM(
+                GREATEST(outstanding_micro - outstanding_recovered_micro, 0)
+            ), 0) AS outstanding_micro
+            FROM credit_llm_reservations
+            WHERE user_id = %s AND status = 'settled'
+            """,
+            (user_id,),
+        )
+        remaining = cur.fetchone()
+        reason = account["restriction_reason"]
+        if account["status"] == "restricted" and reason not in {
+            "llm_overage",
+            "refund_reconciliation",
+        }:
+            reason = "refund_reconciliation"
+        return {
+            "recovered_micro": recovered,
+            "outstanding_micro": int(remaining["outstanding_micro"]),
+            "account_status": account["status"],
+            "restriction_reason": reason,
+        }
+
+    @staticmethod
+    def _recover_llm_overage_in_transaction(
+        cur, user_id: int, *, source_operation_key: str
+    ) -> dict[str, Any]:
+        PostgresCreditsStore._ensure_account_in_transaction(cur, user_id)
+        cur.execute(
+            "SELECT status, restriction_reason FROM credit_accounts WHERE user_id = %s FOR UPDATE",
+            (user_id,),
+        )
+        account = cur.fetchone()
+        previous = PostgresCreditsStore._recovery_result_for_source_operation_in_transaction(
+            cur, user_id, source_operation_key=source_operation_key
+        )
+        if previous is not None:
+            return previous
+        reason = account["restriction_reason"]
+        if account["status"] != "restricted" or reason != "llm_overage":
+            return {
+                "recovered_micro": 0,
+                "outstanding_micro": 0,
+                "account_status": account["status"],
+                "restriction_reason": reason,
+            }
+        projection = PostgresCreditsStore._balance_projection_in_transaction(
+            cur, user_id
+        )
+        grant_available = max(int(projection["grant_available_micro"]), 0)
+        purchased_available = max(int(projection["purchased_available_micro"]), 0)
+        remaining_funds = grant_available + purchased_available
+        recovered_total = 0
+        cur.execute(
+            """
+            SELECT * FROM credit_llm_reservations
+            WHERE user_id = %s AND status = 'settled'
+              AND outstanding_micro > outstanding_recovered_micro
+            ORDER BY created_at, reservation_id
+            FOR UPDATE
+            """,
+            (user_id,),
+        )
+        reservations = cur.fetchall()
+        for reservation in reservations:
+            debt = max(
+                int(reservation["outstanding_micro"])
+                - int(reservation["outstanding_recovered_micro"]),
+                0,
+            )
+            amount = min(debt, remaining_funds)
+            if amount <= 0:
+                break
+            grant_debit = min(amount, grant_available)
+            purchased_debit = amount - grant_debit
+            evidence_json = json.dumps(
+                {
+                    "recovery_source": source_operation_key,
+                    "reservation_id": reservation["reservation_id"],
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=True,
+            )
+            for bucket, debit in (
+                ("grant", grant_debit),
+                ("purchased", purchased_debit),
+            ):
+                if debit <= 0:
+                    continue
+                operation_key = (
+                    f"{reservation['operation_key']}:recovery:"
+                    f"{source_operation_key}:{bucket}"
+                )
+                cur.execute(
+                    "SELECT amount_micro FROM credit_llm_usage_entries WHERE operation_key = %s",
+                    (operation_key,),
+                )
+                if cur.fetchone() is None:
+                    cur.execute(
+                        """
+                        INSERT INTO credit_llm_usage_entries (
+                            user_id, reservation_id, run_id, call_index,
+                            bucket, amount_micro, operation_key,
+                            evidence_json, created_at
+                        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        """,
+                        (
+                            user_id,
+                            reservation["reservation_id"],
+                            reservation["run_id"],
+                            reservation["call_index"],
+                            bucket,
+                            -debit,
+                            operation_key,
+                            evidence_json,
+                            _utcnow_iso(),
+                        ),
+                    )
+            cur.execute(
+                """
+                UPDATE credit_llm_reservations
+                SET outstanding_recovered_micro =
+                    outstanding_recovered_micro + %s, updated_at = %s
+                WHERE reservation_id = %s
+                """,
+                (amount, _utcnow_iso(), reservation["reservation_id"]),
+            )
+            grant_available -= grant_debit
+            purchased_available -= purchased_debit
+            remaining_funds -= amount
+            recovered_total += amount
+
+        cur.execute(
+            """
+            SELECT COALESCE(SUM(
+                GREATEST(outstanding_micro - outstanding_recovered_micro, 0)
+            ), 0) AS outstanding_micro
+            FROM credit_llm_reservations
+            WHERE user_id = %s AND status = 'settled'
+            """,
+            (user_id,),
+        )
+        outstanding = int(cur.fetchone()["outstanding_micro"])
+        if outstanding == 0:
+            cur.execute(
+                """
+                UPDATE credit_accounts
+                SET status = 'active', restriction_reason = NULL
+                WHERE user_id = %s AND status = 'restricted'
+                  AND restriction_reason = 'llm_overage'
+                """,
+                (user_id,),
+            )
+            account_status = "active"
+            reason = None
+        else:
+            account_status = "restricted"
+        return {
+            "recovered_micro": recovered_total,
+            "outstanding_micro": outstanding,
+            "account_status": account_status,
+            "restriction_reason": reason,
+        }
 
     def release_llm_credits(self, reservation_id: str, *, reason: str) -> dict[str, Any]:
         reservation_id = _required_text(reservation_id, "reservation_id", max_length=160)
@@ -1357,11 +1620,15 @@ class PostgresCreditsStore:
                     """,
                     (payment_intent_id, checkout_session_id, now, now, order_id),
                 )
+                recovery = self._recover_llm_overage_in_transaction(
+                    cur, order["user_id"], source_operation_key=operation_key
+                )
                 return {
                     "outcome": "processed",
                     "balance_micro": self._balance_in_transaction(
                         cur, order["user_id"]
                     ),
+                    **recovery,
                 }
 
     @staticmethod
@@ -1411,8 +1678,8 @@ class PostgresCreditsStore:
                         AS grant_usage_micro,
                     COALESCE(SUM(CASE WHEN bucket = 'purchased' THEN amount_micro ELSE 0 END), 0)
                         AS purchased_usage_micro
-                FROM credit_llm_usage_entries
-                WHERE user_id = %s
+                    FROM credit_llm_usage_entries
+                    WHERE user_id = %s
                 """,
                 (user_id,),
             )
@@ -1508,18 +1775,26 @@ class PostgresCreditsStore:
                 row = cur.fetchone()
                 return dict(row) if row else None
 
-    def restrict_account(self, user_id: int) -> dict[str, Any]:
+    def restrict_account(
+        self,
+        user_id: int,
+        *,
+        reason: str = "refund_reconciliation",
+    ) -> dict[str, Any]:
         _positive_integer(user_id, "user_id")
+        if reason not in {"llm_overage", "refund_reconciliation"}:
+            raise ValueError("invalid account restriction reason")
         with self._get_connection() as conn:
             with conn.cursor() as cur:
                 self._ensure_account_in_transaction(cur, user_id)
                 cur.execute(
                     """
-                    UPDATE credit_accounts SET status = 'restricted'
+                    UPDATE credit_accounts
+                    SET status = 'restricted', restriction_reason = %s
                     WHERE user_id = %s
                     RETURNING *
                     """,
-                    (user_id,),
+                    (reason, user_id),
                 )
                 return dict(cur.fetchone())
 
@@ -1531,7 +1806,7 @@ class PostgresCreditsStore:
                 self._ensure_account_in_transaction(cur, user_id)
                 cur.execute(
                     """
-                    UPDATE credit_accounts SET status = 'active'
+                    UPDATE credit_accounts SET status = 'active', restriction_reason = NULL
                     WHERE user_id = %s
                     RETURNING *
                     """,
@@ -1619,6 +1894,7 @@ class PostgresCreditsStore:
                                NULL::TEXT AS evidence_json
                         FROM credit_llm_usage_entries
                         WHERE user_id = %s
+                          AND operation_key NOT LIKE '%%:recovery:%%'
                         GROUP BY user_id, run_id
                     ),
                     promotion_activity AS (
@@ -1675,6 +1951,7 @@ class PostgresCreditsStore:
                         SELECT DISTINCT run_id, evidence_json
                         FROM credit_llm_usage_entries
                         WHERE user_id = %s AND run_id = ANY(%s)
+                          AND operation_key NOT LIKE '%%:recovery:%%'
                         """,
                         (user_id, run_ids),
                     )
@@ -2518,7 +2795,7 @@ class PostgresCreditsStore:
                     self._ensure_account_in_transaction(cur, int(user_id))
                     cur.execute(
                         """
-                        SELECT status FROM credit_accounts
+                        SELECT status, restriction_reason FROM credit_accounts
                         WHERE user_id = %s FOR UPDATE
                         """,
                         (user_id,),
@@ -2560,7 +2837,14 @@ class PostgresCreditsStore:
                         raise IdempotencyConflictError(
                             "Grant idempotency key conflicts with an existing operation"
                         )
-                    return self._grant_mutation_result_in_transaction(cur, existing)
+                    result = self._grant_mutation_result_in_transaction(cur, existing)
+                    if operation_type == "assign":
+                        recovery = self._recovery_result_for_source_operation_in_transaction(
+                            cur, int(user_id), source_operation_key=operation_id
+                        )
+                        if recovery is not None:
+                            result["recovery"] = recovery
+                    return result
 
                 pool_balance = self._pool_balance_in_transaction(cur, pool_id)
                 if (
@@ -2574,9 +2858,12 @@ class PostgresCreditsStore:
                 user_entry_id = None
                 created_at = _utcnow_iso()
                 if operation_type == "assign":
-                    if account["status"] == "restricted":
+                    if (
+                        account["status"] == "restricted"
+                        and account["restriction_reason"] != "llm_overage"
+                    ):
                         raise CreditAccountRestrictedStoreError(
-                            "restricted credit account cannot receive Grant Credits"
+                            "refund-review credit account requires administrator review"
                         )
                     user_entry_id = self._insert_user_grant_entry_in_transaction(
                         cur,
@@ -2639,7 +2926,16 @@ class PostgresCreditsStore:
                     (pool_entry_id,),
                 )
                 pool_entry = cur.fetchone()
-                return self._grant_mutation_result_in_transaction(cur, pool_entry)
+                if operation_type == "assign":
+                    recovery = self._recover_llm_overage_in_transaction(
+                        cur, int(user_id), source_operation_key=operation_id
+                    )
+                else:
+                    recovery = {}
+                result = self._grant_mutation_result_in_transaction(cur, pool_entry)
+                if recovery.get("recovered_micro", 0) > 0:
+                    result["recovery"] = recovery
+                return result
 
     def fund_grant_pool(self, **kwargs: Any) -> dict[str, Any]:
         return self._grant_mutation(operation_type="fund", **kwargs)

--- a/dashboard/backend/domain/credits/service.py
+++ b/dashboard/backend/domain/credits/service.py
@@ -14,6 +14,7 @@ from dashboard.backend.domain.credits.models import (
     BalanceProjection,
     CheckoutRequest,
     CheckoutResult,
+    CreditRecoveryResult,
     GrantMutationResult,
     GrantPoolSummary,
     LLMReservation,
@@ -59,10 +60,21 @@ class PaymentOrderNotFoundError(CreditsServiceError):
 
 
 class AccountRestrictedError(CreditsServiceError):
-    def __init__(self):
+    def __init__(self, reason: str | None = None, outstanding_micro: int = 0):
+        if reason == "llm_overage":
+            amount = format_credits(max(int(outstanding_micro), 0))
+            message = (
+                "This account has an unpaid model-usage overage of "
+                f"{amount} Credits. Add Credits to restore access."
+            )
+        else:
+            message = (
+                "This account is paused for a payment refund review; "
+                "an administrator must restore access."
+            )
         super().__init__(
             "credit_account_restricted",
-            "This account cannot purchase Credits; contact an administrator",
+            message,
         )
 
 
@@ -122,6 +134,8 @@ class CreditsService:
     def get_balance(self, user_id: int) -> BalanceResult:
         account = self.store.ensure_account(user_id)
         projection = self._projection_model(self.store.get_balance_projection(user_id))
+        state_reader = getattr(self.store, "get_account_billing_state", None)
+        state = state_reader(user_id) if callable(state_reader) else account
         gateway = self.gateway
         if gateway is None:
             config = load_billing_config()
@@ -131,8 +145,12 @@ class CreditsService:
             balance_micro=projection.total_available_micro,
             display_credits=projection.display_total_credits,
             **projection.model_dump(),
-            account_status=account["status"],
+            account_status=state.get("account_status", account["status"]),
             billing_available=(True if config is None else bool(config.ready)),
+            restriction_reason=state.get("restriction_reason"),
+            outstanding_credits_micro=int(
+                state.get("outstanding_credits_micro", 0) or 0
+            ),
         )
 
     def grant_default_signup_credits(self, user_id: int) -> bool:
@@ -203,6 +221,9 @@ class CreditsService:
             settled_micro=int(value["settled_micro"]),
             actual_micro=int(value.get("actual_micro") or 0),
             outstanding_micro=int(value.get("outstanding_micro") or 0),
+            outstanding_recovered_micro=int(
+                value.get("outstanding_recovered_micro") or 0
+            ),
             status=str(value["status"]),
             created_at=str(value["created_at"]),
             updated_at=str(value["updated_at"]),
@@ -219,6 +240,9 @@ class CreditsService:
             settled_micro=int(value["settled_micro"]),
             actual_micro=int(value.get("actual_micro") or 0),
             outstanding_micro=int(value.get("outstanding_micro") or 0),
+            outstanding_recovered_micro=int(
+                value.get("outstanding_recovered_micro") or 0
+            ),
             released_micro=int(value["released_micro"]),
             status=str(value["status"]),
             grant_debited_micro=int(value.get("grant_debited_micro") or 0),
@@ -480,6 +504,11 @@ class CreditsService:
                 if entry.get("user_ledger_entry_id") is not None
                 else None
             ),
+            recovery=(
+                CreditRecoveryResult.model_validate(raw["recovery"])
+                if raw.get("recovery") is not None
+                else None
+            ),
         )
 
     def fund_grant_pool(self, *, admin_id: int, request: Any) -> GrantMutationResult:
@@ -536,6 +565,14 @@ class CreditsService:
 
     def reinstate_account(self, user_id: int) -> BalanceResult:
         """Admin remedy for an automatic restriction; returns the fresh balance."""
+        state_reader = getattr(self.store, "get_account_billing_state", None)
+        if callable(state_reader):
+            state = state_reader(user_id)
+            if state.get("restriction_reason") == "llm_overage":
+                raise CreditsServiceError(
+                    "credit_account_requires_recovery",
+                    "Model-usage overage must be settled with added Credits before reinstatement.",
+                )
         self.store.reinstate_account(user_id)
         return self.get_balance(user_id)
 
@@ -547,7 +584,13 @@ class CreditsService:
         # could still create Checkout Sessions with a plain fetch.
         account = self.store.ensure_account(user_id)
         if account["status"] == "restricted":
-            raise AccountRestrictedError()
+            state_reader = getattr(self.store, "get_account_billing_state", None)
+            state = state_reader(user_id) if callable(state_reader) else account
+            if state.get("restriction_reason") != "llm_overage":
+                raise AccountRestrictedError(
+                    state.get("restriction_reason"),
+                    int(state.get("outstanding_credits_micro", 0) or 0),
+                )
 
         amount = request.amount_usd_cents
         credits_micro = credits_micro_for_cents(amount)
@@ -834,6 +877,8 @@ class CreditsService:
             event_type=event.event_type,
             reason=result.get("reason"),
             balance_micro=result.get("balance_micro"),
+            recovered_micro=int(result.get("recovered_micro", 0) or 0),
+            outstanding_micro=int(result.get("outstanding_micro", 0) or 0),
         )
 
     def _handle_checkout_unpaid(self, event: StripeWebhookEvent) -> WebhookResult:

--- a/dashboard/backend/infrastructure/llm/execution/errors.py
+++ b/dashboard/backend/infrastructure/llm/execution/errors.py
@@ -13,6 +13,7 @@ class ExecutionErrorCategory(StrEnum):
     RESPONSE_INVALID = "response_invalid"
     USAGE_UNAVAILABLE = "usage_unavailable"
     BILLING_FAILED = "billing_failed"
+    ACCOUNT_RESTRICTED = "account_restricted"
     WORKER_FAILED = "worker_failed"
 
 
@@ -24,7 +25,19 @@ _SAFE_MESSAGES = {
     ExecutionErrorCategory.RESPONSE_INVALID: "The model returned an invalid response.",
     ExecutionErrorCategory.USAGE_UNAVAILABLE: "The model did not return billable usage.",
     ExecutionErrorCategory.BILLING_FAILED: "Model usage billing could not be completed.",
+    ExecutionErrorCategory.ACCOUNT_RESTRICTED: (
+        "Your Credits account is paused. Add Credits to settle model usage "
+        "or contact an administrator."
+    ),
     ExecutionErrorCategory.WORKER_FAILED: "The model worker failed before completion.",
+}
+
+_SAFE_RESTRICTED_MESSAGES = {
+    "llm_overage": "Your Credits account is paused because model usage exceeded its reserved amount. Add Credits to settle the outstanding usage.",
+    "refund_reconciliation": (
+        "Your Credits account is paused for payment refund review. "
+        "Contact an administrator to restore access."
+    ),
 }
 
 
@@ -37,13 +50,42 @@ class LLMExecutionError(RuntimeError):
         message: str | None = None,
     ) -> None:
         self.category = ExecutionErrorCategory(category)
-        allowed_message = message if message in _SAFE_MESSAGES.values() else None
+        allowed_message = (
+            message
+            if message in (*_SAFE_MESSAGES.values(), *_SAFE_RESTRICTED_MESSAGES.values())
+            else None
+        )
+        if (
+            category == ExecutionErrorCategory.ACCOUNT_RESTRICTED
+            and isinstance(message, str)
+            and message.startswith(
+                "Your Credits account is paused because model usage exceeded its reserved amount."
+            )
+        ):
+            allowed_message = message
         self.safe_message = allowed_message or _SAFE_MESSAGES[self.category]
         super().__init__(self.safe_message)
 
     @classmethod
     def safe(cls, category: ExecutionErrorCategory | str) -> "LLMExecutionError":
         return cls(category)
+
+    @classmethod
+    def account_restricted(
+        cls, reason: str | None, outstanding_micro: int = 0
+    ) -> "LLMExecutionError":
+        if reason == "llm_overage" and outstanding_micro > 0:
+            whole, fraction = divmod(int(outstanding_micro), 1_000_000)
+            message = (
+                "Your Credits account is paused because model usage exceeded its "
+                f"reserved amount. Add at least {whole}.{fraction:06d} Credits "
+                "to settle the outstanding usage."
+            )
+        else:
+            message = _SAFE_RESTRICTED_MESSAGES.get(
+                reason, _SAFE_MESSAGES[ExecutionErrorCategory.ACCOUNT_RESTRICTED]
+            )
+        return cls(ExecutionErrorCategory.ACCOUNT_RESTRICTED, message)
 
 
 __all__ = ["ExecutionErrorCategory", "LLMExecutionError"]

--- a/dashboard/backend/infrastructure/llm/execution/service.py
+++ b/dashboard/backend/infrastructure/llm/execution/service.py
@@ -7,6 +7,9 @@ from collections.abc import Callable
 
 from dashboard.backend.domain.credits.models import LLMSettlementResult
 from dashboard.backend.domain.credits.service import CreditsService
+from dashboard.backend.domain.credits.repository_common import (
+    CreditAccountRestrictedStoreError,
+)
 from dashboard.backend.domain.analytics import instrumentation as analytics_instrumentation
 from dashboard.backend.domain.model_providers.models import ProviderRecord
 from dashboard.backend.domain.model_providers.service import (
@@ -169,6 +172,7 @@ class LLMExecutionService:
             ExecutionErrorCategory.PROVIDER_UNAVAILABLE: "provider_unavailable",
             ExecutionErrorCategory.PROVIDER_TIMEOUT: "provider_timeout",
             ExecutionErrorCategory.BILLING_FAILED: "credits_unavailable",
+            ExecutionErrorCategory.ACCOUNT_RESTRICTED: "account_restricted",
         }.get(category, "internal_error")
 
     @staticmethod
@@ -239,12 +243,24 @@ class LLMExecutionService:
         try:
             reserved_micro = _reservation_ceiling_micro(request, pricing_snapshot)
             if reserved_micro > 0:
-                reservation = self.credits.reserve_llm_credits(
-                    user_id=request.user_id,
-                    run_id=request.run_id,
-                    call_index=request.call_index,
-                    amount_micro=reserved_micro,
-                )
+                try:
+                    reservation = self.credits.reserve_llm_credits(
+                        user_id=request.user_id,
+                        run_id=request.run_id,
+                        call_index=request.call_index,
+                        amount_micro=reserved_micro,
+                    )
+                except CreditAccountRestrictedStoreError as exc:
+                    try:
+                        balance = self.credits.get_balance(request.user_id)
+                        reason = balance.restriction_reason
+                        outstanding_micro = balance.outstanding_credits_micro
+                    except Exception:  # noqa: BLE001 - keep the safe fallback
+                        reason = None
+                        outstanding_micro = 0
+                    raise LLMExecutionError.account_restricted(
+                        reason, outstanding_micro
+                    ) from exc
                 reservation_id = reservation.reservation_id
                 self._platform_runs.add(request.run_id)
                 if reservation.status != "open":

--- a/dashboard/backend/tests/domain/credits/test_grant_models.py
+++ b/dashboard/backend/tests/domain/credits/test_grant_models.py
@@ -140,6 +140,8 @@ def test_balance_result_exposes_total_aliases_and_separate_credit_buckets():
         "spending_enabled": False,
         "account_status": "active",
         "billing_available": True,
+        "restriction_reason": None,
+        "outstanding_credits_micro": 0,
     }
     assert balance.balance_micro == balance.total_available_micro
     assert balance.display_credits == balance.display_total_credits
@@ -363,6 +365,7 @@ def test_grant_mutation_result_has_typed_evidence_and_is_frozen():
         "user_balance": projection.model_dump(),
         "pool_ledger_entry_id": 101,
         "user_ledger_entry_id": 202,
+        "recovery": None,
     }
     with pytest.raises(ValidationError, match="frozen"):
         result.amount_micro = 1

--- a/dashboard/backend/tests/domain/credits/test_repository.py
+++ b/dashboard/backend/tests/domain/credits/test_repository.py
@@ -181,9 +181,15 @@ def test_llm_overage_debits_the_hold_and_restricts_the_account(tmp_path):
     assert settled["actual_micro"] == 1_250_000
     assert settled["settled_micro"] == 1_000_000
     assert settled["outstanding_micro"] == 250_000
+    assert settled["outstanding_recovered_micro"] == 0
     assert settled["released_micro"] == 0
     assert store.get_balance_micro(1) == 9_000_000
     assert store.ensure_account(1)["status"] == "restricted"
+    assert store.get_account_billing_state(1) == {
+        "account_status": "restricted",
+        "restriction_reason": "llm_overage",
+        "outstanding_credits_micro": 250_000,
+    }
     assert store.settle_llm_credits(
         reservation["reservation_id"],
         actual_micro=1_250_000,
@@ -206,6 +212,77 @@ def test_llm_overage_debits_the_hold_and_restricts_the_account(tmp_path):
             operation_key="llm-reserve-blocked",
             request_digest="b" * 64,
         )
+
+
+def test_grant_recovers_llm_overage_and_reinstates_account(tmp_path):
+    store = _store(tmp_path)
+    _pending_order(store)
+    _pay_order(store)
+    reservation = store.reserve_llm_credits(
+        reservation_id="llm-res-recover",
+        user_id=1,
+        run_id="run-recover",
+        call_index=0,
+        reserved_micro=1_000_000,
+        operation_key="llm-reserve-recover",
+        request_digest="c" * 64,
+    )
+    store.settle_llm_credits(
+        reservation["reservation_id"],
+        actual_micro=1_250_000,
+        evidence={"provider_id": "openrouter", "model_id": "qwen/qwen3"},
+    )
+    store.fund_grant_pool(
+        pool_id="default",
+        amount_micro=250_000,
+        operation_id="fund-recovery",
+        idempotency_key="fund-recovery",
+        request_digest="d" * 64,
+        actor_user_id=2,
+        source="test",
+        reason="Fund recovery.",
+    )
+    assigned = store.assign_grant(
+        pool_id="default",
+        user_id=1,
+        amount_micro=250_000,
+        operation_id="assign-recovery",
+        idempotency_key="assign-recovery",
+        request_digest="e" * 64,
+        actor_user_id=2,
+        source="test",
+        reason="Recover overage.",
+    )
+
+    assert assigned["recovery"] == {
+        "recovered_micro": 250_000,
+        "outstanding_micro": 0,
+        "account_status": "active",
+        "restriction_reason": None,
+    }
+    replayed = store.assign_grant(
+        user_id=1,
+        pool_id="default",
+        amount_micro=250_000,
+        operation_id="assign-recovery",
+        idempotency_key="assign-recovery",
+        request_digest="e" * 64,
+        actor_user_id=2,
+        source="test",
+        reason="Recover overage.",
+    )
+    assert replayed == assigned
+    assert store.get_account_billing_state(1) == {
+        "account_status": "active",
+        "restriction_reason": None,
+        "outstanding_credits_micro": 0,
+    }
+    with store._get_connection() as conn:
+        row = conn.execute(
+            "SELECT outstanding_recovered_micro FROM credit_llm_reservations WHERE reservation_id = ?",
+            (reservation["reservation_id"],),
+        ).fetchone()
+    assert row["outstanding_recovered_micro"] == 250_000
 
 
 @pytest.mark.parametrize(

--- a/dashboard/backend/tests/domain/credits/test_repository_postgres.py
+++ b/dashboard/backend/tests/domain/credits/test_repository_postgres.py
@@ -1057,14 +1057,29 @@ def test_purchase_and_duplicate_webhooks_post_once(pg_credits_store):
     duplicate_event = _pay_order(store)
     second_event = _pay_order(store, event_id="evt_paid_retry")
 
-    assert first == {"outcome": "processed", "balance_micro": 10_000_000}
+    assert first == {
+        "outcome": "processed",
+        "balance_micro": 10_000_000,
+        "recovered_micro": 0,
+        "outstanding_micro": 0,
+        "account_status": "active",
+        "restriction_reason": None,
+    }
     assert duplicate_event == {
         "outcome": "duplicate",
         "balance_micro": 10_000_000,
+        "recovered_micro": 0,
+        "outstanding_micro": 0,
+        "account_status": "active",
+        "restriction_reason": None,
     }
     assert second_event == {
         "outcome": "duplicate",
         "balance_micro": 10_000_000,
+        "recovered_micro": 0,
+        "outstanding_micro": 0,
+        "account_status": "active",
+        "restriction_reason": None,
     }
     assert store.get_balance_micro(1) == 10_000_000
     assert len(store.list_ledger_entries(1)["items"]) == 1

--- a/dashboard/backend/tests/domain/credits/test_repository_postgres.py
+++ b/dashboard/backend/tests/domain/credits/test_repository_postgres.py
@@ -1068,18 +1068,10 @@ def test_purchase_and_duplicate_webhooks_post_once(pg_credits_store):
     assert duplicate_event == {
         "outcome": "duplicate",
         "balance_micro": 10_000_000,
-        "recovered_micro": 0,
-        "outstanding_micro": 0,
-        "account_status": "active",
-        "restriction_reason": None,
     }
     assert second_event == {
         "outcome": "duplicate",
         "balance_micro": 10_000_000,
-        "recovered_micro": 0,
-        "outstanding_micro": 0,
-        "account_status": "active",
-        "restriction_reason": None,
     }
     assert store.get_balance_micro(1) == 10_000_000
     assert len(store.list_ledger_entries(1)["items"]) == 1

--- a/dashboard/backend/tests/domain/credits/test_service.py
+++ b/dashboard/backend/tests/domain/credits/test_service.py
@@ -16,7 +16,10 @@ from dashboard.backend.domain.credits.models import (
     format_credits,
 )
 from dashboard.backend.domain.credits.repository import CreditsStore, OrderConflictError
-from dashboard.backend.domain.credits.service import CreditsService
+from dashboard.backend.domain.credits.service import (
+    AccountRestrictedError,
+    CreditsService,
+)
 from dashboard.backend.domain.credits.stripe_gateway import (
     CheckoutSessionResult,
     InvalidWebhookSignatureError,
@@ -178,6 +181,50 @@ def _refund_event(
     )
 
 
+def test_checkout_pays_model_overage_and_restores_account(tmp_path):
+    service, gateway = _service(tmp_path)
+    first = _checkout(service)
+    _pay(service, gateway, first)
+    reservation = service.reserve_llm_credits(
+        user_id=1,
+        run_id="service-overage",
+        call_index=0,
+        amount_micro=1_000_000,
+    )
+    service.settle_llm_credits(
+        reservation.reservation_id,
+        actual_micro=1_250_000,
+        evidence={"provider_id": "openrouter", "model_id": "qwen/qwen3"},
+    )
+    blocked = service.get_balance(1)
+    assert blocked.account_status == "restricted"
+    assert blocked.restriction_reason == "llm_overage"
+    assert blocked.outstanding_credits_micro == 250_000
+
+    recovery = _checkout(
+        service,
+        cents=50,
+        request_id=UUID("22222222-2222-4222-8222-222222222222"),
+    )
+    gateway.event = _checkout_event(recovery, event_id="evt_recovery_paid")
+    paid = service.handle_webhook(b"recovery", "valid")
+
+    assert paid.outcome == "processed"
+    assert paid.recovered_micro == 250_000
+    restored = service.get_balance(1)
+    assert restored.account_status == "active"
+    assert restored.restriction_reason is None
+    assert restored.outstanding_credits_micro == 0
+
+
+def test_refund_review_account_stays_blocked_from_checkout(tmp_path):
+    service, _gateway = _service(tmp_path)
+    service.store.restrict_account(1, reason="refund_reconciliation")
+
+    with pytest.raises(AccountRestrictedError, match="payment refund review"):
+        _checkout(service)
+
+
 @pytest.mark.parametrize(
     ("package_id", "cents"),
     [("usd_0_50", 50), ("usd_1", 100), ("usd_2", 200), ("usd_5", 500)],
@@ -248,6 +295,8 @@ def test_balance_format_is_exact_and_not_float_based(tmp_path):
         "spending_enabled": False,
         "account_status": "active",
         "billing_available": True,
+        "restriction_reason": None,
+        "outstanding_credits_micro": 0,
     }
     assert format_credits(10_000_001) == "10.000001"
     assert format_credits(-4_000_000) == "-4.000000"

--- a/dashboard/backend/tests/infrastructure/llm/test_platform_credits_env_fallback.py
+++ b/dashboard/backend/tests/infrastructure/llm/test_platform_credits_env_fallback.py
@@ -304,3 +304,41 @@ def test_platform_execution_releases_reservation_when_usage_is_missing(
             ("env-platform-failed-run",),
         ).fetchone()[0]
     assert status == "released"
+
+
+@pytest.mark.parametrize(
+    ("reason", "expected"),
+    [
+        ("llm_overage", "Add at least 0.250000 Credits"),
+        ("refund_reconciliation", "payment refund review"),
+    ],
+)
+def test_restricted_account_execution_error_is_actionable(
+    tmp_path, monkeypatch, reason, expected
+):
+    adapter = FakeExecutionAdapter(LLMUsage(input_tokens=100, output_tokens=100))
+    service, credits_store = _execution_service(tmp_path, monkeypatch, adapter)
+    if reason == "llm_overage":
+        reservation = credits_store.reserve_llm_credits(
+            reservation_id="restricted-error-reservation",
+            user_id=USER_ID,
+            run_id="restricted-error-seed",
+            call_index=0,
+            reserved_micro=1_000_000,
+            operation_key="restricted-error-seed",
+            request_digest="r" * 64,
+        )
+        credits_store.settle_llm_credits(
+            reservation["reservation_id"],
+            actual_micro=1_250_000,
+            evidence={"provider_id": "openrouter", "model_id": MODEL_ID},
+        )
+    else:
+        credits_store.restrict_account(USER_ID, reason=reason)
+
+    with pytest.raises(LLMExecutionError) as exc_info:
+        service.execute(_request(f"restricted-{reason}"))
+
+    assert exc_info.value.category is ExecutionErrorCategory.ACCOUNT_RESTRICTED
+    assert expected in exc_info.value.safe_message
+    assert "CreditAccountRestrictedStoreError" not in exc_info.value.safe_message

--- a/dashboard/backend/tests/test_admin_credits_api.py
+++ b/dashboard/backend/tests/test_admin_credits_api.py
@@ -200,9 +200,34 @@ def test_admin_user_search_composes_identity_with_bucket_projection(
                 "display_grant_credits": "0.000000",
                 "display_purchased_credits": "0.000000",
                 "display_total_credits": "0.000000",
+                "account_status": "active",
+                "restriction_reason": None,
+                "outstanding_credits_micro": 0,
             },
         }
     ]
+
+
+def test_admin_user_list_exposes_restricted_account_recovery_state(
+    live_admin_credits_api,
+):
+    admin = _signup(live_admin_credits_api.client, "status-admin@example.com")
+    target = _signup(live_admin_credits_api.client, "status-target@example.com")
+    live_admin_credits_api.users.apply_admin_patch(admin["id"], role="admin")
+    live_admin_credits_api.credits.restrict_account(
+        target["id"], reason="refund_reconciliation"
+    )
+    _login(live_admin_credits_api.client, "status-admin@example.com")
+
+    response = live_admin_credits_api.client.get(
+        "/api/admin/credits/users", params={"query": "status-target"}
+    )
+
+    assert response.status_code == 200, response.text
+    balance = response.json()["users"][0]["balance"]
+    assert balance["account_status"] == "restricted"
+    assert balance["restriction_reason"] == "refund_reconciliation"
+    assert balance["outstanding_credits_micro"] == 0
 
 
 def test_admin_user_list_defaults_to_25_accounts_per_page(live_admin_credits_api):

--- a/dashboard/backend/tests/test_admin_credits_frontend.py
+++ b/dashboard/backend/tests/test_admin_credits_frontend.py
@@ -76,6 +76,14 @@ def test_admin_grant_client_uses_server_api_and_never_persists_secrets():
     assert "innerHTML" not in ADMIN_JS
 
 
+def test_admin_grant_console_surfaces_restrictions_and_refund_reinstate_only():
+    assert ">Status</th>" in APP_HTML
+    assert "restriction_reason" in ADMIN_JS
+    assert "outstanding_credits_micro" in ADMIN_JS
+    assert "reason !== 'llm_overage'" in ADMIN_JS
+    assert "/api/admin/credits/accounts/${Number(user.id)}/reinstate" in ADMIN_JS
+
+
 def test_admin_grant_client_defaults_to_short_user_pages():
     assert "ADMIN_CREDITS_USERS_PAGE_SIZE = 25" in ADMIN_JS
     assert "usersLimit: ADMIN_CREDITS_USERS_PAGE_SIZE" in ADMIN_JS

--- a/dashboard/backend/tests/test_credits_frontend.py
+++ b/dashboard/backend/tests/test_credits_frontend.py
@@ -111,6 +111,14 @@ def test_balance_copy_describes_platform_and_byok_lanes():
     assert ">Available balance<" not in APP_HTML
 
 
+def test_balance_explains_recoverable_and_review_restrictions():
+    assert "restriction_reason" in CREDITS_JS
+    assert "llm_overage" in CREDITS_JS
+    assert "Add at least" in CREDITS_JS
+    assert "payment refund review" in CREDITS_JS
+    assert "outstanding_credits_micro" in CREDITS_JS
+
+
 def test_activity_renders_one_backtest_usage_summary_with_safe_context():
     source = CREDITS_JS_PATH.read_text(encoding="utf-8")
     assert "entry.entry_type === 'backtest_usage'" in source

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -2312,8 +2312,8 @@
                 </form>
                 <div class="admin-credits-table-wrap">
                     <table class="admin-credits-users-table" aria-label="Grant Credits user allocation">
-                        <thead><tr><th scope="col">Account</th><th scope="col">Role</th><th scope="col">Grant</th><th scope="col">Purchased</th><th scope="col">Total</th><th scope="col">Amount</th><th scope="col"><span class="sr-only">Actions</span></th></tr></thead>
-                        <tbody id="adminCreditsUsersBody"><tr><td colspan="7" class="admin-empty">Search for an account to allocate Grant Credits.</td></tr></tbody>
+                        <thead><tr><th scope="col">Account</th><th scope="col">Role</th><th scope="col">Status</th><th scope="col">Grant</th><th scope="col">Purchased</th><th scope="col">Total</th><th scope="col">Amount</th><th scope="col"><span class="sr-only">Actions</span></th></tr></thead>
+                        <tbody id="adminCreditsUsersBody"><tr><td colspan="8" class="admin-empty">Search for an account to allocate Grant Credits.</td></tr></tbody>
                     </table>
                 </div>
                 <div class="admin-credits-pager" aria-label="Account pages">

--- a/dashboard/frontend/js/admin-credits.js
+++ b/dashboard/frontend/js/admin-credits.js
@@ -192,7 +192,7 @@
     if (!state.users.length) {
       const row = document.createElement('tr');
       const cell = textNode('td', 'admin-empty', 'No matching accounts.');
-      cell.colSpan = 7;
+      cell.colSpan = 8;
       row.appendChild(cell);
       body.appendChild(row);
       return;
@@ -226,6 +226,17 @@
         roleSelect.addEventListener('change', () => mutateUserRole(user, roleSelect));
         roleCell.appendChild(roleSelect);
       }
+      const statusCell = document.createElement('td');
+      const status = balance.account_status || 'active';
+      const reason = balance.restriction_reason;
+      const outstanding = Number(balance.outstanding_credits_micro || 0);
+      statusCell.appendChild(textNode('strong', status === 'active' ? 'admin-status-active' : 'admin-status-restricted', status));
+      if (status !== 'active') {
+        const detail = reason === 'llm_overage'
+          ? `Owes ${formatCreditsMicro(outstanding)} Credits`
+          : 'Refund review';
+        statusCell.appendChild(textNode('span', 'admin-credits-status-detail', detail));
+      }
       const amountCell = document.createElement('td');
       const amount = document.createElement('input');
       amount.type = 'text';
@@ -250,10 +261,18 @@
       reclaim.disabled = Number(balance.grant_available_micro || 0) <= 0;
       reclaim.addEventListener('click', () => mutateUserGrant(user, 'reclaim', amount));
       actions.append(assign, reclaim);
+      if (status !== 'active' && reason !== 'llm_overage') {
+        const reinstate = textNode('button', 'credits-key-action', 'Reinstate');
+        reinstate.type = 'button';
+        reinstate.title = `Reinstate ${userName(user)}`;
+        reinstate.addEventListener('click', () => reinstateUser(user));
+        actions.appendChild(reinstate);
+      }
 
       row.append(
         account,
         roleCell,
+        statusCell,
         textNode('td', 'admin-credits-number', formatCredits(balance.display_grant_credits)),
         textNode('td', 'admin-credits-number', formatCredits(balance.display_purchased_credits)),
         textNode('td', 'admin-credits-number', formatCredits(balance.display_total_credits)),
@@ -262,6 +281,18 @@
       );
       body.appendChild(row);
     });
+  }
+
+  async function reinstateUser(user) {
+    if (!window.confirm(`Reinstate ${userName(user)} after refund review?`)) return;
+    try {
+      setStatus('Restoring account access…', 'pending');
+      await request(`/api/admin/credits/accounts/${Number(user.id)}/reinstate`, { method: 'POST' });
+      setStatus(`${userName(user)} is active again.`, 'success');
+      await refresh();
+    } catch (error) {
+      if (!handleAccessLost(error)) setStatus(error.message || 'Account could not be reinstated.', 'error');
+    }
   }
 
   async function loadUsers({ offset = state.usersOffset } = {}) {

--- a/dashboard/frontend/js/credits.js
+++ b/dashboard/frontend/js/credits.js
@@ -510,14 +510,22 @@
     element('creditsBalance').textContent = `${formatCredits(balance.display_credits)} Credits`;
     const accountStatus = element('creditsAccountStatus');
     const restricted = balance.account_status !== 'active';
-    if (restricted) {
-      setStatus(accountStatus, 'Purchases are paused while this account is under review.', 'error');
+    const reason = balance.restriction_reason;
+    const outstandingMicro = Number(balance.outstanding_credits_micro || 0);
+    if (reason === 'llm_overage') {
+      setStatus(
+        accountStatus,
+        `Model usage exceeded the reserved amount. Add at least ${window.CreditFormat.formatCreditsMicro(outstandingMicro)} Credits to restore access.`,
+        'error',
+      );
+    } else if (restricted) {
+      setStatus(accountStatus, 'Purchases are paused for a payment refund review. Contact an administrator to restore access.', 'error');
     } else if (!balance.billing_available) {
       setStatus(accountStatus, 'Stripe Test Mode is not configured on this server.', 'error');
     } else {
       setStatus(accountStatus, 'Available for metered ATL model runs. BYOK runs use your provider account and do not deduct ATL Credits.', 'success');
     }
-    setPurchaseEnabled(!restricted && balance.billing_available);
+    setPurchaseEnabled((!restricted || reason === 'llm_overage') && balance.billing_available);
   }
 
   function renderLedger(items) {

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -13199,6 +13199,30 @@ body.agent-editor-open {
     white-space: nowrap;
 }
 
+.admin-status-active,
+.admin-status-restricted {
+    display: block;
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: capitalize;
+}
+
+.admin-status-active {
+    color: #86efac;
+}
+
+.admin-status-restricted {
+    color: #fda4af;
+}
+
+.admin-credits-status-detail {
+    display: block;
+    margin-top: 3px;
+    color: var(--text-secondary);
+    font-size: 10px;
+    white-space: nowrap;
+}
+
 .admin-credits-role-select {
     width: 94px;
     min-width: 0;

--- a/docs/superpowers/plans/2026-08-31-credit-restriction-recovery.md
+++ b/docs/superpowers/plans/2026-08-31-credit-restriction-recovery.md
@@ -1,0 +1,226 @@
+# Credit Restriction Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make LLM-overage accounts recover automatically after new Credits arrive, keep refund-review accounts protected, and expose actionable restriction errors and admin controls.
+
+**Architecture:** Extend the existing account and LLM reservation ledgers in both SQLite and PostgreSQL. Store a safe restriction reason and a per-reservation recovered-overage total; process recovery atomically inside purchase webhook and Grant transactions using idempotent usage entries. Add a dedicated execution error category and expose status/recovery data through the existing Credits and Admin Users routes and vanilla frontend modules.
+
+**Tech Stack:** Python 3, FastAPI, Pydantic, SQLite, PostgreSQL/psycopg, vanilla JavaScript, pytest.
+
+**Spec:** `docs/superpowers/specs/2026-08-31-credit-restriction-recovery-design.md`
+
+## Global Constraints
+
+- Keep SQLite and PostgreSQL behavior equivalent.
+- Never return provider credentials, raw Stripe payloads, or stack traces.
+- Preserve existing balance aliases, numeric ledger cursors, idempotency keys, and historical rows.
+- Recovery must be atomic with the source purchase or Grant and safe under retries.
+- Only `llm_overage` accounts may accept new Credits while restricted; `refund_reconciliation` accounts require explicit administrator review.
+- Do not modify provider credentials, Render configuration, or unrelated backtest timeout behavior.
+
+---
+
+### Task 1: Add typed restriction and recovery fields
+
+**Files:**
+- Modify: `dashboard/backend/domain/credits/models.py`
+- Modify: `dashboard/backend/domain/credits/repository_common.py`
+- Test: `dashboard/backend/tests/domain/credits/test_grant_models.py`
+
+**Interfaces:**
+- Produces `RestrictionReason`, `BalanceResult.restriction_reason`, `BalanceResult.outstanding_credits_micro`, and `LLMSettlementResult.outstanding_recovered_micro`.
+
+- [ ] **Step 1: Write failing model tests**
+
+Add assertions that a balance exposes `restriction_reason`, non-negative `outstanding_credits_micro`, and that a settlement accepts `outstanding_recovered_micro` defaulting to zero while rejecting negative values.
+
+- [ ] **Step 2: Implement the fields and safe reason constants**
+
+Add a `Literal["llm_overage", "refund_reconciliation"]` alias, default legacy reasons to `None` on active accounts, and keep Pydantic `extra="forbid"` validation.
+
+- [ ] **Step 3: Run the focused model tests**
+
+Run `pytest dashboard/backend/tests/domain/credits/test_grant_models.py -q` and confirm the new and existing assertions pass.
+
+- [ ] **Step 4: Commit**
+
+Run `git add dashboard/backend/domain/credits/models.py dashboard/backend/domain/credits/repository_common.py dashboard/backend/tests/domain/credits/test_grant_models.py && git commit -m "feat(billing): model restriction recovery state"`.
+
+### Task 2: Migrate stores and expose restriction metadata
+
+**Files:**
+- Modify: `dashboard/backend/domain/credits/repository.py`
+- Modify: `dashboard/backend/domain/credits/repository_postgres.py`
+- Modify: `dashboard/backend/domain/credits/service.py`
+- Test: `dashboard/backend/tests/domain/credits/test_repository.py`
+- Test: `dashboard/backend/tests/domain/credits/test_repository_postgres.py`
+
+**Interfaces:**
+- Produces `get_account_billing_state(user_id)`, account fields `restriction_reason`, and reservation field `outstanding_recovered_micro` for both stores.
+
+- [ ] **Step 1: Add migration and metadata tests**
+
+Create a restricted account in each store, assert the default reason is `refund_reconciliation`, create an overage reservation, and assert the result reports zero recovered amount and the aggregate outstanding amount.
+
+- [ ] **Step 2: Add backward-compatible columns**
+
+Add `credit_accounts.restriction_reason TEXT` and `credit_llm_reservations.outstanding_recovered_micro INTEGER/BIGINT NOT NULL DEFAULT 0`. Inspect existing SQLite columns before issuing `ALTER TABLE`; use `ADD COLUMN IF NOT EXISTS` in PostgreSQL migration SQL. Add constraints for the two reason values and non-negative recovery.
+
+- [ ] **Step 3: Include metadata in balance projections**
+
+Lock/read the account status and reason alongside the existing projection. Sum `max(outstanding_micro - outstanding_recovered_micro, 0)` over settled reservations for the user. Treat a restricted account with a null reason as `refund_reconciliation`.
+
+- [ ] **Step 4: Run both store suites**
+
+Run `pytest dashboard/backend/tests/domain/credits/test_repository.py dashboard/backend/tests/domain/credits/test_repository_postgres.py -k 'account or reservation or migration' -q`. PostgreSQL tests may skip only through the repository's existing environment convention.
+
+- [ ] **Step 5: Commit**
+
+Run `git add dashboard/backend/domain/credits/repository.py dashboard/backend/domain/credits/repository_postgres.py dashboard/backend/domain/credits/service.py dashboard/backend/tests/domain/credits/test_repository.py dashboard/backend/tests/domain/credits/test_repository_postgres.py && git commit -m "feat(billing): persist restriction reasons and recovery state"`.
+
+### Task 3: Implement atomic overage recovery
+
+**Files:**
+- Modify: `dashboard/backend/domain/credits/repository.py`
+- Modify: `dashboard/backend/domain/credits/repository_postgres.py`
+- Modify: `dashboard/backend/domain/credits/service.py`
+- Test: `dashboard/backend/tests/domain/credits/test_repository.py`
+- Test: `dashboard/backend/tests/domain/credits/test_repository_postgres.py`
+
+**Interfaces:**
+- Produces `recover_llm_overage_in_transaction(user_id, source_operation_key)` returning recovered and remaining micro-Credits.
+
+- [ ] **Step 1: Add failing partial/complete recovery tests**
+
+Reserve 1.00 Credit, settle 1.25 Credits to create a 0.25 overage, add a 0.10 purchased or Grant entry, assert the account remains restricted with 0.15 outstanding, then add 0.15 and assert the account becomes active. Assert balance decreases by each recovery and identical source operation retries do not add another usage row.
+
+- [ ] **Step 2: Implement the recovery transaction helper**
+
+Lock the account, select oldest settled reservations with unrecovered overage, calculate available Grant-first and purchased balances, insert negative usage entries with a source-derived idempotency key, increment `outstanding_recovered_micro`, and clear `restriction_reason`/set `active` only when total unrecovered overage reaches zero. Return aggregate recovered and remaining amounts.
+
+- [ ] **Step 3: Set overage reason during settlement**
+
+When `outstanding_micro > 0`, update the account to `restricted` with `restriction_reason='llm_overage'`. Preserve refund-review restrictions and never overwrite them from model settlement.
+
+- [ ] **Step 4: Verify both stores**
+
+Run `pytest dashboard/backend/tests/domain/credits/test_repository.py dashboard/backend/tests/domain/credits/test_repository_postgres.py -k 'overage or recovery or restriction' -q`.
+
+- [ ] **Step 5: Commit**
+
+Run `git add dashboard/backend/domain/credits/repository.py dashboard/backend/domain/credits/repository_postgres.py dashboard/backend/domain/credits/service.py dashboard/backend/tests/domain/credits/test_repository.py dashboard/backend/tests/domain/credits/test_repository_postgres.py && git commit -m "feat(billing): recover model overage from added Credits"`.
+
+### Task 4: Allow safe funding paths and recover atomically
+
+**Files:**
+- Modify: `dashboard/backend/domain/credits/repository.py`
+- Modify: `dashboard/backend/domain/credits/repository_postgres.py`
+- Modify: `dashboard/backend/domain/credits/service.py`
+- Modify: `dashboard/backend/api/routers/credits.py`
+- Modify: `dashboard/backend/api/routers/admin_credits.py`
+- Test: `dashboard/backend/tests/domain/credits/test_service.py`
+- Test: `dashboard/backend/tests/test_credits_api.py`
+
+**Interfaces:**
+- Checkout creation accepts restricted `llm_overage` accounts and rejects `refund_reconciliation` with a safe 403.
+- Paid checkout settlement and Grant assignment call recovery using their stable operation IDs.
+
+- [ ] **Step 1: Add failing service/API tests**
+
+Assert checkout is allowed for an LLM-overage account, remains blocked for refund review, and that paid webhook settlement/Grant assignment automatically reduce outstanding overage and return the new account state.
+
+- [ ] **Step 2: Implement reason-aware gates**
+
+Change `create_checkout` and Grant assignment to inspect `restriction_reason`. Keep the existing refund-review refusal and map it to a message explaining administrator review.
+
+- [ ] **Step 3: Wire recovery after successful funding**
+
+In each store's paid checkout and Grant mutation transaction, call the recovery helper only after the positive ledger entry is written. Pass the order/event or Grant operation key so the recovery writes are replay-safe.
+
+- [ ] **Step 4: Return recovery metadata**
+
+Include `account_status`, `restriction_reason`, `outstanding_credits_micro`, and recovered amount in the relevant service result/API payload without changing existing fields.
+
+- [ ] **Step 5: Run focused API/service tests and commit**
+
+Run `pytest dashboard/backend/tests/domain/credits/test_service.py dashboard/backend/tests/test_credits_api.py -k 'checkout or grant or restricted or recovery' -q`, then commit with `feat(billing): unblock and recover overage funding`.
+
+### Task 5: Add dedicated restricted execution errors
+
+**Files:**
+- Modify: `dashboard/backend/infrastructure/llm/execution/errors.py`
+- Modify: `dashboard/backend/infrastructure/llm/execution/service.py`
+- Modify: `dashboard/backend/api/routers/backtests.py`
+- Test: `dashboard/backend/tests/infrastructure/llm/test_execution_client.py`
+- Test: `dashboard/backend/tests/test_backtests_router.py`
+
+**Interfaces:**
+- Produces `ExecutionErrorCategory.ACCOUNT_RESTRICTED` and a safe message that directs the user to add Credits or contact an administrator.
+
+- [ ] **Step 1: Add failing restricted-error tests**
+
+Make a reservation mock raise `CreditAccountRestrictedStoreError` and assert the execution layer returns `account_restricted`, while provider/credential details remain absent from the public message.
+
+- [ ] **Step 2: Implement category mapping and message**
+
+Catch the restriction store error before the generic billing arm, map it to `ACCOUNT_RESTRICTED`, and use a fixed message distinguishing “add Credits to settle model usage” from “administrator review” based on the balance state available to the service.
+
+- [ ] **Step 3: Verify router serialization**
+
+Assert failed backtest responses contain the safe human-readable message, never Python class names, SQL text, or stack traces.
+
+- [ ] **Step 4: Run focused execution/router tests and commit**
+
+Run `pytest dashboard/backend/tests/infrastructure/llm/test_execution_client.py dashboard/backend/tests/test_backtests_router.py -k 'billing or restricted or error' -q`, then commit with `fix(billing): explain restricted Credit execution failures`.
+
+### Task 6: Update Credits and Admin Users UI
+
+**Files:**
+- Modify: `dashboard/frontend/js/credits.js`
+- Modify: `dashboard/frontend/js/admin-credits.js`
+- Modify: `dashboard/frontend/app.html`
+- Modify: `dashboard/frontend/styles.css`
+- Test: `dashboard/backend/tests/test_credits_frontend.py`
+- Test: `dashboard/backend/tests/test_admin_credits_frontend.py`
+
+**Interfaces:**
+- Credits UI shows reason/outstanding amount and enables purchase controls only for recoverable LLM overage.
+- Admin Users displays status/reason/outstanding amount and exposes Reinstate only for refund-review accounts.
+
+- [ ] **Step 1: Add failing frontend contract assertions**
+
+Assert the scripts contain reason-aware copy, render the outstanding amount, call the existing Reinstate endpoint, and do not render a Reinstate action for `llm_overage` accounts.
+
+- [ ] **Step 2: Extend admin user payload and table**
+
+Return each user's account metadata from `/api/admin/credits/users`, add status/reason/outstanding columns, and implement an accessible button that posts to `/api/credits/admin/credits/accounts/{user_id}/reinstate` with confirmation and refresh.
+
+- [ ] **Step 3: Update Credits state rendering**
+
+Replace the generic “under review” message with reason-specific copy. Keep checkout enabled for `llm_overage` and disabled for refund review or unavailable billing. Display the exact remaining amount using the existing six-decimal formatter.
+
+- [ ] **Step 4: Run frontend contract tests and commit**
+
+Run `pytest dashboard/backend/tests/test_credits_frontend.py dashboard/backend/tests/test_admin_credits_frontend.py -q`, then commit with `feat(ui): surface Credit restriction recovery state`.
+
+### Task 7: Full verification and PR
+
+**Files:**
+- No additional source files; review all task diffs and generated metadata.
+
+- [ ] **Step 1: Run focused regression suite**
+
+Run `pytest dashboard/backend/tests/domain/credits dashboard/backend/tests/test_credits_api.py dashboard/backend/tests/test_backtests_router.py dashboard/backend/tests/infrastructure/llm/test_execution_client.py -q`.
+
+- [ ] **Step 2: Run complete backend tests**
+
+Run `pytest -q`; record the pass/skip counts and investigate any regression before publishing.
+
+- [ ] **Step 3: Audit the diff**
+
+Run `git diff origin/main...HEAD --check`, inspect `git diff origin/main...HEAD`, and confirm no API keys, database URLs, `.superpowers/`, or `work/` files are staged.
+
+- [ ] **Step 4: Push and open the PR**
+
+Push the current branch with `git push -u origin fix/backtest-timeout-consistency` and create a PR targeting `main` titled `fix(billing): recover restricted Credit accounts safely`, including the test commands and the distinction between automatic overage recovery and manual refund review.

--- a/docs/superpowers/specs/2026-08-31-credit-restriction-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-31-credit-restriction-recovery-design.md
@@ -1,0 +1,100 @@
+# Credit Restriction Recovery and Error Transparency
+
+## Goal
+
+Make Platform Credits restrictions recoverable without weakening the refund
+audit guard. A model-usage overage must be payable through a later purchase or
+administrator Grant, while an out-of-band Stripe refund must remain an
+administrator-reviewed condition. Users and administrators must see the
+reason and amount behind a restriction instead of an opaque billing error.
+
+## Current problem
+
+`credit_accounts.status` currently has only `active` and `restricted`. Both an
+LLM settlement overage and a Stripe refund reconciliation failure write the
+same status, while checkout and Grant assignment reject every restricted
+account. This creates a deadlock for an LLM overage: the account needs Credits
+to repay the outstanding amount, but the restriction prevents adding them.
+The existing `reinstate_account` operation is appropriate for refund review,
+but it is not a recovery path for normal model metering.
+
+## Design
+
+### Restriction reasons
+
+Persist a safe reason on the account:
+
+- `llm_overage`: a settled model reservation has an unpaid amount because the
+  provider's billable usage exceeded the reserved ceiling.
+- `refund_reconciliation`: Stripe reported a refund that could not be safely
+  correlated with a local refund request or refundable purchase lot.
+
+Historical restricted rows without a reason are treated as
+`refund_reconciliation` for safety. The public balance and admin-user
+responses include `account_status`, `restriction_reason`, and the aggregate
+unrecovered overage in Credits. No provider secrets, raw Stripe payloads, or
+internal stack traces are exposed.
+
+### Automatic recovery for model overage
+
+When a purchase webhook or administrator Grant successfully adds Credits to a
+restricted account whose reason is `llm_overage`, the same database
+transaction:
+
+1. records the new Credit entry;
+2. applies available Credits to the oldest unrecovered reservation overages;
+3. records idempotent recovery usage entries in the existing LLM usage ledger;
+4. clears the restriction only when all overage is recovered.
+
+The recovery consumes the same Grant-first bucket order used for model
+reservations. If the new amount is insufficient, the account remains
+restricted and reports the remaining amount. Checkout and Grant assignment
+are allowed for `llm_overage` accounts so this state cannot deadlock. A
+`refund_reconciliation` account remains blocked from both operations until an
+administrator explicitly reinstates it.
+
+Recovery is idempotent and atomic with the source purchase/Grant operation.
+Retries cannot double-charge the account or clear a restriction prematurely.
+
+### Error and UI behavior
+
+Add a dedicated safe execution category for restricted Credits. A failed
+Platform Credits run reports a human-readable message that the account is
+paused, identifies whether the cause is an unpaid model-use overage or refund
+review, and includes the remaining amount when available. The frontend keeps
+the detailed provider-safe message and does not display Python exception
+names or stack traces.
+
+The Credits view explains the current state and, for an LLM overage, keeps the
+purchase controls enabled with the amount still required. For a refund review
+it shows that only an administrator can restore purchases. Admin Users shows
+the account status, reason, outstanding amount, and a Reinstate action only
+for refund-review accounts. Reinstate remains an explicit administrator
+override and does not erase or rewrite ledger history.
+
+## Compatibility and storage
+
+Apply backward-compatible migrations to SQLite and PostgreSQL. Add the account
+restriction reason and reservation overage-recovery amount with safe defaults.
+Existing balance calculations continue to subtract every LLM usage entry, so
+recovered overage is reflected in the authoritative balance projection.
+
+The SQLite and PostgreSQL stores expose equivalent behavior. Existing numeric
+ledger cursors, historical reservations, and public balance aliases remain
+valid.
+
+## Testing
+
+Cover both stores and the API/UI contracts for:
+
+- overage restriction and reason reporting;
+- partial and complete recovery from a purchase;
+- partial and complete recovery from an administrator Grant;
+- replay-safe recovery and no double debit;
+- refund-review accounts remaining blocked;
+- administrator Reinstate behavior;
+- safe, human-readable restricted-account execution errors;
+- public responses never containing secrets or raw exception text.
+
+Run the focused Credits, execution, router, and frontend contract suites, then
+the complete backend test suite before opening the PR.


### PR DESCRIPTION
## Summary

- Distinguish model-usage overage restrictions from Stripe refund-reconciliation restrictions.
- Allow Credits checkout and admin grants to recover `llm_overage` accounts atomically, prioritizing the oldest outstanding usage.
- Keep refund-review accounts blocked until an administrator explicitly reinstates them.
- Surface safe, human-readable restriction reasons and outstanding amounts in user and admin views.
- Add compatible SQLite/PostgreSQL migrations and idempotent recovery bookkeeping.

## Verification

- Targeted Credits/API/UI/execution tests: `293 passed, 21 skipped, 3 warnings`.
- `python -m py_compile` passed.
- `node --check dashboard/frontend/js/credits.js` passed.
- `node --check dashboard/frontend/js/admin-credits.js` passed.
- `git diff --cached --check` passed before commit.

The full `pytest -q` collection remains blocked by existing experimental scripts that require `OPENAI_API_KEY` during import; no API key was added to this branch.