### PR TITLE
fix(credits): retry sqlite reservation migration lazily

### DIFF
--- a/dashboard/backend/domain/credits/repository.py
+++ b/dashboard/backend/domain/credits/repository.py
@@ -1122,6 +1122,7 @@ class CreditsStore:
 
         with self._get_connection() as conn:
             self._begin(conn)
+            self._migrate_llm_reservation_constraint_in_transaction(conn)
             existing = conn.execute(
                 """
                 SELECT * FROM credit_llm_reservations
@@ -1210,6 +1211,7 @@ class CreditsStore:
         evidence_json = _evidence_json(evidence)
         with self._get_connection() as conn:
             self._begin(conn)
+            self._migrate_llm_reservation_constraint_in_transaction(conn)
             reservation = conn.execute(
                 "SELECT * FROM credit_llm_reservations WHERE reservation_id = ?",
                 (reservation_id,),

--- a/dashboard/backend/tests/domain/credits/test_repository.py
+++ b/dashboard/backend/tests/domain/credits/test_repository.py
@@ -155,21 +155,6 @@ def test_sqlite_migrates_legacy_reservation_settlement_constraint(tmp_path):
     with sqlite3.connect(path) as conn:
         conn.execute(
             """
-            CREATE TABLE users (
-                id INTEGER PRIMARY KEY,
-                email TEXT NOT NULL UNIQUE,
-                display_name TEXT NOT NULL,
-                password_hash TEXT NOT NULL,
-                role TEXT NOT NULL,
-                created_at TEXT NOT NULL
-            )
-            """
-        )
-        conn.execute(
-            "INSERT INTO users VALUES (1, 'legacy@example.com', 'Legacy', 'unused', 'user', '2026-08-01')"
-        )
-        conn.execute(
-            """
             CREATE TABLE credit_llm_reservations (
                 reservation_id TEXT PRIMARY KEY,
                 user_id INTEGER NOT NULL,
@@ -233,7 +218,31 @@ def test_sqlite_migrates_legacy_reservation_settlement_constraint(tmp_path):
             """
         )
 
+    # The Credits store can initialize before UserStore creates its parent
+    # table. The first pass must not fail or mark the migration complete.
     store = CreditsStore(path)
+
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE users (
+                id INTEGER PRIMARY KEY,
+                email TEXT NOT NULL UNIQUE,
+                display_name TEXT NOT NULL,
+                password_hash TEXT NOT NULL,
+                role TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO users VALUES (1, 'legacy@example.com', 'Legacy', 'unused', 'user', '2026-08-01')"
+        )
+    settled = store.settle_llm_credits(
+        "legacy-reservation",
+        actual_micro=1_200,
+        evidence={"provider_id": "openrouter", "model_id": "qwen/qwen3"},
+    )
 
     with store._get_connection() as conn:
         schema = conn.execute(
@@ -245,14 +254,12 @@ def test_sqlite_migrates_legacy_reservation_settlement_constraint(tmp_path):
         usage = conn.execute(
             "SELECT operation_key, amount_micro FROM credit_llm_usage_entries"
         ).fetchone()
-        conn.execute(
-            "UPDATE credit_llm_reservations SET settled_micro = 1200 "
-            "WHERE reservation_id = 'legacy-reservation'"
-        )
 
     assert "settled_micro <= reserved_micro" not in "".join(schema.lower().split())
     assert tuple(row) == (1000, "legacy-operation")
     assert tuple(usage) == ("legacy-usage", -100)
+    assert settled["settled_micro"] == 1000
+    assert settled["outstanding_micro"] == 200
 
 
 def test_llm_overage_debits_the_hold_and_restricts_the_account(tmp_path):


### PR DESCRIPTION
## Summary

- Retry the SQLite legacy reservation constraint migration when reservation or settlement starts.
- Handle the startup ordering where CreditsStore is created before the users table exists.
- Add a regression test covering lazy migration and successful settlement after the users table is created.

## Root Cause

The first overage fix skipped SQLite migration when `users` did not yet exist, but the singleton CreditsStore did not retry later. Existing reservations then retained `settled_micro <= reserved_micro`; a covered overage failed at settlement despite a positive account balance.

## Verification

- `pytest -q dashboard/backend/tests/domain/credits/test_repository.py dashboard/backend/tests/domain/credits/test_repository_postgres.py dashboard/backend/tests/infrastructure/llm/test_platform_credits_env_fallback.py` -> 48 passed, 23 skipped.
- `python -m py_compile dashboard/backend/domain/credits/repository.py`.
- `git diff --check`.
