### PR TITLE
fix(credits): charge available balance for reservation overage

### DIFF
--- a/dashboard/backend/domain/credits/repository.py
+++ b/dashboard/backend/domain/credits/repository.py
@@ -33,6 +33,37 @@ from dashboard.backend.domain.credits.repository_common import (
 )
 
 
+_SETTLEMENT_OUTCOME_EVIDENCE_KEYS = {
+    "debited_credits_micro",
+    "outstanding_credits_micro",
+}
+
+
+def _evidence_json(evidence: dict[str, Any]) -> str:
+    return json.dumps(
+        evidence,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+
+
+def _evidence_identity_json(evidence_json: str) -> str:
+    try:
+        payload = json.loads(evidence_json)
+    except (TypeError, ValueError):
+        return evidence_json
+    if not isinstance(payload, dict):
+        return evidence_json
+    payload = {
+        key: value
+        for key, value in payload.items()
+        if key not in _SETTLEMENT_OUTCOME_EVIDENCE_KEYS
+    }
+    return _evidence_json(payload)
+
+
 _CREDIT_LEDGER_DDL = """
 CREATE TABLE credit_ledger_entries (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -136,7 +167,6 @@ CREATE TABLE IF NOT EXISTS credit_llm_reservations (
     updated_at TEXT NOT NULL,
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
     CHECK (reserved_micro = reserved_grant_micro + reserved_purchased_micro),
-    CHECK (settled_micro <= reserved_micro),
     UNIQUE (user_id, run_id, call_index)
 )
 """
@@ -494,6 +524,7 @@ class CreditsStore:
             WHERE status = 'settled' AND actual_micro = 0
             """
         )
+        cls._migrate_llm_reservation_constraint_in_transaction(conn)
         conn.execute(_LLM_USAGE_LEDGER_DDL)
         conn.execute(
             """
@@ -513,6 +544,66 @@ class CreditsStore:
             ON credit_llm_usage_entries(user_id, id DESC)
             """
         )
+
+    @classmethod
+    def _migrate_llm_reservation_constraint_in_transaction(
+        cls, conn: sqlite3.Connection
+    ) -> None:
+        """Rebuild legacy SQLite reservations that capped settled debits."""
+
+        # Some maintenance/CLI entry points instantiate the Credits store
+        # before the account database has created its users table. The legacy
+        # table can remain in place safely; the migration will run on the next
+        # normal application initialization once its parent table exists.
+        if not cls._table_columns(conn, "users"):
+            return
+
+        row = conn.execute(
+            "SELECT sql FROM sqlite_master "
+            "WHERE type = 'table' AND name = 'credit_llm_reservations'"
+        ).fetchone()
+        table_sql = "".join(str(row["sql"] or "").lower().split()) if row else ""
+        if "settled_micro<=reserved_micro" not in table_sql:
+            return
+
+        usage_exists = bool(cls._table_columns(conn, "credit_llm_usage_entries"))
+        if usage_exists:
+            conn.execute(
+                "CREATE TABLE credit_llm_usage_entries_migration_backup AS "
+                "SELECT * FROM credit_llm_usage_entries"
+            )
+            conn.execute("DROP TABLE credit_llm_usage_entries")
+
+        conn.execute(
+            "ALTER TABLE credit_llm_reservations "
+            "RENAME TO credit_llm_reservations_migration_legacy"
+        )
+        conn.execute(_LLM_RESERVATION_DDL)
+        columns = (
+            "reservation_id, user_id, run_id, call_index, reserved_micro, "
+            "reserved_grant_micro, reserved_purchased_micro, settled_micro, "
+            "actual_micro, outstanding_micro, outstanding_recovered_micro, status, "
+            "operation_key, request_digest, evidence_json, failure_reason, "
+            "created_at, updated_at"
+        )
+        conn.execute(
+            f"INSERT INTO credit_llm_reservations ({columns}) "
+            f"SELECT {columns} FROM credit_llm_reservations_migration_legacy"
+        )
+        conn.execute("DROP TABLE credit_llm_reservations_migration_legacy")
+
+        if usage_exists:
+            conn.execute(_LLM_USAGE_LEDGER_DDL)
+            usage_columns = (
+                "id, user_id, reservation_id, run_id, call_index, bucket, "
+                "amount_micro, operation_key, evidence_json, created_at"
+            )
+            conn.execute(
+                f"INSERT INTO credit_llm_usage_entries ({usage_columns}) "
+                f"SELECT {usage_columns} "
+                "FROM credit_llm_usage_entries_migration_backup"
+            )
+            conn.execute("DROP TABLE credit_llm_usage_entries_migration_backup")
 
     @classmethod
     def _create_grant_pool_schema_in_transaction(
@@ -991,8 +1082,8 @@ class CreditsStore:
         )
         row = dict(reservation)
         row.update(
-            released_micro=(
-                int(row["reserved_micro"]) - int(row["settled_micro"])
+            released_micro=max(
+                int(row["reserved_micro"]) - int(row["settled_micro"]), 0
             ),
             outstanding_recovered_micro=int(
                 row["outstanding_recovered_micro"] or 0
@@ -1116,13 +1207,7 @@ class CreditsStore:
             or actual_micro < 0
         ):
             raise ValueError("actual_micro must be a non-negative integer")
-        evidence_json = json.dumps(
-            evidence,
-            sort_keys=True,
-            separators=(",", ":"),
-            ensure_ascii=True,
-            allow_nan=False,
-        )
+        evidence_json = _evidence_json(evidence)
         with self._get_connection() as conn:
             self._begin(conn)
             reservation = conn.execute(
@@ -1134,7 +1219,10 @@ class CreditsStore:
             if reservation["status"] == "settled":
                 if (
                     int(reservation["actual_micro"]) != actual_micro
-                    or reservation["evidence_json"] != evidence_json
+                    or _evidence_identity_json(
+                        str(reservation["evidence_json"] or "")
+                    )
+                    != _evidence_identity_json(evidence_json)
                 ):
                     raise LLMReservationConflictError(
                         "settlement replay has different input"
@@ -1147,16 +1235,39 @@ class CreditsStore:
                     "released reservation cannot be settled"
                 )
             reserved_micro = int(reservation["reserved_micro"])
-            debit_micro = min(actual_micro, reserved_micro)
+            excess_micro = max(actual_micro - reserved_micro, 0)
+            supplementary_grant = 0
+            supplementary_purchased = 0
+            if excess_micro > 0:
+                projection = self._balance_projection_in_transaction(
+                    conn, int(reservation["user_id"])
+                )
+                supplementary_grant = min(
+                    excess_micro,
+                    max(int(projection["grant_available_micro"]), 0),
+                )
+                supplementary_purchased = min(
+                    excess_micro - supplementary_grant,
+                    max(int(projection["purchased_available_micro"]), 0),
+                )
+            supplementary_micro = supplementary_grant + supplementary_purchased
+            debit_micro = min(actual_micro, reserved_micro) + supplementary_micro
             outstanding_micro = actual_micro - debit_micro
             grant_debit = min(
-                debit_micro, int(reservation["reserved_grant_micro"])
+                min(actual_micro, reserved_micro),
+                int(reservation["reserved_grant_micro"]),
             )
-            purchased_debit = debit_micro - grant_debit
+            purchased_debit = min(actual_micro, reserved_micro) - grant_debit
             now = _utcnow_iso()
-            for bucket, amount in (
-                ("grant", grant_debit),
-                ("purchased", purchased_debit),
+            evidence_payload = dict(evidence)
+            evidence_payload["debited_credits_micro"] = debit_micro
+            evidence_payload["outstanding_credits_micro"] = outstanding_micro
+            settled_evidence_json = _evidence_json(evidence_payload)
+            for bucket, amount, suffix in (
+                ("grant", grant_debit, "grant"),
+                ("purchased", purchased_debit, "purchased"),
+                ("grant", supplementary_grant, "overage:grant"),
+                ("purchased", supplementary_purchased, "overage:purchased"),
             ):
                 if amount <= 0:
                     continue
@@ -1176,8 +1287,8 @@ class CreditsStore:
                         reservation["call_index"],
                         bucket,
                         -amount,
-                        f"{reservation['operation_key']}:{bucket}",
-                        evidence_json,
+                        f"{reservation['operation_key']}:{suffix}",
+                        settled_evidence_json,
                         now,
                     ),
                 )
@@ -1193,7 +1304,7 @@ class CreditsStore:
                     debit_micro,
                     actual_micro,
                     outstanding_micro,
-                    evidence_json,
+                    settled_evidence_json,
                     now,
                     reservation_id,
                 ),

--- a/dashboard/backend/domain/credits/repository_postgres.py
+++ b/dashboard/backend/domain/credits/repository_postgres.py
@@ -29,6 +29,37 @@ from dashboard.backend.domain.credits.repository_common import (
 )
 
 
+_SETTLEMENT_OUTCOME_EVIDENCE_KEYS = {
+    "debited_credits_micro",
+    "outstanding_credits_micro",
+}
+
+
+def _evidence_json(evidence: dict[str, Any]) -> str:
+    return json.dumps(
+        evidence,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+
+
+def _evidence_identity_json(evidence_json: str) -> str:
+    try:
+        payload = json.loads(evidence_json)
+    except (TypeError, ValueError):
+        return evidence_json
+    if not isinstance(payload, dict):
+        return evidence_json
+    payload = {
+        key: value
+        for key, value in payload.items()
+        if key not in _SETTLEMENT_OUTCOME_EVIDENCE_KEYS
+    }
+    return _evidence_json(payload)
+
+
 # Kept as literal DDL so the SQLite/Postgres parity guard can compare the
 # authoritative table and column contracts without requiring a live database.
 CREDITS_POSTGRES_DDL = """
@@ -269,7 +300,6 @@ CREATE TABLE IF NOT EXISTS credit_llm_reservations (
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL,
     CHECK (reserved_micro = reserved_grant_micro + reserved_purchased_micro),
-    CHECK (settled_micro <= reserved_micro),
     UNIQUE (user_id, run_id, call_index)
 );
 
@@ -329,6 +359,13 @@ ADD COLUMN IF NOT EXISTS restriction_reason TEXT;
 UPDATE credit_llm_reservations
 SET actual_micro = settled_micro
 WHERE status = 'settled' AND actual_micro = 0;
+ALTER TABLE credit_llm_reservations
+DROP CONSTRAINT IF EXISTS credit_llm_reservations_settled_micro_check;
+ALTER TABLE credit_llm_reservations
+DROP CONSTRAINT IF EXISTS credit_llm_reservations_settled_micro_nonnegative_check;
+ALTER TABLE credit_llm_reservations
+ADD CONSTRAINT credit_llm_reservations_settled_micro_nonnegative_check
+CHECK (settled_micro >= 0);
 
 ALTER TABLE credit_grant_pool_ledger_entries
 ADD COLUMN IF NOT EXISTS pool_name_snapshot TEXT;
@@ -791,7 +828,9 @@ class PostgresCreditsStore:
         entries = cur.fetchall()
         row = dict(reservation)
         row.update(
-            released_micro=int(row["reserved_micro"]) - int(row["settled_micro"]),
+            released_micro=max(
+                int(row["reserved_micro"]) - int(row["settled_micro"]), 0
+            ),
             outstanding_recovered_micro=int(
                 row.get("outstanding_recovered_micro") or 0
             ),
@@ -867,26 +906,75 @@ class PostgresCreditsStore:
         reservation_id = _required_text(reservation_id, "reservation_id", max_length=160)
         if not isinstance(actual_micro, int) or isinstance(actual_micro, bool) or actual_micro < 0:
             raise ValueError("actual_micro must be a non-negative integer")
-        evidence_json = json.dumps(evidence, sort_keys=True, separators=(",", ":"), ensure_ascii=True, allow_nan=False)
+        evidence_json = _evidence_json(evidence)
         with self._get_connection() as conn:
             with conn.cursor() as cur:
-                cur.execute("SELECT * FROM credit_llm_reservations WHERE reservation_id = %s FOR UPDATE", (reservation_id,))
+                cur.execute(
+                    "SELECT user_id FROM credit_llm_reservations "
+                    "WHERE reservation_id = %s",
+                    (reservation_id,),
+                )
+                owner = cur.fetchone()
+                if not owner:
+                    raise LLMReservationConflictError("reservation was not found")
+                self._ensure_account_in_transaction(cur, int(owner["user_id"]))
+                cur.execute(
+                    "SELECT status FROM credit_accounts WHERE user_id = %s FOR UPDATE",
+                    (owner["user_id"],),
+                )
+                cur.execute(
+                    "SELECT * FROM credit_llm_reservations "
+                    "WHERE reservation_id = %s FOR UPDATE",
+                    (reservation_id,),
+                )
                 reservation = cur.fetchone()
                 if not reservation:
                     raise LLMReservationConflictError("reservation was not found")
                 if reservation["status"] == "settled":
-                    if int(reservation["actual_micro"]) != actual_micro or reservation["evidence_json"] != evidence_json:
+                    if (
+                        int(reservation["actual_micro"]) != actual_micro
+                        or _evidence_identity_json(
+                            str(reservation["evidence_json"] or "")
+                        )
+                        != _evidence_identity_json(evidence_json)
+                    ):
                         raise LLMReservationConflictError("settlement replay has different input")
                     return self._llm_reservation_result(cur, reservation)
                 if reservation["status"] != "open":
                     raise LLMReservationConflictError("released reservation cannot be settled")
                 reserved_micro = int(reservation["reserved_micro"])
-                debit_micro = min(actual_micro, reserved_micro)
+                excess_micro = max(actual_micro - reserved_micro, 0)
+                supplementary_grant = 0
+                supplementary_purchased = 0
+                if excess_micro > 0:
+                    projection = self._balance_projection_in_transaction(
+                        cur, int(reservation["user_id"])
+                    )
+                    supplementary_grant = min(
+                        excess_micro,
+                        max(int(projection["grant_available_micro"]), 0),
+                    )
+                    supplementary_purchased = min(
+                        excess_micro - supplementary_grant,
+                        max(int(projection["purchased_available_micro"]), 0),
+                    )
+                supplementary_micro = supplementary_grant + supplementary_purchased
+                debit_micro = min(actual_micro, reserved_micro) + supplementary_micro
                 outstanding_micro = actual_micro - debit_micro
-                grant_debit = min(debit_micro, int(reservation["reserved_grant_micro"]))
-                purchased_debit = debit_micro - grant_debit
+                hold_debit = min(actual_micro, reserved_micro)
+                grant_debit = min(hold_debit, int(reservation["reserved_grant_micro"]))
+                purchased_debit = hold_debit - grant_debit
                 now = _utcnow_iso()
-                for bucket, amount in (("grant", grant_debit), ("purchased", purchased_debit)):
+                evidence_payload = dict(evidence)
+                evidence_payload["debited_credits_micro"] = debit_micro
+                evidence_payload["outstanding_credits_micro"] = outstanding_micro
+                settled_evidence_json = _evidence_json(evidence_payload)
+                for bucket, amount, suffix in (
+                    ("grant", grant_debit, "grant"),
+                    ("purchased", purchased_debit, "purchased"),
+                    ("grant", supplementary_grant, "overage:grant"),
+                    ("purchased", supplementary_purchased, "overage:purchased"),
+                ):
                     if amount <= 0:
                         continue
                     cur.execute(
@@ -897,11 +985,11 @@ class PostgresCreditsStore:
                         ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
                         """,
                         (reservation["user_id"], reservation_id, reservation["run_id"], reservation["call_index"], bucket,
-                         -amount, f"{reservation['operation_key']}:{bucket}", evidence_json, now),
+                         -amount, f"{reservation['operation_key']}:{suffix}", settled_evidence_json, now),
                     )
                 cur.execute(
                     "UPDATE credit_llm_reservations SET settled_micro = %s, actual_micro = %s, outstanding_micro = %s, status = 'settled', evidence_json = %s, failure_reason = NULL, updated_at = %s WHERE reservation_id = %s RETURNING *",
-                    (debit_micro, actual_micro, outstanding_micro, evidence_json, now, reservation_id),
+                    (debit_micro, actual_micro, outstanding_micro, settled_evidence_json, now, reservation_id),
                 )
                 settled = cur.fetchone()
                 if outstanding_micro > 0:

--- a/dashboard/backend/infrastructure/llm/execution/service.py
+++ b/dashboard/backend/infrastructure/llm/execution/service.py
@@ -281,16 +281,15 @@ class LLMExecutionService:
 
             if reservation_id is not None:
                 actual_micro = billing.provider_cost_credits_micro
+                settlement = self._settle(
+                    reservation_id, billing, actual_micro=actual_micro
+                )
                 billing = billing.model_copy(
                     update={
-                        "debited_credits_micro": min(actual_micro, reserved_micro),
-                        "outstanding_credits_micro": max(
-                            actual_micro - reserved_micro,
-                            0,
-                        ),
+                        "debited_credits_micro": settlement.settled_micro,
+                        "outstanding_credits_micro": settlement.outstanding_micro,
                     }
                 )
-                self._settle(reservation_id, billing, actual_micro=actual_micro)
             elif billing.provider_cost_credits_micro > 0:
                 # A zero-priced snapshot must not become a paid call after the
                 # fact; there is no held balance from which to settle it.
@@ -412,7 +411,7 @@ class LLMExecutionService:
         billing: BillingEvidence,
         *,
         actual_micro: int,
-    ) -> None:
+    ) -> LLMSettlementResult:
         try:
             settlement = self.credits.settle_llm_credits(
                 reservation_id,
@@ -423,11 +422,10 @@ class LLMExecutionService:
             raise LLMExecutionError(ExecutionErrorCategory.BILLING_FAILED) from exc
         if (
             settlement.status != "settled"
-            or settlement.settled_micro != billing.debited_credits_micro
             or settlement.actual_micro != actual_micro
-            or settlement.outstanding_micro != billing.outstanding_credits_micro
         ):
             raise LLMExecutionError(ExecutionErrorCategory.BILLING_FAILED)
+        return settlement
 
     def _release_after_failure(
         self,

--- a/dashboard/backend/tests/domain/credits/test_repository.py
+++ b/dashboard/backend/tests/domain/credits/test_repository.py
@@ -150,10 +150,115 @@ def test_schema_is_created_and_new_account_balance_is_zero(tmp_path):
     }.issubset(tables)
 
 
+def test_sqlite_migrates_legacy_reservation_settlement_constraint(tmp_path):
+    path = tmp_path / "legacy-credits.db"
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE users (
+                id INTEGER PRIMARY KEY,
+                email TEXT NOT NULL UNIQUE,
+                display_name TEXT NOT NULL,
+                password_hash TEXT NOT NULL,
+                role TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO users VALUES (1, 'legacy@example.com', 'Legacy', 'unused', 'user', '2026-08-01')"
+        )
+        conn.execute(
+            """
+            CREATE TABLE credit_llm_reservations (
+                reservation_id TEXT PRIMARY KEY,
+                user_id INTEGER NOT NULL,
+                run_id TEXT NOT NULL,
+                call_index INTEGER NOT NULL,
+                reserved_micro INTEGER NOT NULL,
+                reserved_grant_micro INTEGER NOT NULL,
+                reserved_purchased_micro INTEGER NOT NULL,
+                settled_micro INTEGER NOT NULL DEFAULT 0,
+                actual_micro INTEGER NOT NULL DEFAULT 0,
+                outstanding_micro INTEGER NOT NULL DEFAULT 0,
+                outstanding_recovered_micro INTEGER NOT NULL DEFAULT 0,
+                status TEXT NOT NULL DEFAULT 'open',
+                operation_key TEXT NOT NULL UNIQUE,
+                request_digest TEXT NOT NULL,
+                evidence_json TEXT,
+                failure_reason TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                CHECK (reserved_micro = reserved_grant_micro + reserved_purchased_micro),
+                CHECK (settled_micro <= reserved_micro),
+                UNIQUE (user_id, run_id, call_index),
+                FOREIGN KEY (user_id) REFERENCES users(id)
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE credit_llm_usage_entries (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                reservation_id TEXT NOT NULL,
+                run_id TEXT NOT NULL,
+                call_index INTEGER NOT NULL,
+                bucket TEXT NOT NULL,
+                amount_micro INTEGER NOT NULL,
+                operation_key TEXT NOT NULL UNIQUE,
+                evidence_json TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                FOREIGN KEY (reservation_id) REFERENCES credit_llm_reservations(reservation_id)
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO credit_llm_reservations (
+                reservation_id, user_id, run_id, call_index, reserved_micro,
+                reserved_grant_micro, reserved_purchased_micro, operation_key,
+                request_digest, created_at, updated_at
+            ) VALUES ('legacy-reservation', 1, 'legacy-run', 0, 1000, 1000, 0,
+                      'legacy-operation', 'a', '2026-08-01', '2026-08-01')
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO credit_llm_usage_entries (
+                user_id, reservation_id, run_id, call_index, bucket,
+                amount_micro, operation_key, evidence_json, created_at
+            ) VALUES (1, 'legacy-reservation', 'legacy-run', 0, 'grant',
+                      -100, 'legacy-usage', '{}', '2026-08-01')
+            """
+        )
+
+    store = CreditsStore(path)
+
+    with store._get_connection() as conn:
+        schema = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE name = 'credit_llm_reservations'"
+        ).fetchone()[0]
+        row = conn.execute(
+            "SELECT reserved_micro, operation_key FROM credit_llm_reservations"
+        ).fetchone()
+        usage = conn.execute(
+            "SELECT operation_key, amount_micro FROM credit_llm_usage_entries"
+        ).fetchone()
+        conn.execute(
+            "UPDATE credit_llm_reservations SET settled_micro = 1200 "
+            "WHERE reservation_id = 'legacy-reservation'"
+        )
+
+    assert "settled_micro <= reserved_micro" not in "".join(schema.lower().split())
+    assert tuple(row) == (1000, "legacy-operation")
+    assert tuple(usage) == ("legacy-usage", -100)
+
+
 def test_llm_overage_debits_the_hold_and_restricts_the_account(tmp_path):
     store = _store(tmp_path)
-    _pending_order(store)
-    _pay_order(store)
+    _pending_order(store, amount_usd_cents=110, credits_micro=1_100_000)
+    _pay_order(store, amount_usd_cents=110)
     reservation = store.reserve_llm_credits(
         reservation_id="llm-res-overage",
         user_id=1,
@@ -179,16 +284,18 @@ def test_llm_overage_debits_the_hold_and_restricts_the_account(tmp_path):
 
     assert settled["status"] == "settled"
     assert settled["actual_micro"] == 1_250_000
-    assert settled["settled_micro"] == 1_000_000
-    assert settled["outstanding_micro"] == 250_000
+    assert settled["settled_micro"] == 1_100_000
+    assert settled["outstanding_micro"] == 150_000
     assert settled["outstanding_recovered_micro"] == 0
     assert settled["released_micro"] == 0
-    assert store.get_balance_micro(1) == 9_000_000
+    assert settled["grant_debited_micro"] == 0
+    assert settled["purchased_debited_micro"] == 1_100_000
+    assert store.get_balance_micro(1) == 0
     assert store.ensure_account(1)["status"] == "restricted"
     assert store.get_account_billing_state(1) == {
         "account_status": "restricted",
         "restriction_reason": "llm_overage",
-        "outstanding_credits_micro": 250_000,
+        "outstanding_credits_micro": 150_000,
     }
     assert store.settle_llm_credits(
         reservation["reservation_id"],
@@ -214,10 +321,108 @@ def test_llm_overage_debits_the_hold_and_restricts_the_account(tmp_path):
         )
 
 
+def test_llm_overage_uses_unreserved_grant_before_restricting(tmp_path):
+    store = _store(tmp_path)
+    store.fund_grant_pool(
+        pool_id="default",
+        amount_micro=2_000_000,
+        operation_id="fund-covered-overage",
+        idempotency_key="fund-covered-overage",
+        request_digest="f" * 64,
+        actor_user_id=2,
+        source="test",
+        reason="Fund covered overage.",
+    )
+    store.assign_grant(
+        user_id=1,
+        pool_id="default",
+        amount_micro=2_000_000,
+        operation_id="assign-covered-overage",
+        idempotency_key="assign-covered-overage",
+        request_digest="g" * 64,
+        actor_user_id=2,
+        source="test",
+        reason="Assign covered overage.",
+    )
+    reservation = store.reserve_llm_credits(
+        reservation_id="llm-res-covered-overage",
+        user_id=1,
+        run_id="run-covered-overage",
+        call_index=0,
+        reserved_micro=1_000_000,
+        operation_key="llm-reserve-covered-overage",
+        request_digest="h" * 64,
+    )
+
+    settled = store.settle_llm_credits(
+        reservation["reservation_id"],
+        actual_micro=1_250_000,
+        evidence={
+            "provider_id": "openrouter",
+            "model_id": "qwen/qwen3",
+            "debited_credits_micro": 1_000_000,
+            "outstanding_credits_micro": 250_000,
+        },
+    )
+
+    assert settled["settled_micro"] == 1_250_000
+    assert settled["outstanding_micro"] == 0
+    assert settled["released_micro"] == 0
+    assert settled["grant_debited_micro"] == 1_250_000
+    assert settled["purchased_debited_micro"] == 0
+    assert store.get_balance_micro(1) == 750_000
+    assert store.get_account_billing_state(1) == {
+        "account_status": "active",
+        "restriction_reason": None,
+        "outstanding_credits_micro": 0,
+    }
+
+
+def test_llm_overage_does_not_spend_another_open_reservation(tmp_path):
+    store = _store(tmp_path)
+    _pending_order(store, amount_usd_cents=200, credits_micro=2_000_000)
+    _pay_order(store, amount_usd_cents=200)
+    current = store.reserve_llm_credits(
+        reservation_id="llm-res-current",
+        user_id=1,
+        run_id="run-current",
+        call_index=0,
+        reserved_micro=1_000_000,
+        operation_key="llm-reserve-current",
+        request_digest="i" * 64,
+    )
+    protected = store.reserve_llm_credits(
+        reservation_id="llm-res-protected",
+        user_id=1,
+        run_id="run-protected",
+        call_index=0,
+        reserved_micro=500_000,
+        operation_key="llm-reserve-protected",
+        request_digest="j" * 64,
+    )
+
+    settled = store.settle_llm_credits(
+        current["reservation_id"],
+        actual_micro=1_750_000,
+        evidence={"provider_id": "openrouter", "model_id": "qwen/qwen3"},
+    )
+
+    assert settled["settled_micro"] == 1_500_000
+    assert settled["outstanding_micro"] == 250_000
+    assert store.get_balance_projection(1)["total_available_micro"] == 0
+    with store._get_connection() as conn:
+        row = conn.execute(
+            "SELECT status, reserved_micro FROM credit_llm_reservations "
+            "WHERE reservation_id = ?",
+            (protected["reservation_id"],),
+        ).fetchone()
+    assert tuple(row) == ("open", 500_000)
+
+
 def test_grant_recovers_llm_overage_and_reinstates_account(tmp_path):
     store = _store(tmp_path)
-    _pending_order(store)
-    _pay_order(store)
+    _pending_order(store, amount_usd_cents=110, credits_micro=1_100_000)
+    _pay_order(store, amount_usd_cents=110)
     reservation = store.reserve_llm_credits(
         reservation_id="llm-res-recover",
         user_id=1,
@@ -255,7 +460,7 @@ def test_grant_recovers_llm_overage_and_reinstates_account(tmp_path):
     )
 
     assert assigned["recovery"] == {
-        "recovered_micro": 250_000,
+        "recovered_micro": 150_000,
         "outstanding_micro": 0,
         "account_status": "active",
         "restriction_reason": None,
@@ -282,7 +487,7 @@ def test_grant_recovers_llm_overage_and_reinstates_account(tmp_path):
             "SELECT outstanding_recovered_micro FROM credit_llm_reservations WHERE reservation_id = ?",
             (reservation["reservation_id"],),
         ).fetchone()
-    assert row["outstanding_recovered_micro"] == 250_000
+        assert row["outstanding_recovered_micro"] == 150_000
 
 
 @pytest.mark.parametrize(

--- a/dashboard/backend/tests/domain/credits/test_repository_postgres.py
+++ b/dashboard/backend/tests/domain/credits/test_repository_postgres.py
@@ -58,6 +58,18 @@ def test_postgres_schema_declares_the_welcome_promotion_ledger():
     assert "UNIQUE (campaign_key, user_id)" in ddl
 
 
+def test_postgres_schema_allows_settlement_overage_and_migrates_legacy_check():
+    assert "settled_micro <= reserved_micro" not in pg_module.CREDITS_POSTGRES_DDL
+    assert (
+        "DROP CONSTRAINT IF EXISTS credit_llm_reservations_settled_micro_check"
+        in pg_module.CREDITS_POSTGRES_GRANT_MIGRATION_DDL
+    )
+    assert (
+        "credit_llm_reservations_settled_micro_nonnegative_check"
+        in pg_module.CREDITS_POSTGRES_GRANT_MIGRATION_DDL
+    )
+
+
 def test_build_credits_store_picks_postgres_from_users_url(monkeypatch, capsys):
     created = {}
 
@@ -404,7 +416,13 @@ def _pending_order(
     )
 
 
-def _pay_order(store, *, order_id: str = "ord_10", event_id: str = "evt_paid"):
+def _pay_order(
+    store,
+    *,
+    order_id: str = "ord_10",
+    event_id: str = "evt_paid",
+    cents: int = 1000,
+):
     return store.settle_paid_checkout(
         event_id=event_id,
         event_type="checkout.session.completed",
@@ -415,7 +433,7 @@ def _pay_order(store, *, order_id: str = "ord_10", event_id: str = "evt_paid"):
         checkout_session_id=f"cs_test_{order_id}",
         payment_intent_id=f"pi_test_{order_id}",
         currency="usd",
-        amount_usd_cents=1000,
+        amount_usd_cents=cents,
     )
 
 
@@ -430,6 +448,63 @@ def _grant_args(operation: str, *, amount_micro: int) -> dict[str, object]:
         "source": "postgres_contract",
         "reason": f"Postgres contract operation {operation}.",
     }
+
+
+@pg_only
+def test_postgres_llm_overage_uses_unreserved_balance(pg_credits_store):
+    store = pg_credits_store
+    _pending_order(store, cents=110)
+    _pay_order(store, cents=110)
+    reservation = store.reserve_llm_credits(
+        reservation_id="pg-partial-overage",
+        user_id=1,
+        run_id="pg-partial-overage-run",
+        call_index=0,
+        reserved_micro=1_000_000,
+        operation_key="pg-partial-overage-operation",
+        request_digest="p" * 64,
+    )
+
+    settled = store.settle_llm_credits(
+        reservation["reservation_id"],
+        actual_micro=1_250_000,
+        evidence={"provider_id": "openrouter", "model_id": "qwen/qwen3"},
+    )
+
+    assert settled["settled_micro"] == 1_100_000
+    assert settled["outstanding_micro"] == 150_000
+    assert settled["purchased_debited_micro"] == 1_100_000
+    assert store.get_account_billing_state(1)["account_status"] == "restricted"
+
+
+@pg_only
+def test_postgres_llm_overage_uses_grant_before_restricting(pg_credits_store):
+    store = pg_credits_store
+    store.fund_grant_pool(**_grant_args("covered_fund", amount_micro=2_000_000))
+    store.assign_grant(
+        user_id=1,
+        **_grant_args("covered_assign", amount_micro=2_000_000),
+    )
+    reservation = store.reserve_llm_credits(
+        reservation_id="pg-covered-overage",
+        user_id=1,
+        run_id="pg-covered-overage-run",
+        call_index=0,
+        reserved_micro=1_000_000,
+        operation_key="pg-covered-overage-operation",
+        request_digest="q" * 64,
+    )
+
+    settled = store.settle_llm_credits(
+        reservation["reservation_id"],
+        actual_micro=1_250_000,
+        evidence={"provider_id": "openrouter", "model_id": "qwen/qwen3"},
+    )
+
+    assert settled["settled_micro"] == 1_250_000
+    assert settled["outstanding_micro"] == 0
+    assert settled["grant_debited_micro"] == 1_250_000
+    assert store.get_account_billing_state(1)["account_status"] == "active"
 
 
 @pg_only

--- a/dashboard/backend/tests/domain/credits/test_service.py
+++ b/dashboard/backend/tests/domain/credits/test_service.py
@@ -183,7 +183,7 @@ def _refund_event(
 
 def test_checkout_pays_model_overage_and_restores_account(tmp_path):
     service, gateway = _service(tmp_path)
-    first = _checkout(service)
+    first = _checkout(service, cents=110)
     _pay(service, gateway, first)
     reservation = service.reserve_llm_credits(
         user_id=1,
@@ -199,7 +199,7 @@ def test_checkout_pays_model_overage_and_restores_account(tmp_path):
     blocked = service.get_balance(1)
     assert blocked.account_status == "restricted"
     assert blocked.restriction_reason == "llm_overage"
-    assert blocked.outstanding_credits_micro == 250_000
+    assert blocked.outstanding_credits_micro == 150_000
 
     recovery = _checkout(
         service,
@@ -210,7 +210,7 @@ def test_checkout_pays_model_overage_and_restores_account(tmp_path):
     paid = service.handle_webhook(b"recovery", "valid")
 
     assert paid.outcome == "processed"
-    assert paid.recovered_micro == 250_000
+    assert paid.recovered_micro == 150_000
     restored = service.get_balance(1)
     assert restored.account_status == "active"
     assert restored.restriction_reason is None

--- a/dashboard/backend/tests/infrastructure/llm/test_platform_credits_env_fallback.py
+++ b/dashboard/backend/tests/infrastructure/llm/test_platform_credits_env_fallback.py
@@ -194,6 +194,24 @@ def test_platform_execution_uses_env_key_and_debits_grant_before_purchased(
     assert balance["purchased_available_micro"] == 900_000
 
 
+def test_platform_execution_settles_covered_reservation_overage(
+    tmp_path, monkeypatch
+):
+    adapter = FakeExecutionAdapter(LLMUsage(input_tokens=100, output_tokens=600))
+    service, credits_store = _execution_service(tmp_path, monkeypatch, adapter)
+
+    result = service.execute(_request("env-platform-covered-overage"))
+
+    assert result.billing.provider_cost_credits_micro == 700_000
+    assert result.billing.debited_credits_micro == 700_000
+    assert result.billing.outstanding_credits_micro == 0
+    assert credits_store.get_account_billing_state(USER_ID) == {
+        "account_status": "active",
+        "restriction_reason": None,
+        "outstanding_credits_micro": 0,
+    }
+
+
 def test_platform_execution_emits_bucketed_resource_evidence(
     tmp_path,
     monkeypatch,
@@ -309,7 +327,7 @@ def test_platform_execution_releases_reservation_when_usage_is_missing(
 @pytest.mark.parametrize(
     ("reason", "expected"),
     [
-        ("llm_overage", "Add at least 0.250000 Credits"),
+        ("llm_overage", "Add at least 0.150000 Credits"),
         ("refund_reconciliation", "payment refund review"),
     ],
 )

--- a/docs/superpowers/plans/2026-08-31-credit-overage-settlement.md
+++ b/docs/superpowers/plans/2026-08-31-credit-overage-settlement.md
@@ -1,0 +1,81 @@
+# Credit Overage Settlement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Charge model-cost reservation overruns from a user's unreserved Credits before restricting the account.
+
+**Architecture:** Keep settlement atomic inside each Credits store transaction. The reservation's held Grant/Purchased split is consumed first; supplementary available Grant/Purchased balances are computed from the same transaction snapshot and consumed only for the excess. SQLite and PostgreSQL retain parity, while the execution service continues to expose sanitized billing results.
+
+**Tech Stack:** Python 3.13, SQLite, PostgreSQL/psycopg, Pydantic, pytest.
+
+**Spec:** `docs/superpowers/specs/2026-08-31-credit-overage-settlement-design.md`
+
+## Global Constraints
+
+- Never spend Credits reserved by another open LLM reservation.
+- Preserve idempotent settlement replay behavior and existing Grant-first accounting.
+- Restrict an account only when an actual unpaid remainder remains.
+- Do not expose provider response data or credentials in errors.
+- Keep SQLite/PostgreSQL behavior and response fields equivalent.
+
+### Task 1: Update Reservation Schema and Migrations
+
+**Files:**
+- Modify: `dashboard/backend/domain/credits/repository.py:116-145, 460-515`
+- Modify: `dashboard/backend/domain/credits/repository_postgres.py:250-330`
+- Test: `dashboard/backend/tests/domain/credits/test_repository.py`
+- Test: `dashboard/backend/tests/domain/credits/test_repository_postgres.py`
+
+**Interfaces:**
+- Produces reservation tables that allow `settled_micro` to include supplementary debits.
+- Preserves all existing columns, foreign keys, indexes, and historical rows.
+
+- [ ] **Step 1: Write failing migration tests** for a legacy SQLite reservation table and a PostgreSQL migration SQL assertion; assert the obsolete `settled_micro <= reserved_micro` constraint is absent and existing rows survive.
+- [ ] **Step 2: Run the focused tests** with `pytest -q dashboard/backend/tests/domain/credits/test_repository.py dashboard/backend/tests/domain/credits/test_repository_postgres.py`; confirm the new migration assertions fail before implementation.
+- [ ] **Step 3: Implement the schema migration**: use a SQLite table rebuild when the legacy reservation SQL contains the upper-bound check, and add PostgreSQL `DROP CONSTRAINT IF EXISTS` plus a non-negative replacement constraint.
+- [ ] **Step 4: Re-run the focused migration tests** and confirm they pass.
+- [ ] **Step 5: Commit** with `git commit -m "fix(credits): allow settlement debits above reservations"`.
+
+### Task 2: Implement Atomic Supplementary Settlement
+
+**Files:**
+- Modify: `dashboard/backend/domain/credits/repository.py:1100-1220`
+- Modify: `dashboard/backend/domain/credits/repository_postgres.py:865-925`
+- Test: `dashboard/backend/tests/domain/credits/test_repository.py`
+- Test: `dashboard/backend/tests/domain/credits/test_repository_postgres.py`
+
+**Interfaces:**
+- `CreditsStore.settle_llm_credits(...)` and `PostgresCreditsStore.settle_llm_credits(...)` continue returning reservation dictionaries with `settled_micro`, `actual_micro`, `outstanding_micro`, and per-bucket ledger IDs.
+
+- [ ] **Step 1: Add failing SQLite tests** for fully covered and partially covered overruns, asserting supplementary Grant-first debits, active versus restricted account status, and remaining outstanding amount.
+- [ ] **Step 2: Add matching PostgreSQL contract tests** using the existing `@pg_only` fixture.
+- [ ] **Step 3: Implement settlement allocation**: calculate `excess_micro`, read unreserved Grant/Purchased projection inside the transaction, insert uniquely keyed supplementary usage entries, set `settled_micro` to reservation debit plus supplementary debit, and restrict only for a positive remainder.
+- [ ] **Step 4: Preserve replay behavior** by returning the settled row without creating duplicate usage entries when the same evidence is submitted again.
+- [ ] **Step 5: Run SQLite and PostgreSQL-focused tests** and confirm all pass (PostgreSQL may skip locally when unavailable).
+- [ ] **Step 6: Commit** with `git commit -m "fix(credits): charge available balance for reservation overage"`.
+
+### Task 3: Wire Execution Billing Evidence and Regression Coverage
+
+**Files:**
+- Modify: `dashboard/backend/infrastructure/llm/execution/service.py:270-305`
+- Test: `dashboard/backend/tests/infrastructure/llm/test_platform_credits_env_fallback.py`
+- Test: `dashboard/backend/tests/infrastructure/llm/test_execution_client.py`
+
+**Interfaces:**
+- `LLMExecutionService._execute_platform` passes the actual provider cost to settlement and reports the store's full debit and outstanding values without changing safe error categories.
+
+- [ ] **Step 1: Add a failing execution-service regression** where actual provider cost exceeds the reservation but available Credits cover the difference; assert successful result and zero outstanding.
+- [ ] **Step 2: Update evidence mapping** so `debited_credits_micro` reflects the full amount charged after supplementary settlement while `outstanding_credits_micro` reflects only unpaid remainder.
+- [ ] **Step 3: Run the execution-focused tests** and confirm they pass.
+- [ ] **Step 4: Commit** with `git commit -m "test(llm): cover covered reservation overruns"`.
+
+### Task 4: Full Verification and Pull Request
+
+**Files:**
+- Verify all files changed in Tasks 1-3.
+
+- [ ] **Step 1: Run targeted regression suite**: `pytest -q dashboard/backend/tests/domain/credits dashboard/backend/tests/infrastructure/llm/test_platform_credits_env_fallback.py dashboard/backend/tests/infrastructure/llm/test_execution_client.py`.
+- [ ] **Step 2: Run static checks**: `python -m py_compile` on changed Python files, `git diff --check`, and repository JavaScript checks if frontend files are touched.
+- [ ] **Step 3: Inspect staged names and diff** for database files, secrets, `.superpowers/`, and `work/` before committing.
+- [ ] **Step 4: Push branch** with `git push -u origin fix/credit-overage-settlement`.
+- [ ] **Step 5: Open PR** targeting `main` with title `fix(credits): charge available balance for reservation overage`, documenting test results and any local PostgreSQL skips.

--- a/docs/superpowers/plans/2026-08-31-credit-overage-settlement.md
+++ b/docs/superpowers/plans/2026-08-31-credit-overage-settlement.md
@@ -30,11 +30,11 @@
 - Produces reservation tables that allow `settled_micro` to include supplementary debits.
 - Preserves all existing columns, foreign keys, indexes, and historical rows.
 
-- [ ] **Step 1: Write failing migration tests** for a legacy SQLite reservation table and a PostgreSQL migration SQL assertion; assert the obsolete `settled_micro <= reserved_micro` constraint is absent and existing rows survive.
-- [ ] **Step 2: Run the focused tests** with `pytest -q dashboard/backend/tests/domain/credits/test_repository.py dashboard/backend/tests/domain/credits/test_repository_postgres.py`; confirm the new migration assertions fail before implementation.
-- [ ] **Step 3: Implement the schema migration**: use a SQLite table rebuild when the legacy reservation SQL contains the upper-bound check, and add PostgreSQL `DROP CONSTRAINT IF EXISTS` plus a non-negative replacement constraint.
-- [ ] **Step 4: Re-run the focused migration tests** and confirm they pass.
-- [ ] **Step 5: Commit** with `git commit -m "fix(credits): allow settlement debits above reservations"`.
+- [x] **Step 1: Write failing migration tests** for a legacy SQLite reservation table and a PostgreSQL migration SQL assertion; assert the obsolete `settled_micro <= reserved_micro` constraint is absent and existing rows survive.
+- [x] **Step 2: Run the focused tests** with `pytest -q dashboard/backend/tests/domain/credits/test_repository.py dashboard/backend/tests/domain/credits/test_repository_postgres.py`; confirm the new migration assertions fail before implementation.
+- [x] **Step 3: Implement the schema migration**: use a SQLite table rebuild when the legacy reservation SQL contains the upper-bound check, and add PostgreSQL `DROP CONSTRAINT IF EXISTS` plus a non-negative replacement constraint.
+- [x] **Step 4: Re-run the focused migration tests** and confirm they pass.
+- [x] **Step 5: Commit** the migration changes in the final PR commit.
 
 ### Task 2: Implement Atomic Supplementary Settlement
 
@@ -47,12 +47,12 @@
 **Interfaces:**
 - `CreditsStore.settle_llm_credits(...)` and `PostgresCreditsStore.settle_llm_credits(...)` continue returning reservation dictionaries with `settled_micro`, `actual_micro`, `outstanding_micro`, and per-bucket ledger IDs.
 
-- [ ] **Step 1: Add failing SQLite tests** for fully covered and partially covered overruns, asserting supplementary Grant-first debits, active versus restricted account status, and remaining outstanding amount.
-- [ ] **Step 2: Add matching PostgreSQL contract tests** using the existing `@pg_only` fixture.
-- [ ] **Step 3: Implement settlement allocation**: calculate `excess_micro`, read unreserved Grant/Purchased projection inside the transaction, insert uniquely keyed supplementary usage entries, set `settled_micro` to reservation debit plus supplementary debit, and restrict only for a positive remainder.
-- [ ] **Step 4: Preserve replay behavior** by returning the settled row without creating duplicate usage entries when the same evidence is submitted again.
-- [ ] **Step 5: Run SQLite and PostgreSQL-focused tests** and confirm all pass (PostgreSQL may skip locally when unavailable).
-- [ ] **Step 6: Commit** with `git commit -m "fix(credits): charge available balance for reservation overage"`.
+- [x] **Step 1: Add failing SQLite tests** for fully covered and partially covered overruns, asserting supplementary Grant-first debits, active versus restricted account status, and remaining outstanding amount.
+- [x] **Step 2: Add matching PostgreSQL contract tests** using the existing `@pg_only` fixture.
+- [x] **Step 3: Implement settlement allocation**: calculate `excess_micro`, read unreserved Grant/Purchased projection inside the transaction, insert uniquely keyed supplementary usage entries, set `settled_micro` to reservation debit plus supplementary debit, and restrict only for a positive remainder.
+- [x] **Step 4: Preserve replay behavior** by returning the settled row without creating duplicate usage entries when the same evidence is submitted again.
+- [x] **Step 5: Run SQLite and PostgreSQL-focused tests** and confirm all pass (PostgreSQL may skip locally when unavailable).
+- [x] **Step 6: Commit** the settlement changes in the final PR commit.
 
 ### Task 3: Wire Execution Billing Evidence and Regression Coverage
 
@@ -64,18 +64,18 @@
 **Interfaces:**
 - `LLMExecutionService._execute_platform` passes the actual provider cost to settlement and reports the store's full debit and outstanding values without changing safe error categories.
 
-- [ ] **Step 1: Add a failing execution-service regression** where actual provider cost exceeds the reservation but available Credits cover the difference; assert successful result and zero outstanding.
-- [ ] **Step 2: Update evidence mapping** so `debited_credits_micro` reflects the full amount charged after supplementary settlement while `outstanding_credits_micro` reflects only unpaid remainder.
-- [ ] **Step 3: Run the execution-focused tests** and confirm they pass.
-- [ ] **Step 4: Commit** with `git commit -m "test(llm): cover covered reservation overruns"`.
+- [x] **Step 1: Add a failing execution-service regression** where actual provider cost exceeds the reservation but available Credits cover the difference; assert successful result and zero outstanding.
+- [x] **Step 2: Update evidence mapping** so `debited_credits_micro` reflects the full amount charged after supplementary settlement while `outstanding_credits_micro` reflects only unpaid remainder.
+- [x] **Step 3: Run the execution-focused tests** and confirm they pass.
+- [x] **Step 4: Commit** the execution changes in the final PR commit.
 
 ### Task 4: Full Verification and Pull Request
 
 **Files:**
 - Verify all files changed in Tasks 1-3.
 
-- [ ] **Step 1: Run targeted regression suite**: `pytest -q dashboard/backend/tests/domain/credits dashboard/backend/tests/infrastructure/llm/test_platform_credits_env_fallback.py dashboard/backend/tests/infrastructure/llm/test_execution_client.py`.
-- [ ] **Step 2: Run static checks**: `python -m py_compile` on changed Python files, `git diff --check`, and repository JavaScript checks if frontend files are touched.
-- [ ] **Step 3: Inspect staged names and diff** for database files, secrets, `.superpowers/`, and `work/` before committing.
+- [x] **Step 1: Run targeted regression suite**: `pytest -q dashboard/backend/tests/domain/credits dashboard/backend/tests/infrastructure/llm/test_platform_credits_env_fallback.py dashboard/backend/tests/infrastructure/llm/test_execution_client.py`.
+- [x] **Step 2: Run static checks**: `python -m py_compile` on changed Python files, `git diff --check`, and repository JavaScript checks if frontend files are touched.
+- [x] **Step 3: Inspect staged names and diff** for database files, secrets, `.superpowers/`, and `work/` before committing.
 - [ ] **Step 4: Push branch** with `git push -u origin fix/credit-overage-settlement`.
 - [ ] **Step 5: Open PR** targeting `main` with title `fix(credits): charge available balance for reservation overage`, documenting test results and any local PostgreSQL skips.

--- a/docs/superpowers/plans/2026-08-31-credit-overage-settlement.md
+++ b/docs/superpowers/plans/2026-08-31-credit-overage-settlement.md
@@ -77,5 +77,5 @@
 - [x] **Step 1: Run targeted regression suite**: `pytest -q dashboard/backend/tests/domain/credits dashboard/backend/tests/infrastructure/llm/test_platform_credits_env_fallback.py dashboard/backend/tests/infrastructure/llm/test_execution_client.py`.
 - [x] **Step 2: Run static checks**: `python -m py_compile` on changed Python files, `git diff --check`, and repository JavaScript checks if frontend files are touched.
 - [x] **Step 3: Inspect staged names and diff** for database files, secrets, `.superpowers/`, and `work/` before committing.
-- [ ] **Step 4: Push branch** with `git push -u origin fix/credit-overage-settlement`.
-- [ ] **Step 5: Open PR** targeting `main` with title `fix(credits): charge available balance for reservation overage`, documenting test results and any local PostgreSQL skips.
+- [x] **Step 4: Push branch** with `git push -u origin fix/credit-overage-settlement`.
+- [x] **Step 5: Open PR** targeting `main` with title `fix(credits): charge available balance for reservation overage`, documenting test results and any local PostgreSQL skips.

--- a/docs/superpowers/specs/2026-08-31-credit-overage-settlement-design.md
+++ b/docs/superpowers/specs/2026-08-31-credit-overage-settlement-design.md
@@ -1,0 +1,36 @@
+# Credit Overage Settlement Design
+
+## Goal
+
+Prevent a Credits account from becoming restricted when a model call costs more than its reservation but the account still has enough unreserved Credits to pay the difference.
+
+## Current Failure
+
+`settle_llm_credits` debits at most `reserved_micro` and records `actual_micro - reserved_micro` as outstanding. It then restricts the account whenever that difference is positive. The code does not try the account's currently available Grant or Purchased balance, so a small estimator error can freeze an account with a large positive balance.
+
+## Behavior
+
+1. Settlement consumes the reservation's Grant allocation first, then its Purchased allocation, exactly as today.
+2. When `actual_micro > reserved_micro`, settlement computes the user's unreserved balances in the same transaction. It debits the excess from available Grant Credits first and Purchased Credits second.
+3. `settled_micro` records the full amount actually debited, including the excess. `outstanding_micro` records only the unpaid remainder.
+4. The account is restricted with reason `llm_overage` only when the unreserved balance cannot cover the excess. A fully covered excess leaves the account active and reports zero outstanding.
+5. The current reservation is excluded from the supplementary-balance calculation; other open reservations remain protected. Concurrent settlements serialize on the account/reservation transaction locks and cannot spend the same Credits twice.
+6. Existing overage recovery remains unchanged and can settle historical debt through a later purchase or admin Grant.
+
+## Storage Changes
+
+- Replace the `settled_micro <= reserved_micro` reservation check with a non-negative settled amount check in fresh SQLite/PostgreSQL schemas.
+- Add an idempotent migration for existing SQLite tables, preserving reservation and usage rows while removing the obsolete upper-bound check.
+- Drop and recreate the equivalent PostgreSQL check constraint in the existing migration DDL.
+- Keep `outstanding_recovered_micro` semantics unchanged: only rows with unpaid remainder participate in recovery.
+
+## API and UI
+
+No endpoint shape changes are required. Existing settlement and balance responses expose the corrected `settled_micro`, `outstanding_micro`, `account_status`, and `restriction_reason` values. User-facing restricted copy remains reserved for genuinely unpaid overage.
+
+## Verification
+
+- SQLite: a fully covered excess settles without restriction; a partially covered excess leaves only the remainder restricted; existing overage and recovery tests remain green.
+- PostgreSQL contract tests cover the same two paths and verify the migration constraint update.
+- Execution-service tests verify the billing evidence reports full debit and zero outstanding when supplementary balance covers the excess.
+- Run targeted Credits/execution tests, syntax checks, and the repository's standard CI command before opening the PR.


### PR DESCRIPTION
## Summary

- Charge reservation overage from unreserved Grant and Purchased Credits before restricting an account.
- Keep other open reservations protected and settlement replay idempotent across SQLite and PostgreSQL.
- Migrate legacy reservation constraints and return final debit/outstanding values in execution billing evidence.

## Verification

- `pytest -q dashboard/backend/tests` -> 3891 passed, 149 skipped.
- Targeted Credits/LLM suite -> 89 passed, 23 skipped (PostgreSQL live tests skipped locally because `TEST_POSTGRES_URL` is not configured).
- `python -m py_compile` on changed Python modules.
- `git diff --check`.
