### PR TITLE
feat: fail over platform credits to CommonStack

### DIFF
--- a/dashboard/backend/domain/analytics/models.py
+++ b/dashboard/backend/domain/analytics/models.py
@@ -61,6 +61,7 @@ ALLOWED_ERROR_CATEGORIES = {
     "credential_missing",
     "provider_timeout",
     "provider_unavailable",
+    "provider_quota_exhausted",
     "credits_unavailable",
     "model_not_allowed",
     "internal_error",

--- a/dashboard/backend/domain/analytics/repository.py
+++ b/dashboard/backend/domain/analytics/repository.py
@@ -61,7 +61,8 @@ CREATE TABLE IF NOT EXISTS analytics_events (
     error_category TEXT CHECK (
         error_category IS NULL OR error_category IN (
             'credential_invalid', 'credential_missing', 'provider_timeout',
-            'provider_unavailable', 'credits_unavailable',
+            'provider_unavailable', 'provider_quota_exhausted',
+            'credits_unavailable',
             'model_not_allowed', 'internal_error'
         )
     ),
@@ -235,6 +236,46 @@ class AnalyticsStore:
     def _init_schema(self) -> None:
         with self._get_connection() as conn:
             conn.executescript(ANALYTICS_SQLITE_DDL)
+            self._migrate_error_category_constraint(conn)
+
+    @staticmethod
+    def _migrate_error_category_constraint(conn: sqlite3.Connection) -> None:
+        """Rebuild the events table when upgrading its closed category check."""
+
+        row = conn.execute(
+            "SELECT sql FROM sqlite_master "
+            "WHERE type = 'table' AND name = 'analytics_events'"
+        ).fetchone()
+        table_sql = str(row[0] or "").lower() if row else ""
+        if "provider_quota_exhausted" in table_sql:
+            return
+
+        # Index names are schema-global, so remove the old table's indexes
+        # before creating the replacement table and its indexes.
+        for index_name in (
+            "idx_analytics_events_user_time",
+            "idx_analytics_events_name_time",
+            "idx_analytics_events_session_time",
+            "idx_analytics_events_outcome_time",
+            "idx_analytics_events_error_time",
+        ):
+            conn.execute(f"DROP INDEX IF EXISTS {index_name}")
+        conn.execute(
+            "ALTER TABLE analytics_events "
+            "RENAME TO analytics_events_migration_legacy"
+        )
+        conn.executescript(ANALYTICS_SQLITE_DDL)
+        columns = (
+            "sequence, "
+            + ", ".join(_EVENT_COLUMNS)
+            + ", country_code, device_category, browser_family, "
+            "network_hash, properties_json"
+        )
+        conn.execute(
+            f"INSERT INTO analytics_events ({columns}) "
+            f"SELECT {columns} FROM analytics_events_migration_legacy"
+        )
+        conn.execute("DROP TABLE analytics_events_migration_legacy")
 
     @staticmethod
     def _existing_rows_for_event(

--- a/dashboard/backend/domain/analytics/repository.py
+++ b/dashboard/backend/domain/analytics/repository.py
@@ -242,6 +242,13 @@ class AnalyticsStore:
     def _migrate_error_category_constraint(conn: sqlite3.Connection) -> None:
         """Rebuild the events table when upgrading its closed category check."""
 
+        users_table = conn.execute(
+            "SELECT 1 FROM sqlite_master "
+            "WHERE type = 'table' AND name = 'users'"
+        ).fetchone()
+        if users_table is None:
+            return
+
         row = conn.execute(
             "SELECT sql FROM sqlite_master "
             "WHERE type = 'table' AND name = 'analytics_events'"
@@ -300,6 +307,7 @@ class AnalyticsStore:
         placeholders = ", ".join("?" for _ in _EVENT_COLUMNS)
         columns = ", ".join(_EVENT_COLUMNS)
         with self._get_connection() as conn:
+            self._migrate_error_category_constraint(conn)
             try:
                 cursor = conn.execute(
                     f"INSERT INTO analytics_events ({columns}) VALUES ({placeholders})",

--- a/dashboard/backend/domain/analytics/repository_postgres.py
+++ b/dashboard/backend/domain/analytics/repository_postgres.py
@@ -58,7 +58,8 @@ CREATE TABLE IF NOT EXISTS analytics_events (
     error_category TEXT CHECK (
         error_category IS NULL OR error_category IN (
             'credential_invalid', 'credential_missing', 'provider_timeout',
-            'provider_unavailable', 'credits_unavailable',
+            'provider_unavailable', 'provider_quota_exhausted',
+            'credits_unavailable',
             'model_not_allowed', 'internal_error'
         )
     ),
@@ -166,6 +167,24 @@ class PostgresAnalyticsStore:
         with self._get_connection() as conn:
             with conn.cursor() as cur:
                 cur.execute(ANALYTICS_POSTGRES_DDL)
+                cur.execute(
+                    "ALTER TABLE analytics_events "
+                    "DROP CONSTRAINT IF EXISTS analytics_events_error_category_check"
+                )
+                cur.execute(
+                    """
+                    ALTER TABLE analytics_events
+                    ADD CONSTRAINT analytics_events_error_category_check
+                    CHECK (
+                        error_category IS NULL OR error_category IN (
+                            'credential_invalid', 'credential_missing',
+                            'provider_timeout', 'provider_unavailable',
+                            'provider_quota_exhausted', 'credits_unavailable',
+                            'model_not_allowed', 'internal_error'
+                        )
+                    )
+                    """
+                )
 
     @staticmethod
     def _select_event(cur, field: str, value: str | None):

--- a/dashboard/backend/domain/credits/models.py
+++ b/dashboard/backend/domain/credits/models.py
@@ -362,6 +362,8 @@ class LLMReservation(BaseModel):
     user_id: StrictInt
     run_id: str
     call_index: StrictInt
+    provider_id: str | None = None
+    attempt_index: StrictInt = Field(default=0, ge=0)
     reserved_micro: StrictInt
     settled_micro: StrictInt
     actual_micro: StrictInt = Field(default=0, ge=0)
@@ -379,6 +381,8 @@ class LLMSettlementResult(BaseModel):
     reservation_id: str
     user_id: StrictInt
     run_id: str
+    provider_id: str | None = None
+    attempt_index: StrictInt = Field(default=0, ge=0)
     reserved_micro: StrictInt
     settled_micro: StrictInt
     actual_micro: StrictInt = Field(default=0, ge=0)

--- a/dashboard/backend/domain/credits/repository.py
+++ b/dashboard/backend/domain/credits/repository.py
@@ -31,6 +31,9 @@ from dashboard.backend.domain.credits.repository_common import (
     _utcnow_iso,
     _validate_amount_pair,
 )
+from dashboard.backend.domain.model_providers.repository_common import (
+    validate_provider_id,
+)
 
 
 _SETTLEMENT_OUTCOME_EVIDENCE_KEYS = {
@@ -149,6 +152,8 @@ CREATE TABLE IF NOT EXISTS credit_llm_reservations (
     user_id INTEGER NOT NULL,
     run_id TEXT NOT NULL CHECK (length(trim(run_id)) > 0),
     call_index INTEGER NOT NULL CHECK (call_index >= 0),
+    provider_id TEXT,
+    attempt_index INTEGER NOT NULL DEFAULT 0 CHECK (attempt_index >= 0),
     reserved_micro INTEGER NOT NULL CHECK (reserved_micro > 0),
     reserved_grant_micro INTEGER NOT NULL CHECK (reserved_grant_micro >= 0),
     reserved_purchased_micro INTEGER NOT NULL CHECK (reserved_purchased_micro >= 0),
@@ -167,7 +172,7 @@ CREATE TABLE IF NOT EXISTS credit_llm_reservations (
     updated_at TEXT NOT NULL,
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
     CHECK (reserved_micro = reserved_grant_micro + reserved_purchased_micro),
-    UNIQUE (user_id, run_id, call_index)
+    UNIQUE (user_id, run_id, call_index, attempt_index)
 )
 """
 
@@ -512,6 +517,16 @@ class CreditsStore:
                 "ADD COLUMN outstanding_recovered_micro INTEGER NOT NULL DEFAULT 0 "
                 "CHECK (outstanding_recovered_micro >= 0)"
             )
+        if "provider_id" not in reservation_columns:
+            conn.execute(
+                "ALTER TABLE credit_llm_reservations ADD COLUMN provider_id TEXT"
+            )
+        if "attempt_index" not in reservation_columns:
+            conn.execute(
+                "ALTER TABLE credit_llm_reservations "
+                "ADD COLUMN attempt_index INTEGER NOT NULL DEFAULT 0 "
+                "CHECK (attempt_index >= 0)"
+            )
         account_columns = cls._table_columns(conn, "credit_accounts")
         if "restriction_reason" not in account_columns:
             conn.execute(
@@ -535,7 +550,7 @@ class CreditsStore:
         conn.execute(
             """
             CREATE INDEX IF NOT EXISTS idx_credit_llm_reservations_run_status
-            ON credit_llm_reservations(run_id, status, call_index)
+            ON credit_llm_reservations(run_id, status, call_index, attempt_index)
             """
         )
         conn.execute(
@@ -558,12 +573,19 @@ class CreditsStore:
         if not cls._table_columns(conn, "users"):
             return
 
+        reservation_columns = cls._table_columns(conn, "credit_llm_reservations")
         row = conn.execute(
             "SELECT sql FROM sqlite_master "
             "WHERE type = 'table' AND name = 'credit_llm_reservations'"
         ).fetchone()
         table_sql = "".join(str(row["sql"] or "").lower().split()) if row else ""
-        if "settled_micro<=reserved_micro" not in table_sql:
+        needs_rebuild = (
+            "provider_id" not in reservation_columns
+            or "attempt_index" not in reservation_columns
+            or "unique(user_id,run_id,call_index)" in table_sql
+            or "settled_micro<=reserved_micro" in table_sql
+        )
+        if not needs_rebuild:
             return
 
         usage_exists = bool(cls._table_columns(conn, "credit_llm_usage_entries"))
@@ -580,7 +602,17 @@ class CreditsStore:
         )
         conn.execute(_LLM_RESERVATION_DDL)
         columns = (
-            "reservation_id, user_id, run_id, call_index, reserved_micro, "
+            "reservation_id, user_id, run_id, call_index, provider_id, "
+            "attempt_index, reserved_micro, reserved_grant_micro, "
+            "reserved_purchased_micro, settled_micro, actual_micro, "
+            "outstanding_micro, outstanding_recovered_micro, status, operation_key, "
+            "request_digest, evidence_json, failure_reason, created_at, updated_at"
+        )
+        provider_expression = "provider_id" if "provider_id" in reservation_columns else "NULL"
+        attempt_expression = "attempt_index" if "attempt_index" in reservation_columns else "0"
+        select_columns = (
+            "reservation_id, user_id, run_id, call_index, "
+            f"{provider_expression}, {attempt_expression}, reserved_micro, "
             "reserved_grant_micro, reserved_purchased_micro, settled_micro, "
             "actual_micro, outstanding_micro, outstanding_recovered_micro, status, "
             "operation_key, request_digest, evidence_json, failure_reason, "
@@ -588,7 +620,7 @@ class CreditsStore:
         )
         conn.execute(
             f"INSERT INTO credit_llm_reservations ({columns}) "
-            f"SELECT {columns} FROM credit_llm_reservations_migration_legacy"
+            f"SELECT {select_columns} FROM credit_llm_reservations_migration_legacy"
         )
         conn.execute("DROP TABLE credit_llm_reservations_migration_legacy")
 
@@ -1101,6 +1133,8 @@ class CreditsStore:
         user_id: int,
         run_id: str,
         call_index: int,
+        attempt_index: int,
+        provider_id: str,
         reserved_micro: int,
         operation_key: str,
         request_digest: str,
@@ -1119,6 +1153,9 @@ class CreditsStore:
         _positive_integer(reserved_micro, "reserved_micro")
         if isinstance(call_index, bool) or not isinstance(call_index, int) or call_index < 0:
             raise ValueError("call_index must be a non-negative integer")
+        if isinstance(attempt_index, bool) or not isinstance(attempt_index, int) or attempt_index < 0:
+            raise ValueError("attempt_index must be a non-negative integer")
+        provider_id = validate_provider_id(provider_id)
 
         with self._get_connection() as conn:
             self._begin(conn)
@@ -1127,9 +1164,9 @@ class CreditsStore:
                 """
                 SELECT * FROM credit_llm_reservations
                 WHERE reservation_id = ? OR operation_key = ?
-                   OR (user_id = ? AND run_id = ? AND call_index = ?)
+                   OR (user_id = ? AND run_id = ? AND call_index = ? AND attempt_index = ?)
                 """,
-                (reservation_id, operation_key, user_id, run_id, call_index),
+                (reservation_id, operation_key, user_id, run_id, call_index, attempt_index),
             ).fetchone()
             if existing:
                 if (
@@ -1137,6 +1174,8 @@ class CreditsStore:
                     or int(existing["user_id"]) != user_id
                     or existing["run_id"] != run_id
                     or int(existing["call_index"]) != call_index
+                    or int(existing["attempt_index"]) != attempt_index
+                    or existing["provider_id"] != provider_id
                     or int(existing["reserved_micro"]) != reserved_micro
                     or existing["operation_key"] != operation_key
                     or existing["request_digest"] != request_digest
@@ -1165,18 +1204,21 @@ class CreditsStore:
             conn.execute(
                 """
                 INSERT INTO credit_llm_reservations (
-                    reservation_id, user_id, run_id, call_index,
+                    reservation_id, user_id, run_id, call_index, provider_id,
+                    attempt_index,
                     reserved_micro, reserved_grant_micro,
                     reserved_purchased_micro, settled_micro, status,
                     operation_key, request_digest, created_at, updated_at
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, 0, 'open', ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 'open', ?, ?, ?, ?)
                 """,
                 (
                     reservation_id,
                     user_id,
                     run_id,
                     call_index,
+                    provider_id,
+                    attempt_index,
                     reserved_micro,
                     reserved_grant,
                     reserved_purchased,
@@ -1596,7 +1638,7 @@ class CreditsStore:
             rows = conn.execute(
                 """
                 SELECT * FROM credit_llm_reservations
-                WHERE run_id = ? ORDER BY call_index
+                WHERE run_id = ? ORDER BY call_index, attempt_index, reservation_id
                 """,
                 (run_id,),
             ).fetchall()

--- a/dashboard/backend/domain/credits/repository_postgres.py
+++ b/dashboard/backend/domain/credits/repository_postgres.py
@@ -27,6 +27,9 @@ from dashboard.backend.domain.credits.repository_common import (
     _utcnow_iso,
     _validate_amount_pair,
 )
+from dashboard.backend.domain.model_providers.repository_common import (
+    validate_provider_id,
+)
 
 
 _SETTLEMENT_OUTCOME_EVIDENCE_KEYS = {
@@ -283,6 +286,8 @@ CREATE TABLE IF NOT EXISTS credit_llm_reservations (
     user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     run_id TEXT NOT NULL CHECK (length(trim(run_id)) > 0),
     call_index INTEGER NOT NULL CHECK (call_index >= 0),
+    provider_id TEXT,
+    attempt_index INTEGER NOT NULL DEFAULT 0 CHECK (attempt_index >= 0),
     reserved_micro BIGINT NOT NULL CHECK (reserved_micro > 0),
     reserved_grant_micro BIGINT NOT NULL CHECK (reserved_grant_micro >= 0),
     reserved_purchased_micro BIGINT NOT NULL CHECK (reserved_purchased_micro >= 0),
@@ -300,14 +305,15 @@ CREATE TABLE IF NOT EXISTS credit_llm_reservations (
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL,
     CHECK (reserved_micro = reserved_grant_micro + reserved_purchased_micro),
-    UNIQUE (user_id, run_id, call_index)
+    CONSTRAINT credit_llm_reservations_logical_attempt_key
+        UNIQUE (user_id, run_id, call_index, attempt_index)
 );
 
 CREATE INDEX IF NOT EXISTS idx_credit_llm_reservations_user_status
 ON credit_llm_reservations(user_id, status, created_at);
 
 CREATE INDEX IF NOT EXISTS idx_credit_llm_reservations_run_status
-ON credit_llm_reservations(run_id, status, call_index);
+ON credit_llm_reservations(run_id, status, call_index, attempt_index);
 
 CREATE TABLE IF NOT EXISTS credit_llm_usage_entries (
     id BIGSERIAL PRIMARY KEY,
@@ -354,6 +360,15 @@ ALTER TABLE credit_llm_reservations
 ADD COLUMN IF NOT EXISTS outstanding_micro BIGINT NOT NULL DEFAULT 0;
 ALTER TABLE credit_llm_reservations
 ADD COLUMN IF NOT EXISTS outstanding_recovered_micro BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE credit_llm_reservations
+ADD COLUMN IF NOT EXISTS provider_id TEXT;
+ALTER TABLE credit_llm_reservations
+ADD COLUMN IF NOT EXISTS attempt_index INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE credit_llm_reservations
+DROP CONSTRAINT IF EXISTS credit_llm_reservations_attempt_index_check;
+ALTER TABLE credit_llm_reservations
+ADD CONSTRAINT credit_llm_reservations_attempt_index_check
+CHECK (attempt_index >= 0);
 ALTER TABLE credit_accounts
 ADD COLUMN IF NOT EXISTS restriction_reason TEXT;
 UPDATE credit_llm_reservations
@@ -384,6 +399,35 @@ DROP CONSTRAINT IF EXISTS credit_llm_reservations_settled_micro_nonnegative_chec
 ALTER TABLE credit_llm_reservations
 ADD CONSTRAINT credit_llm_reservations_settled_micro_nonnegative_check
 CHECK (settled_micro >= 0);
+DO $$
+DECLARE
+    legacy_constraint TEXT;
+BEGIN
+    FOR legacy_constraint IN
+        SELECT con.conname
+        FROM pg_constraint AS con
+        WHERE con.conrelid = 'credit_llm_reservations'::regclass
+          AND con.contype = 'u'
+          AND (
+              SELECT array_agg(att.attname ORDER BY key.ord)
+              FROM unnest(con.conkey) WITH ORDINALITY AS key(attnum, ord)
+              JOIN pg_attribute AS att
+                ON att.attrelid = con.conrelid
+               AND att.attnum = key.attnum
+          ) = ARRAY['user_id', 'run_id', 'call_index']::name[]
+    LOOP
+        EXECUTE format(
+            'ALTER TABLE credit_llm_reservations DROP CONSTRAINT %I',
+            legacy_constraint
+        );
+    END LOOP;
+END
+$$;
+ALTER TABLE credit_llm_reservations
+DROP CONSTRAINT IF EXISTS credit_llm_reservations_logical_attempt_key;
+ALTER TABLE credit_llm_reservations
+ADD CONSTRAINT credit_llm_reservations_logical_attempt_key
+UNIQUE (user_id, run_id, call_index, attempt_index);
 
 ALTER TABLE credit_grant_pool_ledger_entries
 ADD COLUMN IF NOT EXISTS pool_name_snapshot TEXT;
@@ -859,7 +903,8 @@ class PostgresCreditsStore:
         return row
 
     def reserve_llm_credits(self, *, reservation_id: str, user_id: int, run_id: str,
-                            call_index: int, reserved_micro: int,
+                            call_index: int, attempt_index: int, provider_id: str,
+                            reserved_micro: int,
                             operation_key: str, request_digest: str) -> dict[str, Any]:
         reservation_id = _required_text(reservation_id, "reservation_id", max_length=160)
         run_id = _required_text(run_id, "run_id", max_length=128)
@@ -867,8 +912,11 @@ class PostgresCreditsStore:
         request_digest = _required_text(request_digest, "request_digest", max_length=128)
         _positive_integer(user_id, "user_id")
         _positive_integer(reserved_micro, "reserved_micro")
+        provider_id = validate_provider_id(provider_id)
         if not isinstance(call_index, int) or isinstance(call_index, bool) or call_index < 0:
             raise ValueError("call_index must be a non-negative integer")
+        if not isinstance(attempt_index, int) or isinstance(attempt_index, bool) or attempt_index < 0:
+            raise ValueError("attempt_index must be a non-negative integer")
         with self._get_connection() as conn:
             with conn.cursor() as cur:
                 self._ensure_account_in_transaction(cur, user_id)
@@ -877,8 +925,8 @@ class PostgresCreditsStore:
                     (operation_key,),
                 )
                 cur.execute(
-                    "SELECT * FROM credit_llm_reservations WHERE reservation_id = %s OR operation_key = %s OR (user_id = %s AND run_id = %s AND call_index = %s) FOR UPDATE",
-                    (reservation_id, operation_key, user_id, run_id, call_index),
+                    "SELECT * FROM credit_llm_reservations WHERE reservation_id = %s OR operation_key = %s OR (user_id = %s AND run_id = %s AND call_index = %s AND attempt_index = %s) FOR UPDATE",
+                    (reservation_id, operation_key, user_id, run_id, call_index, attempt_index),
                 )
                 existing = cur.fetchone()
                 if existing:
@@ -886,6 +934,8 @@ class PostgresCreditsStore:
                             or int(existing["user_id"]) != user_id
                             or existing["run_id"] != run_id
                             or int(existing["call_index"]) != call_index
+                            or int(existing["attempt_index"]) != attempt_index
+                            or existing["provider_id"] != provider_id
                             or int(existing["reserved_micro"]) != reserved_micro
                             or existing["operation_key"] != operation_key or existing["request_digest"] != request_digest):
                         raise LLMReservationConflictError("reservation key already represents different input")
@@ -908,14 +958,16 @@ class PostgresCreditsStore:
                 cur.execute(
                     """
                     INSERT INTO credit_llm_reservations (
-                        reservation_id, user_id, run_id, call_index,
+                        reservation_id, user_id, run_id, call_index, provider_id,
+                        attempt_index,
                         reserved_micro, reserved_grant_micro, reserved_purchased_micro,
                         operation_key, request_digest, created_at, updated_at
-                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                     RETURNING *
                     """,
-                    (reservation_id, user_id, run_id, call_index, reserved_micro,
-                     reserved_grant, reserved_purchased, operation_key, request_digest, now, now),
+                    (reservation_id, user_id, run_id, call_index, provider_id,
+                     attempt_index, reserved_micro, reserved_grant, reserved_purchased,
+                     operation_key, request_digest, now, now),
                 )
                 return dict(cur.fetchone())
 
@@ -1247,7 +1299,7 @@ class PostgresCreditsStore:
         with self._get_connection() as conn:
             with conn.cursor() as cur:
                 cur.execute("UPDATE credit_llm_reservations SET status = 'released', failure_reason = %s, updated_at = %s WHERE run_id = %s AND status = 'open'", (reason, _utcnow_iso(), run_id))
-                cur.execute("SELECT * FROM credit_llm_reservations WHERE run_id = %s ORDER BY call_index", (run_id,))
+                cur.execute("SELECT * FROM credit_llm_reservations WHERE run_id = %s ORDER BY call_index, attempt_index, reservation_id", (run_id,))
                 return [self._llm_reservation_result(cur, row) for row in cur.fetchall()]
 
     def create_or_get_order(

--- a/dashboard/backend/domain/credits/service.py
+++ b/dashboard/backend/domain/credits/service.py
@@ -30,6 +30,9 @@ from dashboard.backend.domain.credits.repository import (
     credits_store,
 )
 from dashboard.backend.domain.credits.repository_common import _canonical_digest
+from dashboard.backend.domain.model_providers.repository_common import (
+    validate_provider_id,
+)
 from dashboard.backend.domain.credits.stripe_gateway import (
     StripeGatewayDefinitiveError,
     StripeGatewayError,
@@ -217,6 +220,12 @@ class CreditsService:
             user_id=int(value["user_id"]),
             run_id=str(value["run_id"]),
             call_index=int(value["call_index"]),
+            provider_id=(
+                str(value["provider_id"])
+                if value.get("provider_id") is not None
+                else None
+            ),
+            attempt_index=int(value.get("attempt_index") or 0),
             reserved_micro=int(value["reserved_micro"]),
             settled_micro=int(value["settled_micro"]),
             actual_micro=int(value.get("actual_micro") or 0),
@@ -236,6 +245,12 @@ class CreditsService:
             reservation_id=str(value["reservation_id"]),
             user_id=int(value["user_id"]),
             run_id=str(value["run_id"]),
+            provider_id=(
+                str(value["provider_id"])
+                if value.get("provider_id") is not None
+                else None
+            ),
+            attempt_index=int(value.get("attempt_index") or 0),
             reserved_micro=int(value["reserved_micro"]),
             settled_micro=int(value["settled_micro"]),
             actual_micro=int(value.get("actual_micro") or 0),
@@ -289,30 +304,49 @@ class CreditsService:
         run_id: str,
         call_index: int,
         amount_micro: int,
+        provider_id: str,
+        attempt_index: int = 0,
         operation_key: str | None = None,
         request_digest: str | None = None,
     ) -> LLMReservation:
         """Temporarily hold a usage ceiling; no Credit debit occurs here."""
 
+        provider_id = validate_provider_id(provider_id)
+        if (
+            isinstance(attempt_index, bool)
+            or not isinstance(attempt_index, int)
+            or attempt_index < 0
+        ):
+            raise ValueError("attempt_index must be a non-negative integer")
         operation_key = operation_key or _operation_id(
-            "llm_reserve", user_id, run_id, call_index
+            "llm_reserve", user_id, run_id, call_index, attempt_index, provider_id
         )
         request_digest = request_digest or _canonical_digest(
             {
                 "user_id": int(user_id),
                 "run_id": run_id,
                 "call_index": call_index,
+                "attempt_index": attempt_index,
+                "provider_id": provider_id,
                 "amount_micro": amount_micro,
             }
         )
         reservation_id = _operation_id(
-            "llm_res", user_id, run_id, call_index, operation_key
+            "llm_res",
+            user_id,
+            run_id,
+            call_index,
+            attempt_index,
+            provider_id,
+            operation_key,
         )
         raw = self.store.reserve_llm_credits(
             reservation_id=reservation_id,
             user_id=int(user_id),
             run_id=str(run_id),
             call_index=int(call_index),
+            attempt_index=int(attempt_index),
+            provider_id=provider_id,
             reserved_micro=int(amount_micro),
             operation_key=operation_key,
             request_digest=request_digest,

--- a/dashboard/backend/domain/model_providers/repository.py
+++ b/dashboard/backend/domain/model_providers/repository.py
@@ -137,7 +137,7 @@ class ModelProviderStore:
                     provider_id, display_name, adapter_type, approved_base_url,
                     capabilities_json, byok_enabled, platform_enabled, status,
                     created_at, updated_at
-                ) VALUES (?, ?, ?, ?, ?, 1, ?, 'enabled', ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, 'enabled', ?, ?)
                 ON CONFLICT(provider_id) DO NOTHING
                 """,
                 (
@@ -146,6 +146,7 @@ class ModelProviderStore:
                     item["adapter_type"],
                     item["approved_base_url"],
                     serialize_capabilities(item["capabilities"]),
+                    int(bool(item.get("byok_enabled", True))),
                     int(bool(item.get("platform_enabled", False))),
                     now,
                     now,

--- a/dashboard/backend/domain/model_providers/repository_common.py
+++ b/dashboard/backend/domain/model_providers/repository_common.py
@@ -75,11 +75,21 @@ SUPPORTED_ADAPTER_TYPES: set[str] = {
 _PROVIDER_ID_PATTERN = re.compile(r"^[a-z0-9_]{2,64}$")
 
 
+COMMONSTACK_MODEL_ALLOWLIST = (
+    "openai/gpt-5.5",
+    "google/gemini-3.1-pro-preview",
+    "anthropic/claude-sonnet-4-6",
+    "deepseek/deepseek-v4-pro",
+    "qwen/qwen3.7-plus",
+)
+
+
 SEEDED_PROVIDERS = (
     {
         "provider_id": "openrouter",
         "display_name": "OpenRouter",
         "adapter_type": "openrouter",
+        "byok_enabled": True,
         "platform_enabled": True,
         "approved_base_url": "https://openrouter.ai/api/v1",
         "capabilities": ProviderCapabilities(
@@ -90,6 +100,25 @@ SEEDED_PROVIDERS = (
             reasoning_token_usage=True,
             reported_monetary_cost=True,
             supported_parameters=("temperature", "max_output_tokens", "reasoning_effort"),
+        ),
+    },
+    {
+        "provider_id": "commonstack",
+        "display_name": "CommonStack",
+        "adapter_type": "openai_compatible",
+        "approved_base_url": "https://api.commonstack.ai/v1",
+        "byok_enabled": False,
+        "platform_enabled": True,
+        "capabilities": ProviderCapabilities(
+            model_discovery=True,
+            system_messages=True,
+            reasoning=True,
+            supported_parameters=(
+                "temperature",
+                "max_output_tokens",
+                "reasoning_effort",
+            ),
+            model_allowlist=COMMONSTACK_MODEL_ALLOWLIST,
         ),
     },
     {

--- a/dashboard/backend/domain/model_providers/repository_postgres.py
+++ b/dashboard/backend/domain/model_providers/repository_postgres.py
@@ -211,7 +211,7 @@ class PostgresModelProviderStore:
                             provider_id, display_name, adapter_type, approved_base_url,
                             capabilities_json, byok_enabled, platform_enabled,
                             status, created_at, updated_at
-                        ) VALUES (%s, %s, %s, %s, %s, TRUE, %s, 'enabled', %s, %s)
+                        ) VALUES (%s, %s, %s, %s, %s, %s, %s, 'enabled', %s, %s)
                         ON CONFLICT (provider_id) DO NOTHING
                         """,
                         (
@@ -220,6 +220,7 @@ class PostgresModelProviderStore:
                             item["adapter_type"],
                             item["approved_base_url"],
                             serialize_capabilities(item["capabilities"]),
+                            bool(item.get("byok_enabled", True)),
                             bool(item.get("platform_enabled", False)),
                             now,
                             now,

--- a/dashboard/backend/domain/model_providers/service.py
+++ b/dashboard/backend/domain/model_providers/service.py
@@ -83,6 +83,7 @@ class CredentialResolutionError(LLMExecutionError):
 
 _ENVIRONMENT_PLATFORM_KEY_NAMES = {
     "openrouter": "OPENROUTER_API_KEY",
+    "commonstack": "COMMONSTACK_API_KEY",
 }
 
 
@@ -208,6 +209,9 @@ class ModelProviderService:
                     ),
                 )
             )
+        # Preserve the repository's existing order while keeping OpenRouter as
+        # the preferred platform lane before the CommonStack fallback.
+        options.sort(key=lambda option: option.provider_id == "commonstack")
         return options
 
     def get_platform_credential(

--- a/dashboard/backend/infrastructure/llm/execution/adapters/base.py
+++ b/dashboard/backend/infrastructure/llm/execution/adapters/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import json
 import os
 from typing import Any, Callable, Protocol
 from urllib.parse import urlsplit
@@ -41,6 +42,26 @@ FINISH_REASON_MAX_TOKENS = "max_tokens"
 # provider may put anything in this field, and a long value must not turn a
 # successful call into ``response_invalid`` when the result model rejects it.
 _FINISH_REASON_MAX_LENGTH = 32
+
+_PROVIDER_ERROR_PAYLOAD_MAX_BYTES = 4096
+_QUOTA_ERROR_IDENTIFIERS = frozenset(
+    {
+        "in_flight_budget_exhausted",
+        "insufficient_quota",
+        "quota_exceeded",
+        "quota_exhausted",
+        "insufficient_balance",
+        "credit_balance_exhausted",
+    }
+)
+_QUOTA_ERROR_PHRASES = (
+    "insufficient balance",
+    "insufficient credits",
+    "quota exceeded",
+    "quota exhausted",
+    "exceeded your current quota",
+    "not enough credits",
+)
 
 
 def normalize_finish_reason(value: Any) -> str | None:
@@ -117,15 +138,74 @@ def usage_from_fields(input_tokens: Any, output_tokens: Any) -> LLMUsage | None:
     return LLMUsage(input_tokens=parsed_input, output_tokens=parsed_output)
 
 
+def _provider_status_codes(exc: Exception) -> tuple[int, ...]:
+    """Read provider statuses without trusting arbitrary exception text."""
+
+    statuses: list[int] = []
+    for value in (
+        getattr(exc, "status_code", None),
+        getattr(getattr(exc, "response", None), "status_code", None),
+    ):
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, int):
+            statuses.append(value)
+    return tuple(statuses)
+
+
+def _bounded_error_payload(exc: Exception) -> dict[str, Any]:
+    """Parse only a small structured provider error body, if one is present."""
+
+    response = getattr(exc, "response", None)
+    content = getattr(response, "content", b"")
+    if isinstance(content, str):
+        content = content.encode("utf-8", errors="ignore")
+    elif isinstance(content, bytearray):
+        content = bytes(content)
+    if not isinstance(content, bytes) or len(content) > _PROVIDER_ERROR_PAYLOAD_MAX_BYTES:
+        return {}
+    try:
+        parsed = json.loads(content.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _structured_quota_signal(payload: dict[str, Any]) -> bool:
+    """Match allowlisted code/type/message fields only."""
+
+    identifiers: list[Any] = [payload.get("code"), payload.get("type")]
+    messages: list[Any] = [payload.get("message")]
+    error = payload.get("error")
+    if isinstance(error, dict):
+        identifiers.extend((error.get("code"), error.get("type")))
+        messages.append(error.get("message"))
+
+    for value in identifiers:
+        if not isinstance(value, str):
+            continue
+        normalized = value.strip().lower()
+        if normalized in _QUOTA_ERROR_IDENTIFIERS:
+            return True
+    for value in messages:
+        if isinstance(value, str) and any(
+            phrase in value.strip().lower() for phrase in _QUOTA_ERROR_PHRASES
+        ):
+            return True
+    return False
+
+
 def map_provider_error(exc: Exception) -> ProviderExecutionError:
     if isinstance(exc, (TimeoutError, httpx.TimeoutException)) or "timeout" in type(exc).__name__.lower():
         return ProviderExecutionError(ExecutionErrorCategory.PROVIDER_TIMEOUT)
-    status_code = getattr(exc, "status_code", None)
-    if status_code in {401, 403}:
+    status_codes = _provider_status_codes(exc)
+    if any(status in {401, 403} for status in status_codes):
         return ProviderExecutionError(ExecutionErrorCategory.CREDENTIAL_INVALID)
-    response = getattr(exc, "response", None)
-    if getattr(response, "status_code", None) in {401, 403}:
-        return ProviderExecutionError(ExecutionErrorCategory.CREDENTIAL_INVALID)
+    if any(status == 402 for status in status_codes):
+        return ProviderExecutionError(ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED)
+    if not status_codes or any(400 <= status < 500 for status in status_codes):
+        if _structured_quota_signal(_bounded_error_payload(exc)):
+            return ProviderExecutionError(ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED)
     if isinstance(exc, (UnsafeProviderAddress, ProviderAddressResolutionError)):
         return ProviderExecutionError(ExecutionErrorCategory.PROVIDER_UNAVAILABLE)
     return ProviderExecutionError(ExecutionErrorCategory.PROVIDER_UNAVAILABLE)

--- a/dashboard/backend/infrastructure/llm/execution/client.py
+++ b/dashboard/backend/infrastructure/llm/execution/client.py
@@ -152,18 +152,25 @@ class AnthropicCompatibleExecutionClient:
         if not self._completed_results:
             return None
 
-        expected_identity = (
-            self.handoff.billing_mode,
-            self.handoff.provider_id,
-            self.handoff.model_id,
-        )
         for result in self._completed_results:
             if (
                 result.billing.billing_source,
-                result.provider_id,
                 result.model_id,
-            ) != expected_identity:
+            ) != (self.handoff.billing_mode, self.handoff.model_id):
                 raise RuntimeError("inconsistent LLM execution identity")
+
+        requested_provider_ids = {
+            result.requested_provider_id or self.handoff.provider_id
+            for result in self._completed_results
+        }
+        if requested_provider_ids != {self.handoff.provider_id}:
+            raise RuntimeError("inconsistent requested LLM provider identity")
+
+        provider_ids = tuple(
+            dict.fromkeys(result.provider_id for result in self._completed_results)
+        )
+        provider_mixed = len(provider_ids) > 1
+        provider_id = "mixed" if provider_mixed else provider_ids[0]
 
         first = self._completed_results[0]
 
@@ -171,9 +178,13 @@ class AnthropicCompatibleExecutionClient:
             result.billing.pricing_snapshot for result in self._completed_results
         ]
         pricing_snapshot = (
-            snapshots[0]
-            if all(snapshot == snapshots[0] for snapshot in snapshots[1:])
-            else None
+            None
+            if provider_mixed
+            else (
+                snapshots[0]
+                if all(snapshot == snapshots[0] for snapshot in snapshots[1:])
+                else None
+            )
         )
 
         usage_available = all(
@@ -193,6 +204,16 @@ class AnthropicCompatibleExecutionClient:
         credential_last_fours = {
             result.credential_key_last_four for result in self._completed_results
         }
+        credential_id = (
+            None
+            if provider_mixed or len(credential_ids) != 1
+            else credential_ids.pop()
+        )
+        credential_key_last_four = (
+            None
+            if provider_mixed or len(credential_last_fours) != 1
+            else credential_last_fours.pop()
+        )
 
         if not usage_available:
             outcome = "unavailable"
@@ -205,14 +226,13 @@ class AnthropicCompatibleExecutionClient:
 
         return LLMRunEvidence(
             billing_mode=self.handoff.billing_mode,
-            provider_id=first.provider_id,
+            provider_id=provider_id,
+            requested_provider_id=self.handoff.provider_id,
+            provider_ids=provider_ids,
+            provider_mixed=provider_mixed,
             model_id=first.model_id,
-            credential_id=(credential_ids.pop() if len(credential_ids) == 1 else None),
-            credential_key_last_four=(
-                credential_last_fours.pop()
-                if len(credential_last_fours) == 1
-                else None
-            ),
+            credential_id=credential_id,
+            credential_key_last_four=credential_key_last_four,
             call_count=len(self._completed_results),
             input_tokens=sum(
                 result.usage.input_tokens for result in self._completed_results

--- a/dashboard/backend/infrastructure/llm/execution/errors.py
+++ b/dashboard/backend/infrastructure/llm/execution/errors.py
@@ -13,6 +13,7 @@ class ExecutionErrorCategory(StrEnum):
     RESPONSE_INVALID = "response_invalid"
     USAGE_UNAVAILABLE = "usage_unavailable"
     BILLING_FAILED = "billing_failed"
+    PROVIDER_QUOTA_EXHAUSTED = "provider_quota_exhausted"
     ACCOUNT_RESTRICTED = "account_restricted"
     WORKER_FAILED = "worker_failed"
 
@@ -25,6 +26,9 @@ _SAFE_MESSAGES = {
     ExecutionErrorCategory.RESPONSE_INVALID: "The model returned an invalid response.",
     ExecutionErrorCategory.USAGE_UNAVAILABLE: "The model did not return billable usage.",
     ExecutionErrorCategory.BILLING_FAILED: "Model usage billing could not be completed.",
+    ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED: (
+        "The selected model provider has insufficient balance or quota."
+    ),
     ExecutionErrorCategory.ACCOUNT_RESTRICTED: (
         "Your Credits account is paused. Add Credits to settle model usage "
         "or contact an administrator."

--- a/dashboard/backend/infrastructure/llm/execution/models.py
+++ b/dashboard/backend/infrastructure/llm/execution/models.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from enum import StrEnum
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from dashboard.backend.domain.model_providers.repository_common import (
+    validate_provider_id,
+)
 
 from dashboard.backend.infrastructure.llm.pricing import (
     PRICING_SOURCE_VERSION,
@@ -171,6 +175,13 @@ class LLMRunEvidence(BaseModel):
 
     billing_mode: BillingMode
     provider_id: str = Field(min_length=2, max_length=64)
+    requested_provider_id: str | None = Field(
+        default=None,
+        min_length=2,
+        max_length=64,
+    )
+    provider_ids: tuple[str, ...] = ()
+    provider_mixed: bool = False
     model_id: str = Field(min_length=1, max_length=64)
     credential_id: str | None = Field(default=None, max_length=128)
     credential_key_last_four: str | None = Field(
@@ -188,6 +199,61 @@ class LLMRunEvidence(BaseModel):
     debited_credits_micro: int = Field(ge=0)
     outstanding_credits_micro: int = Field(ge=0)
     outcome: Literal["byok", "settled", "settled_overage", "unavailable"]
+
+    @model_validator(mode="before")
+    @classmethod
+    def populate_provider_attribution(cls, value: object) -> object:
+        if not isinstance(value, dict):
+            return value
+        payload = dict(value)
+        provider_id = payload.get("provider_id")
+        if "requested_provider_id" not in payload:
+            payload["requested_provider_id"] = provider_id
+        if "provider_ids" not in payload:
+            payload["provider_ids"] = (
+                () if provider_id == "mixed" else (provider_id,)
+            )
+        if "provider_mixed" not in payload:
+            payload["provider_mixed"] = provider_id == "mixed"
+        return payload
+
+    @field_validator("provider_id", "requested_provider_id")
+    @classmethod
+    def validate_provider_identifier(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        try:
+            return validate_provider_id(value)
+        except Exception as exc:
+            raise ValueError("invalid provider id") from exc
+
+    @field_validator("provider_ids")
+    @classmethod
+    def validate_provider_ids(cls, values: tuple[str, ...]) -> tuple[str, ...]:
+        try:
+            cleaned = tuple(validate_provider_id(value) for value in values)
+        except Exception as exc:
+            raise ValueError("provider_ids contains an invalid provider id") from exc
+        if len(set(cleaned)) != len(cleaned):
+            raise ValueError("provider_ids must be ordered and unique")
+        return cleaned
+
+    @model_validator(mode="after")
+    def validate_provider_mix(self) -> "LLMRunEvidence":
+        if self.provider_mixed:
+            if self.provider_id != "mixed" or len(self.provider_ids) < 2:
+                raise ValueError("mixed provider evidence requires multiple providers")
+            if (
+                self.credential_id is not None
+                or self.credential_key_last_four is not None
+                or self.pricing_snapshot is not None
+            ):
+                raise ValueError(
+                    "mixed provider evidence cannot claim one credential or price"
+                )
+        elif self.provider_ids != (self.provider_id,):
+            raise ValueError("uniform provider evidence requires one matching provider")
+        return self
 
     @property
     def total_tokens(self) -> int:

--- a/dashboard/backend/infrastructure/llm/execution/models.py
+++ b/dashboard/backend/infrastructure/llm/execution/models.py
@@ -149,6 +149,11 @@ class LLMExecutionResult(BaseModel):
 
     text: str = Field(min_length=1, max_length=120_000)
     provider_id: str = Field(min_length=2, max_length=64)
+    requested_provider_id: str | None = Field(
+        default=None,
+        min_length=2,
+        max_length=64,
+    )
     model_id: str = Field(min_length=1, max_length=64)
     credential_id: str | None = Field(default=None, max_length=128)
     credential_key_last_four: str | None = Field(default=None, min_length=4, max_length=4)

--- a/dashboard/backend/infrastructure/llm/execution/service.py
+++ b/dashboard/backend/infrastructure/llm/execution/service.py
@@ -12,9 +12,16 @@ from dashboard.backend.domain.credits.repository_common import (
 )
 from dashboard.backend.domain.analytics import instrumentation as analytics_instrumentation
 from dashboard.backend.domain.model_providers.models import ProviderRecord
+from dashboard.backend.domain.model_providers.execution_catalog import (
+    UnsupportedExecutionModel,
+)
+from dashboard.backend.domain.model_providers.repository_common import (
+    ProviderNotFoundError,
+)
 from dashboard.backend.domain.model_providers.service import (
     ModelProviderService,
     ResolvedCredential,
+    CredentialResolutionError,
 )
 from dashboard.backend.infrastructure.llm.execution.adapters.base import (
     AdapterResponse,
@@ -106,38 +113,13 @@ class LLMExecutionService:
     def execute(self, request: LLMExecutionRequest) -> LLMExecutionResult:
         """Run exactly one requested model call with its selected payment lane."""
         try:
-            provider = self._resolve_provider(request.provider_id)
-            credential = self._resolve_credential(request)
-            pricing_snapshot = self.pricing_snapshot_factory(
-                request.model_id, request.provider_id
-            )
-            self._validate_pricing_snapshot(request, pricing_snapshot)
-            adapter = self._resolve_adapter(provider)
-
-            if request.billing_mode is BillingMode.BYOK:
-                response = self._complete(adapter, request, credential, provider)
-                usage = self._result_usage(response)
-                billing = self._build_evidence(
-                    request=request,
-                    usage=usage,
-                    provider_cost_usd=response.provider_cost_usd,
-                    pricing_snapshot=pricing_snapshot,
-                )
-                result = self._result(
-                    request=request,
-                    credential=credential,
-                    usage=usage,
-                    billing=billing,
-                    text=response.text,
-                    finish_reason=response.finish_reason,
-                )
+            if request.billing_mode is BillingMode.PLATFORM_CREDITS:
+                result = self._execute_with_platform_failover(request)
             else:
-                result = self._execute_platform(
-                    request=request,
-                    provider=provider,
-                    credential=credential,
-                    adapter=adapter,
-                    pricing_snapshot=pricing_snapshot,
+                result = self._execute_once(
+                    request,
+                    attempt_index=0,
+                    requested_provider_id=request.provider_id,
                 )
             self._emit_model_usage(request, result)
             return result
@@ -171,6 +153,7 @@ class LLMExecutionService:
             ExecutionErrorCategory.CREDENTIAL_INVALID: "credential_invalid",
             ExecutionErrorCategory.PROVIDER_UNAVAILABLE: "provider_unavailable",
             ExecutionErrorCategory.PROVIDER_TIMEOUT: "provider_timeout",
+            ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED: "provider_quota_exhausted",
             ExecutionErrorCategory.BILLING_FAILED: "credits_unavailable",
             ExecutionErrorCategory.ACCOUNT_RESTRICTED: "account_restricted",
         }.get(category, "internal_error")
@@ -193,7 +176,7 @@ class LLMExecutionService:
             source_record_type="run",
             source_record_id=request.run_id,
             correlation_id=request.run_id,
-            provider_id=request.provider_id,
+            provider_id=result.provider_id,
             model_id=request.model_id,
             billing_mode=request.billing_mode.value,
             outcome="succeeded",
@@ -238,6 +221,8 @@ class LLMExecutionService:
         credential: ResolvedCredential,
         adapter: ProviderExecutionAdapter,
         pricing_snapshot: PricingSnapshot,
+        attempt_index: int,
+        requested_provider_id: str,
     ) -> LLMExecutionResult:
         reservation_id: str | None = None
         try:
@@ -248,6 +233,8 @@ class LLMExecutionService:
                         user_id=request.user_id,
                         run_id=request.run_id,
                         call_index=request.call_index,
+                        attempt_index=attempt_index,
+                        provider_id=request.provider_id,
                         amount_micro=reserved_micro,
                     )
                 except CreditAccountRestrictedStoreError as exc:
@@ -302,6 +289,7 @@ class LLMExecutionService:
                 billing=billing,
                 text=response.text,
                 finish_reason=response.finish_reason,
+                requested_provider_id=requested_provider_id,
             )
         except LLMExecutionError as exc:
             self._release_after_failure(reservation_id, exc.category)
@@ -311,6 +299,93 @@ class LLMExecutionService:
                 reservation_id, ExecutionErrorCategory.BILLING_FAILED
             )
             raise LLMExecutionError(ExecutionErrorCategory.BILLING_FAILED) from exc
+
+    def _execute_once(
+        self,
+        request: LLMExecutionRequest,
+        *,
+        attempt_index: int,
+        requested_provider_id: str,
+    ) -> LLMExecutionResult:
+        """Execute one provider attempt, including its own billing lifecycle."""
+
+        provider = self._resolve_provider(request.provider_id)
+        credential = self._resolve_credential(request)
+        pricing_snapshot = self.pricing_snapshot_factory(
+            request.model_id, request.provider_id
+        )
+        self._validate_pricing_snapshot(request, pricing_snapshot)
+        adapter = self._resolve_adapter(provider)
+
+        if request.billing_mode is BillingMode.BYOK:
+            response = self._complete(adapter, request, credential, provider)
+            usage = self._result_usage(response)
+            billing = self._build_evidence(
+                request=request,
+                usage=usage,
+                provider_cost_usd=response.provider_cost_usd,
+                pricing_snapshot=pricing_snapshot,
+            )
+            return self._result(
+                request=request,
+                credential=credential,
+                usage=usage,
+                billing=billing,
+                text=response.text,
+                finish_reason=response.finish_reason,
+                requested_provider_id=requested_provider_id,
+            )
+
+        return self._execute_platform(
+            request=request,
+            provider=provider,
+            credential=credential,
+            adapter=adapter,
+            pricing_snapshot=pricing_snapshot,
+            attempt_index=attempt_index,
+            requested_provider_id=requested_provider_id,
+        )
+
+    def _execute_with_platform_failover(
+        self,
+        request: LLMExecutionRequest,
+    ) -> LLMExecutionResult:
+        """Apply the one-way OpenRouter quota failover policy."""
+
+        try:
+            return self._execute_once(
+                request,
+                attempt_index=0,
+                requested_provider_id=request.provider_id,
+            )
+        except LLMExecutionError as primary_error:
+            if (
+                request.provider_id != "openrouter"
+                or primary_error.category
+                is not ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED
+            ):
+                raise
+
+            try:
+                self.providers.preflight_execution_model(
+                    "commonstack", request.model_id
+                )
+                self.providers.preflight_platform_credential("commonstack")
+            except (
+                ProviderNotFoundError,
+                CredentialResolutionError,
+                UnsupportedExecutionModel,
+            ):
+                raise primary_error
+
+            fallback_request = request.model_copy(
+                update={"provider_id": "commonstack"}
+            )
+            return self._execute_once(
+                fallback_request,
+                attempt_index=1,
+                requested_provider_id=request.provider_id,
+            )
 
     def _resolve_provider(self, provider_id: str) -> ProviderRecord:
         store = getattr(self.providers, "store", None)
@@ -451,11 +526,13 @@ class LLMExecutionService:
         billing: BillingEvidence,
         text: str,
         finish_reason: str | None = None,
+        requested_provider_id: str | None = None,
     ) -> LLMExecutionResult:
         try:
             return LLMExecutionResult(
                 text=text,
                 provider_id=request.provider_id,
+                requested_provider_id=requested_provider_id,
                 model_id=request.model_id,
                 credential_id=credential.credential_id,
                 credential_key_last_four=credential.key_last_four,

--- a/dashboard/backend/tests/domain/analytics/test_backfill.py
+++ b/dashboard/backend/tests/domain/analytics/test_backfill.py
@@ -11,6 +11,7 @@ from dashboard.backend.domain.analytics.backfill import (
     AuthoritativeBackfillSource,
     BackfillCandidate,
     BackfillCollection,
+    _usage_candidate,
     backfill_analytics,
 )
 from dashboard.backend.domain.analytics.repository import AnalyticsStore
@@ -18,6 +19,40 @@ from dashboard.backend.domain.analytics.service import AnalyticsService
 
 
 NOW = datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc)
+
+
+def test_one_call_backfill_uses_actual_provider_after_failover():
+    candidate = _usage_candidate(
+        {
+            "run_id": "fallback-one-call",
+            "created_at": NOW.isoformat(),
+            "metadata": {
+                "llm_execution": {
+                    "billing_mode": "platform_credits",
+                    "requested_provider_id": "openrouter",
+                    "provider_id": "commonstack",
+                    "provider_ids": ["commonstack"],
+                    "provider_mixed": False,
+                    "model_id": "qwen/qwen3.7-plus",
+                    "call_count": 1,
+                    "input_tokens": 40,
+                    "output_tokens": 20,
+                    "usage_available": True,
+                    "provider_cost_usd": 0.001,
+                    "estimated_cost_usd": 0.001,
+                    "pricing_snapshot": None,
+                    "debited_credits_micro": 1_000,
+                    "outstanding_credits_micro": 0,
+                    "outcome": "settled",
+                }
+            },
+        },
+        user_id=1,
+    )
+
+    assert candidate is not None
+    assert candidate.provider_id == "commonstack"
+    assert candidate.model_id == "qwen/qwen3.7-plus"
 
 
 class StaticSource:

--- a/dashboard/backend/tests/domain/analytics/test_models.py
+++ b/dashboard/backend/tests/domain/analytics/test_models.py
@@ -16,6 +16,10 @@ from dashboard.backend.domain.analytics.models import (
     FrontendAnalyticsEvent,
     sanitize_server_properties,
 )
+from dashboard.backend.infrastructure.llm.execution.errors import (
+    ExecutionErrorCategory,
+    LLMExecutionError,
+)
 
 
 NOW = datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc)
@@ -181,3 +185,23 @@ def test_stored_event_accepts_safe_server_usage_metadata():
     )
     assert record.event_group == "resource"
     assert record.properties["cost_micro_usd"] == 123
+
+
+def test_quota_exhausted_error_message_is_fixed():
+    error = LLMExecutionError(ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED)
+    assert str(error) == "The selected model provider has insufficient balance or quota."
+
+
+def test_safe_error_accepts_provider_quota_exhausted():
+    record = AnalyticsEventRecord.model_validate(
+        _record_payload(
+            event_name="safe_error_recorded",
+            event_group="resource",
+            event_source="server",
+            session_id=None,
+            page_view=None,
+            source_event_id="safe-error:quota-test",
+            error_category="provider_quota_exhausted",
+        )
+    )
+    assert record.error_category == "provider_quota_exhausted"

--- a/dashboard/backend/tests/domain/analytics/test_repository_contract.py
+++ b/dashboard/backend/tests/domain/analytics/test_repository_contract.py
@@ -14,7 +14,10 @@ from dashboard.backend.domain.analytics.query_service import (
     AnalyticsQueryService,
     AnalyticsUserFilters,
 )
-from dashboard.backend.domain.analytics.repository import AnalyticsStore
+from dashboard.backend.domain.analytics.repository import (
+    ANALYTICS_SQLITE_DDL,
+    AnalyticsStore,
+)
 from dashboard.backend.domain.analytics.repository_common import (
     AnalyticsIdempotencyConflictError,
     AnalyticsStoreError,
@@ -117,6 +120,20 @@ def assert_source_event_idempotency_contract(store, user_id):
     changed = replay.model_copy(update={"outcome": "failed"})
     with pytest.raises(AnalyticsIdempotencyConflictError):
         store.append_event(changed)
+
+
+def assert_error_category_contract(store, user_id):
+    event = event_record(
+        user_id,
+        event_name="safe_error_recorded",
+        event_group="resource",
+        event_source="server",
+        source_event_id="safe-error:quota-contract",
+        session_id=None,
+        page_view=None,
+        error_category="provider_quota_exhausted",
+    )
+    assert store.append_event(event).event.error_category == "provider_quota_exhausted"
 
 
 def assert_cursor_contract(store, user_id):
@@ -340,6 +357,41 @@ def test_sqlite_schema_contains_all_foundation_tables(sqlite_contract):
         "analytics_subject_settings",
         "admin_analytics_access_log",
     } <= names
+
+
+def test_sqlite_accepts_provider_quota_exhausted_category(sqlite_contract):
+    store, _admin_id, user_id = sqlite_contract
+    assert_error_category_contract(store, user_id)
+
+
+def test_sqlite_migrates_legacy_error_category_constraint(tmp_path):
+    db_path = tmp_path / "analytics-legacy.db"
+    users = UserStore(db_path=db_path)
+    user = users.create_user(
+        "legacy-analytics-user@example.test",
+        "Legacy Analytics User",
+        "SecurePass1!",
+    )
+    legacy_ddl = ANALYTICS_SQLITE_DDL.replace(
+        "'provider_unavailable', 'provider_quota_exhausted',\n            'credits_unavailable',",
+        "'provider_unavailable', 'credits_unavailable',",
+    )
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(legacy_ddl)
+
+    store = AnalyticsStore(db_path=db_path)
+    event = event_record(
+        int(user["id"]),
+        event_id="10000000-0000-4000-8000-000000000005",
+        event_name="safe_error_recorded",
+        event_group="resource",
+        event_source="server",
+        source_event_id="safe-error:quota-migration",
+        session_id=None,
+        page_view=None,
+        error_category="provider_quota_exhausted",
+    )
+    assert store.append_event(event).created is True
 
 
 def test_sqlite_runs_shared_event_contracts(sqlite_contract):

--- a/dashboard/backend/tests/domain/analytics/test_repository_contract.py
+++ b/dashboard/backend/tests/domain/analytics/test_repository_contract.py
@@ -394,6 +394,36 @@ def test_sqlite_migrates_legacy_error_category_constraint(tmp_path):
     assert store.append_event(event).created is True
 
 
+def test_sqlite_defers_error_category_migration_until_users_table_exists(tmp_path):
+    db_path = tmp_path / "analytics-before-users.db"
+    legacy_ddl = ANALYTICS_SQLITE_DDL.replace(
+        "'provider_unavailable', 'provider_quota_exhausted',\n            'credits_unavailable',",
+        "'provider_unavailable', 'credits_unavailable',",
+    )
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(legacy_ddl)
+
+    store = AnalyticsStore(db_path=db_path)
+    user = UserStore(db_path=db_path).create_user(
+        "deferred-analytics-user@example.test",
+        "Deferred Analytics User",
+        "SecurePass1!",
+    )
+    event = event_record(
+        int(user["id"]),
+        event_id="10000000-0000-4000-8000-000000000006",
+        event_name="safe_error_recorded",
+        event_group="resource",
+        event_source="server",
+        source_event_id="safe-error:quota-deferred-migration",
+        session_id=None,
+        page_view=None,
+        error_category="provider_quota_exhausted",
+    )
+
+    assert store.append_event(event).created is True
+
+
 def test_sqlite_runs_shared_event_contracts(sqlite_contract):
     store, _admin_id, user_id = sqlite_contract
     assert_event_idempotency_contract(store, user_id)

--- a/dashboard/backend/tests/domain/analytics/test_repository_postgres.py
+++ b/dashboard/backend/tests/domain/analytics/test_repository_postgres.py
@@ -24,6 +24,7 @@ from dashboard.backend.tests.domain.analytics.test_repository_contract import (
     assert_pr2_query_contract,
     assert_source_event_idempotency_contract,
     assert_subject_and_access_contract,
+    assert_error_category_contract,
 )
 
 
@@ -154,6 +155,7 @@ def test_postgres_runs_shared_event_contracts(postgres_contract_store):
     store, _admin_id, user_id = postgres_contract_store
     assert_event_idempotency_contract(store, user_id)
     assert_source_event_idempotency_contract(store, user_id)
+    assert_error_category_contract(store, user_id)
 
 
 @pg_only

--- a/dashboard/backend/tests/domain/credits/test_promotion_grants.py
+++ b/dashboard/backend/tests/domain/credits/test_promotion_grants.py
@@ -140,6 +140,8 @@ def test_welcome_grant_funds_platform_credit_reservations(tmp_path):
         user_id=1,
         run_id="welcome-credit-run",
         call_index=0,
+        provider_id="openrouter",
+        attempt_index=0,
         amount_micro=1_000_000,
     )
 
@@ -159,5 +161,7 @@ def test_restricted_account_receives_campaign_but_cannot_spend_it(tmp_path):
             user_id=1,
             run_id="restricted-run",
             call_index=0,
+            provider_id="openrouter",
+            attempt_index=0,
             amount_micro=1,
         )

--- a/dashboard/backend/tests/domain/credits/test_repository.py
+++ b/dashboard/backend/tests/domain/credits/test_repository.py
@@ -16,6 +16,9 @@ from dashboard.backend.domain.credits.repository_common import (
     CreditAccountRestrictedStoreError,
     LLMReservationConflictError,
 )
+from dashboard.backend.domain.model_providers.repository_common import (
+    ModelProviderStoreError,
+)
 
 
 def _store(tmp_path) -> CreditsStore:
@@ -107,6 +110,8 @@ def _settle_activity_call(
         user_id=user_id,
         run_id=run_id,
         call_index=call_index,
+        provider_id=provider_id,
+        attempt_index=0,
         reserved_micro=actual_micro,
         operation_key=f"reserve:{reservation_id}",
         request_digest=f"{user_id}{call_index}".ljust(64, "a")[:64],
@@ -249,17 +254,85 @@ def test_sqlite_migrates_legacy_reservation_settlement_constraint(tmp_path):
             "SELECT sql FROM sqlite_master WHERE name = 'credit_llm_reservations'"
         ).fetchone()[0]
         row = conn.execute(
-            "SELECT reserved_micro, operation_key FROM credit_llm_reservations"
+            "SELECT reserved_micro, operation_key, attempt_index, provider_id "
+            "FROM credit_llm_reservations"
         ).fetchone()
         usage = conn.execute(
             "SELECT operation_key, amount_micro FROM credit_llm_usage_entries"
         ).fetchone()
 
     assert "settled_micro <= reserved_micro" not in "".join(schema.lower().split())
-    assert tuple(row) == (1000, "legacy-operation")
+    assert tuple(row) == (1000, "legacy-operation", 0, None)
     assert tuple(usage) == ("legacy-usage", -100)
     assert settled["settled_micro"] == 1000
     assert settled["outstanding_micro"] == 200
+
+
+def test_provider_attempts_have_independent_reservations_for_one_logical_call(
+    tmp_path,
+):
+    store = _store(tmp_path)
+    _pending_order(store, amount_usd_cents=100, credits_micro=1_000_000)
+    _pay_order(store, amount_usd_cents=100)
+
+    primary = store.reserve_llm_credits(
+        reservation_id="attempt-primary",
+        user_id=1,
+        run_id="attempt-run",
+        call_index=3,
+        attempt_index=0,
+        provider_id="openrouter",
+        reserved_micro=100_000,
+        operation_key="attempt-primary-operation",
+        request_digest="a" * 64,
+    )
+    store.release_llm_credits(
+        primary["reservation_id"], reason="provider_quota_exhausted"
+    )
+    fallback = store.reserve_llm_credits(
+        reservation_id="attempt-fallback",
+        user_id=1,
+        run_id="attempt-run",
+        call_index=3,
+        attempt_index=1,
+        provider_id="commonstack",
+        reserved_micro=100_000,
+        operation_key="attempt-fallback-operation",
+        request_digest="b" * 64,
+    )
+
+    assert primary["attempt_index"] == 0
+    assert primary["provider_id"] == "openrouter"
+    assert fallback["attempt_index"] == 1
+    assert fallback["provider_id"] == "commonstack"
+
+
+def test_reservation_attempt_identity_is_validated_and_idempotent(tmp_path):
+    store = _store(tmp_path)
+    _pending_order(store, amount_usd_cents=100, credits_micro=1_000_000)
+    _pay_order(store, amount_usd_cents=100)
+    payload = {
+        "reservation_id": "attempt-validation",
+        "user_id": 1,
+        "run_id": "attempt-validation-run",
+        "call_index": 0,
+        "attempt_index": 0,
+        "provider_id": "openrouter",
+        "reserved_micro": 100_000,
+        "operation_key": "attempt-validation-operation",
+        "request_digest": "v" * 64,
+    }
+    store.reserve_llm_credits(**payload)
+    assert store.reserve_llm_credits(**payload)["attempt_index"] == 0
+
+    with pytest.raises(ValueError, match="attempt_index"):
+        store.reserve_llm_credits(**{**payload, "attempt_index": -1})
+    with pytest.raises(ModelProviderStoreError, match="provider id"):
+        store.reserve_llm_credits(**{**payload, "provider_id": " "})
+    with pytest.raises(LLMReservationConflictError, match="different input"):
+        store.reserve_llm_credits(**{**payload, "provider_id": "commonstack"})
+    with pytest.raises(LLMReservationConflictError, match="different input"):
+        store.reserve_llm_credits(**{**payload, "attempt_index": 1})
 
 
 def test_llm_overage_debits_the_hold_and_restricts_the_account(tmp_path):
@@ -271,6 +344,8 @@ def test_llm_overage_debits_the_hold_and_restricts_the_account(tmp_path):
         user_id=1,
         run_id="run-overage",
         call_index=0,
+        provider_id="openrouter",
+        attempt_index=0,
         reserved_micro=1_000_000,
         operation_key="llm-reserve-overage",
         request_digest="a" * 64,
@@ -322,6 +397,8 @@ def test_llm_overage_debits_the_hold_and_restricts_the_account(tmp_path):
             user_id=1,
             run_id="run-blocked",
             call_index=0,
+            provider_id="openrouter",
+            attempt_index=0,
             reserved_micro=1,
             operation_key="llm-reserve-blocked",
             request_digest="b" * 64,
@@ -356,6 +433,8 @@ def test_llm_overage_uses_unreserved_grant_before_restricting(tmp_path):
         user_id=1,
         run_id="run-covered-overage",
         call_index=0,
+        provider_id="openrouter",
+        attempt_index=0,
         reserved_micro=1_000_000,
         operation_key="llm-reserve-covered-overage",
         request_digest="h" * 64,
@@ -394,6 +473,8 @@ def test_llm_overage_does_not_spend_another_open_reservation(tmp_path):
         user_id=1,
         run_id="run-current",
         call_index=0,
+        provider_id="openrouter",
+        attempt_index=0,
         reserved_micro=1_000_000,
         operation_key="llm-reserve-current",
         request_digest="i" * 64,
@@ -403,6 +484,8 @@ def test_llm_overage_does_not_spend_another_open_reservation(tmp_path):
         user_id=1,
         run_id="run-protected",
         call_index=0,
+        provider_id="openrouter",
+        attempt_index=0,
         reserved_micro=500_000,
         operation_key="llm-reserve-protected",
         request_digest="j" * 64,
@@ -435,6 +518,8 @@ def test_grant_recovers_llm_overage_and_reinstates_account(tmp_path):
         user_id=1,
         run_id="run-recover",
         call_index=0,
+        provider_id="openrouter",
+        attempt_index=0,
         reserved_micro=1_000_000,
         operation_key="llm-reserve-recover",
         request_digest="c" * 64,
@@ -894,6 +979,8 @@ def test_activity_omits_released_run_without_settled_usage(tmp_path):
         user_id=1,
         run_id="run-released-without-charge",
         call_index=0,
+        provider_id="openrouter",
+        attempt_index=0,
         reserved_micro=1_000,
         operation_key="activity-released-reserve",
         request_digest="r" * 64,

--- a/dashboard/backend/tests/domain/credits/test_repository.py
+++ b/dashboard/backend/tests/domain/credits/test_repository.py
@@ -892,8 +892,8 @@ def test_activity_summarizes_mixed_and_malformed_evidence(tmp_path):
         run_id="run-mixed",
         call_index=1,
         actual_micro=200,
-        provider_id="openai",
-        model_id="model-b",
+        provider_id="commonstack",
+        model_id="model-a",
     )
     _settle_activity_call(
         store,
@@ -912,9 +912,9 @@ def test_activity_summarizes_mixed_and_malformed_evidence(tmp_path):
     unknown = next(item for item in items if item.get("run_id") == "run-unknown")
 
     assert mixed["provider_id"] is None
-    assert mixed["model_id"] is None
+    assert mixed["model_id"] == "model-a"
     assert mixed["provider_mixed"] is True
-    assert mixed["model_mixed"] is True
+    assert mixed["model_mixed"] is False
     assert unknown["amount_micro"] == -300
     assert unknown["provider_id"] is None
     assert unknown["model_id"] is None

--- a/dashboard/backend/tests/domain/credits/test_repository_postgres.py
+++ b/dashboard/backend/tests/domain/credits/test_repository_postgres.py
@@ -21,6 +21,7 @@ from dashboard.backend.domain.credits.repository_common import (
     GrantPoolInsufficientError,
     GrantReclaimExceedsAvailableError,
     IdempotencyConflictError,
+    LLMReservationConflictError,
 )
 from dashboard.backend.tests._postgres_testing import require_local_postgres_url
 from dashboard.backend.tests.domain.credits.test_grant_repository_contract import (
@@ -72,6 +73,18 @@ def test_postgres_schema_allows_settlement_overage_and_migrates_legacy_check():
     assert (
         "credit_llm_reservations_settled_micro_nonnegative_check"
         in pg_module.CREDITS_POSTGRES_GRANT_MIGRATION_DDL
+    )
+
+
+def test_postgres_schema_tracks_provider_attempt_identity():
+    assert "provider_id TEXT" in pg_module.CREDITS_POSTGRES_DDL
+    assert "attempt_index INTEGER NOT NULL DEFAULT 0" in pg_module.CREDITS_POSTGRES_DDL
+    assert (
+        "credit_llm_reservations_logical_attempt_key"
+        in pg_module.CREDITS_POSTGRES_DDL
+    )
+    assert "ARRAY['user_id', 'run_id', 'call_index']::name[]" in (
+        pg_module.CREDITS_POSTGRES_GRANT_MIGRATION_DDL
     )
 
 
@@ -465,6 +478,8 @@ def test_postgres_llm_overage_uses_unreserved_balance(pg_credits_store):
         user_id=1,
         run_id="pg-partial-overage-run",
         call_index=0,
+        provider_id="openrouter",
+        attempt_index=0,
         reserved_micro=1_000_000,
         operation_key="pg-partial-overage-operation",
         request_digest="p" * 64,
@@ -559,6 +574,8 @@ def test_postgres_llm_overage_uses_grant_before_restricting(pg_credits_store):
         user_id=1,
         run_id="pg-covered-overage-run",
         call_index=0,
+        provider_id="openrouter",
+        attempt_index=0,
         reserved_micro=1_000_000,
         operation_key="pg-covered-overage-operation",
         request_digest="q" * 64,
@@ -574,6 +591,51 @@ def test_postgres_llm_overage_uses_grant_before_restricting(pg_credits_store):
     assert settled["outstanding_micro"] == 0
     assert settled["grant_debited_micro"] == 1_250_000
     assert store.get_account_billing_state(1)["account_status"] == "active"
+
+
+@pg_only
+def test_postgres_provider_attempts_share_logical_call_after_release(pg_credits_store):
+    store = pg_credits_store
+    _pending_order(store, cents=100)
+    _pay_order(store, cents=100)
+    primary = store.reserve_llm_credits(
+        reservation_id="pg-attempt-primary",
+        user_id=1,
+        run_id="pg-attempt-run",
+        call_index=4,
+        attempt_index=0,
+        provider_id="openrouter",
+        reserved_micro=100_000,
+        operation_key="pg-attempt-primary-operation",
+        request_digest="a" * 64,
+    )
+    store.release_llm_credits(primary["reservation_id"], reason="provider_quota_exhausted")
+    fallback = store.reserve_llm_credits(
+        reservation_id="pg-attempt-fallback",
+        user_id=1,
+        run_id="pg-attempt-run",
+        call_index=4,
+        attempt_index=1,
+        provider_id="commonstack",
+        reserved_micro=100_000,
+        operation_key="pg-attempt-fallback-operation",
+        request_digest="c" * 64,
+    )
+    assert fallback["attempt_index"] == 1
+    assert fallback["provider_id"] == "commonstack"
+
+    with pytest.raises(LLMReservationConflictError):
+        store.reserve_llm_credits(
+            reservation_id="pg-attempt-fallback",
+            user_id=1,
+            run_id="pg-attempt-run",
+            call_index=4,
+            attempt_index=1,
+            provider_id="openrouter",
+            reserved_micro=100_000,
+            operation_key="pg-attempt-fallback-operation",
+            request_digest="c" * 64,
+        )
 
 
 @pg_only
@@ -659,6 +721,8 @@ def test_postgres_activity_aggregates_calls_before_pagination(pg_credits_store):
             user_id=1,
             run_id="run-pg-activity",
             call_index=call_index,
+            provider_id="openrouter",
+            attempt_index=0,
             reserved_micro=amount,
             operation_key=f"reserve:{reservation_id}",
             request_digest=str(call_index).ljust(64, "b"),

--- a/dashboard/backend/tests/domain/credits/test_service.py
+++ b/dashboard/backend/tests/domain/credits/test_service.py
@@ -189,6 +189,8 @@ def test_checkout_pays_model_overage_and_restores_account(tmp_path):
         user_id=1,
         run_id="service-overage",
         call_index=0,
+        provider_id="openrouter",
+        attempt_index=0,
         amount_micro=1_000_000,
     )
     service.settle_llm_credits(

--- a/dashboard/backend/tests/domain/model_providers/test_repository_contract.py
+++ b/dashboard/backend/tests/domain/model_providers/test_repository_contract.py
@@ -10,6 +10,12 @@ from cryptography.fernet import Fernet
 from dashboard.backend.domain.brokers import repository as broker_repository
 from dashboard.backend.domain.brokers.repository import _encrypt
 from dashboard.backend.domain.model_providers.repository import ModelProviderStore
+from dashboard.backend.domain.model_providers.execution_catalog import (
+    UnsupportedExecutionModel,
+    list_execution_model_routes,
+    resolve_execution_model_route,
+)
+from dashboard.backend.domain.model_providers.models import ProviderRecord
 from dashboard.backend.domain.model_providers.repository_common import CredentialConflictError
 
 
@@ -80,6 +86,36 @@ def test_seed_initialization_does_not_overwrite_admin_configuration(store_factor
 
 def test_seeded_openrouter_is_platform_enabled(store):
     assert store.get_provider("openrouter")["platform_enabled"] is True
+
+
+def test_seeded_commonstack_is_platform_only_with_verified_model_allowlist(store):
+    provider = store.get_provider("commonstack")
+
+    assert provider["adapter_type"] == "openai_compatible"
+    assert provider["approved_base_url"] == "https://api.commonstack.ai/v1"
+    assert provider["byok_enabled"] is False
+    assert provider["platform_enabled"] is True
+    assert provider["capabilities"].model_allowlist == (
+        "openai/gpt-5.5",
+        "google/gemini-3.1-pro-preview",
+        "anthropic/claude-sonnet-4-6",
+        "deepseek/deepseek-v4-pro",
+        "qwen/qwen3.7-plus",
+    )
+
+
+def test_commonstack_routes_only_the_verified_catalog_models(store):
+    provider = ProviderRecord.model_validate(store.get_provider("commonstack"))
+
+    assert [route.catalog_id for route in list_execution_model_routes(provider)] == [
+        "anthropic/claude-sonnet-4-6",
+        "openai/gpt-5.5",
+        "google/gemini-3.1-pro-preview",
+        "deepseek/deepseek-v4-pro",
+        "qwen/qwen3.7-plus",
+    ]
+    with pytest.raises(UnsupportedExecutionModel):
+        resolve_execution_model_route(provider, "anthropic/claude-haiku-4-5")
 
 
 def test_legacy_openrouter_platform_flag_migrates_when_environment_key_exists(

--- a/dashboard/backend/tests/domain/model_providers/test_service.py
+++ b/dashboard/backend/tests/domain/model_providers/test_service.py
@@ -424,6 +424,19 @@ def test_platform_resolver_uses_openrouter_environment_key_when_store_is_empty(
     assert resolved.secret == "sk-or-env-test-abcd"
 
 
+def test_commonstack_platform_credential_uses_explicit_environment_mapping(
+    tmp_path, monkeypatch
+):
+    service, _store = _service(tmp_path, FakeAdapter())
+    monkeypatch.setenv("COMMONSTACK_API_KEY", "cs-fake-environment-abcd")
+
+    resolved = service.resolve_platform_credential("commonstack")
+
+    assert resolved.provider_id == "commonstack"
+    assert resolved.key_last_four == "abcd"
+    assert resolved.secret == "cs-fake-environment-abcd"
+
+
 def test_verified_stored_platform_credential_precedes_environment_key(
     tmp_path, monkeypatch
 ):
@@ -440,6 +453,40 @@ def test_verified_stored_platform_credential_precedes_environment_key(
 
     assert resolved.key_last_four == "wxyz"
     assert resolved.secret == "sk-or-stored-test-wxyz"
+
+
+def test_verified_stored_commonstack_credential_precedes_environment_key(
+    tmp_path, monkeypatch
+):
+    service, store = _service(tmp_path, FakeAdapter())
+    store.upsert_platform_credential(
+        provider_id="commonstack",
+        secret="cs-fake-stored-test-wxyz",
+        status="verified",
+    )
+    monkeypatch.setenv("COMMONSTACK_API_KEY", "cs-fake-environment-abcd")
+
+    resolved = service.resolve_platform_credential("commonstack")
+
+    assert resolved.key_last_four == "wxyz"
+    assert resolved.secret == "cs-fake-stored-test-wxyz"
+
+
+def test_execution_options_keep_openrouter_ahead_of_commonstack(
+    tmp_path, monkeypatch
+):
+    service, _store = _service(tmp_path, FakeAdapter())
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-fake-options-abcd")
+    monkeypatch.setenv("COMMONSTACK_API_KEY", "cs-fake-options-wxyz")
+
+    provider_ids = [
+        option.provider_id
+        for option in service.list_execution_options(7)
+        if option.platform_credits_available
+    ]
+
+    assert provider_ids.index("openrouter") < provider_ids.index("commonstack")
+    assert "cs-fake-options-wxyz" not in repr(service.list_execution_options(7))
 
 
 def test_environment_fallback_is_provider_specific_and_fails_closed(

--- a/dashboard/backend/tests/infrastructure/llm/test_execution_adapter_model_routes.py
+++ b/dashboard/backend/tests/infrastructure/llm/test_execution_adapter_model_routes.py
@@ -9,7 +9,10 @@ import pytest
 import dashboard.backend.infrastructure.llm.execution.adapters.anthropic as anthropic_module
 import dashboard.backend.infrastructure.llm.execution.adapters.gemini as gemini_module
 import dashboard.backend.infrastructure.llm.execution.adapters.openai as openai_module
-from dashboard.backend.domain.model_providers.models import ProviderRecord
+from dashboard.backend.domain.model_providers.models import (
+    ProviderCapabilities,
+    ProviderRecord,
+)
 from dashboard.backend.infrastructure.llm.execution.models import (
     LLMExecutionRequest,
     LLMMessage,
@@ -172,6 +175,55 @@ def test_openrouter_reasoning_none_disables_reasoning(monkeypatch):
     assert captured["extra_body"] == {
         "reasoning": {"effort": "none", "enabled": False, "exclude": True}
     }
+
+
+def test_commonstack_openai_compatible_route_preserves_reasoning_and_ceiling(
+    monkeypatch,
+):
+    captured = {}
+
+    def create(**kwargs):
+        captured.update(kwargs)
+        return _openai_response("qwen/qwen3.7-plus")
+
+    client = _openai_client(create)
+    monkeypatch.setattr(
+        openai_module,
+        "build_safe_http_client",
+        lambda *_args, **_kwargs: _Closable(),
+    )
+    adapter = openai_module.OpenAICompatibleAdapter(
+        client_factory=lambda **_kwargs: client,
+    )
+    provider = ProviderRecord(
+        provider_id="commonstack",
+        display_name="CommonStack",
+        adapter_type="openai_compatible",
+        approved_base_url="https://api.commonstack.ai/v1",
+        capabilities=ProviderCapabilities(
+            model_allowlist=("qwen/qwen3.7-plus",),
+            reasoning=True,
+        ),
+    )
+    request = LLMExecutionRequest(
+        user_id=7,
+        run_id="run-commonstack-route",
+        call_index=0,
+        billing_mode="platform_credits",
+        provider_id="commonstack",
+        model_id="qwen/qwen3.7-plus",
+        messages=(LLMMessage(role="user", content="Return one word."),),
+        usage_policy=UsagePolicy(max_output_tokens=4096),
+        temperature=0.2,
+        reasoning_effort="high",
+    )
+
+    adapter.complete(request, _credential("commonstack"), provider)
+
+    assert captured["model"] == "qwen/qwen3.7-plus"
+    assert captured["max_tokens"] == 4096
+    assert captured["temperature"] == 0.2
+    assert captured["extra_body"] == {"reasoning": {"effort": "high"}}
 
 
 def test_anthropic_uses_native_model_and_keeps_canonical_result(monkeypatch):

--- a/dashboard/backend/tests/infrastructure/llm/test_execution_client.py
+++ b/dashboard/backend/tests/infrastructure/llm/test_execution_client.py
@@ -6,6 +6,7 @@ from dashboard.backend.infrastructure.llm.execution.models import (
     BillingEvidence,
     BillingMode,
     LLMExecutionResult,
+    LLMRunEvidence,
     LLMUsage,
     PricingSnapshot,
 )
@@ -46,9 +47,12 @@ def _result(
     debited_micro=9_000,
     outstanding_micro=0,
     finish_reason=None,
+    provider_id="openrouter",
+    requested_provider_id="openrouter",
+    credential_key_last_four="1234",
 ):
     snapshot = PricingSnapshot(
-        provider_id="openrouter",
+        provider_id=provider_id,
         model_id="openai/gpt-5.5",
         input_usd_per_million_tokens=5,
         output_usd_per_million_tokens=30,
@@ -56,10 +60,11 @@ def _result(
     )
     return LLMExecutionResult(
         text="BUY",
-        provider_id="openrouter",
+        provider_id=provider_id,
+        requested_provider_id=requested_provider_id,
         model_id="openai/gpt-5.5",
         credential_id="credential-safe-id",
-        credential_key_last_four="1234",
+        credential_key_last_four=credential_key_last_four,
         usage=LLMUsage(
             input_tokens=input_tokens,
             output_tokens=output_tokens,
@@ -118,6 +123,9 @@ def test_client_preserves_compatibility_response_and_aggregates_evidence():
     assert [request.call_index for request in service.requests] == [0, 1]
     assert summary.billing_mode is BillingMode.PLATFORM_CREDITS
     assert summary.provider_id == "openrouter"
+    assert summary.requested_provider_id == "openrouter"
+    assert summary.provider_ids == ("openrouter",)
+    assert summary.provider_mixed is False
     assert summary.model_id == "openai/gpt-5.5"
     assert summary.credential_id == "credential-safe-id"
     assert summary.credential_key_last_four == "1234"
@@ -131,6 +139,60 @@ def test_client_preserves_compatibility_response_and_aggregates_evidence():
     assert summary.debited_credits_micro == 24_000
     assert summary.outstanding_credits_micro == 5_000
     assert summary.outcome == "settled_overage"
+
+
+def test_execution_summary_records_mixed_actual_providers():
+    service = _FakeExecutionService(
+        [
+            _result(
+                provider_id="openrouter",
+                requested_provider_id="openrouter",
+                credential_key_last_four="1111",
+            ),
+            _result(
+                provider_id="commonstack",
+                requested_provider_id="openrouter",
+                credential_key_last_four="2222",
+            ),
+        ]
+    )
+    client = AnthropicCompatibleExecutionClient(
+        execution_service=service,
+        handoff=_handoff(),
+    )
+
+    _create(client)
+    _create(client)
+    summary = client.execution_summary()
+
+    assert summary.requested_provider_id == "openrouter"
+    assert summary.provider_id == "mixed"
+    assert summary.provider_ids == ("openrouter", "commonstack")
+    assert summary.provider_mixed is True
+    assert summary.credential_id is None
+    assert summary.credential_key_last_four is None
+    assert summary.pricing_snapshot is None
+
+
+def test_legacy_run_evidence_infers_uniform_provider_attribution():
+    legacy = LLMRunEvidence.model_validate(
+        {
+            "billing_mode": "platform_credits",
+            "provider_id": "openrouter",
+            "model_id": "openai/gpt-5.5",
+            "call_count": 1,
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "usage_available": True,
+            "debited_credits_micro": 1,
+            "outstanding_credits_micro": 0,
+            "outcome": "settled",
+        }
+    )
+
+    assert legacy.requested_provider_id == "openrouter"
+    assert legacy.provider_ids == ("openrouter",)
+    assert legacy.provider_mixed is False
 
 
 def test_byok_summary_does_not_report_missing_usage_as_zero():

--- a/dashboard/backend/tests/infrastructure/llm/test_platform_credits_env_fallback.py
+++ b/dashboard/backend/tests/infrastructure/llm/test_platform_credits_env_fallback.py
@@ -342,6 +342,8 @@ def test_restricted_account_execution_error_is_actionable(
             user_id=USER_ID,
             run_id="restricted-error-seed",
             call_index=0,
+            provider_id="openrouter",
+            attempt_index=0,
             reserved_micro=1_000_000,
             operation_key="restricted-error-seed",
             request_digest="r" * 64,

--- a/dashboard/backend/tests/infrastructure/llm/test_platform_credits_env_fallback.py
+++ b/dashboard/backend/tests/infrastructure/llm/test_platform_credits_env_fallback.py
@@ -10,7 +10,10 @@ from dashboard.backend.domain.credits.repository import CreditsStore
 from dashboard.backend.domain.credits.service import CreditsService
 from dashboard.backend.domain.model_providers.repository import ModelProviderStore
 from dashboard.backend.domain.model_providers.service import ModelProviderService
-from dashboard.backend.infrastructure.llm.execution.adapters.base import AdapterResponse
+from dashboard.backend.infrastructure.llm.execution.adapters.base import (
+    AdapterResponse,
+    ProviderExecutionError,
+)
 from dashboard.backend.infrastructure.llm.execution.errors import (
     ExecutionErrorCategory,
     LLMExecutionError,
@@ -46,6 +49,19 @@ class FakeExecutionAdapter:
             model_id=request.model_id,
             usage=self.usage,
         )
+
+
+class ScriptedExecutionAdapter:
+    def __init__(self, outcomes):
+        self.outcomes = list(outcomes)
+        self.calls = []
+
+    def complete(self, request, credential, provider):
+        self.calls.append(request)
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
 
 
 def _seed_users(path) -> None:
@@ -151,7 +167,7 @@ def _request(run_id: str) -> LLMExecutionRequest:
     )
 
 
-def _execution_service(tmp_path, monkeypatch, adapter):
+def _execution_service(tmp_path, monkeypatch, adapter, *, adapters=None):
     monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-execution-test-abcd")
     provider_store = ModelProviderStore(tmp_path / "providers.db")
     _enable_openrouter(provider_store)
@@ -160,18 +176,23 @@ def _execution_service(tmp_path, monkeypatch, adapter):
     credits_store = CreditsStore(credits_path)
     _seed_balances(credits_store)
     credits_service = CreditsService(store=credits_store)
-    snapshot = PricingSnapshot(
-        provider_id="openrouter",
-        model_id=MODEL_ID,
-        input_usd_per_million_tokens=1000.0,
-        output_usd_per_million_tokens=1000.0,
-        source_version="test-pricing",
-    )
+    def snapshot_for(model_id: str, provider_id: str) -> PricingSnapshot:
+        return PricingSnapshot(
+            provider_id=provider_id,
+            model_id=model_id,
+            input_usd_per_million_tokens=1000.0,
+            output_usd_per_million_tokens=1000.0,
+            source_version="test-pricing",
+        )
+
+    def resolve_adapter(provider):
+        return adapters[provider.provider_id] if adapters is not None else adapter
+
     service = LLMExecutionService(
         providers=ModelProviderService(store=provider_store),
         credits=credits_service,
-        adapter_resolver=lambda _provider: adapter,
-        pricing_snapshot_factory=lambda _model_id, _provider_id: snapshot,
+        adapter_resolver=resolve_adapter,
+        pricing_snapshot_factory=snapshot_for,
     )
     return service, credits_store
 
@@ -244,6 +265,241 @@ def test_platform_execution_emits_bucketed_resource_evidence(
         "cost_micro_usd": 200_000,
     }
     assert "sk-or-execution-test-abcd" not in repr(events)
+
+
+def test_platform_quota_error_retries_once_through_commonstack(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("COMMONSTACK_API_KEY", "cs-fake-failover-abcd")
+    primary_adapter = ScriptedExecutionAdapter(
+        [
+            ProviderExecutionError(
+                ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED
+            )
+        ]
+    )
+    fallback_adapter = ScriptedExecutionAdapter(
+        [
+            AdapterResponse(
+                text="BUY",
+                model_id="qwen/qwen3.7-plus",
+                usage=LLMUsage(input_tokens=40, output_tokens=20),
+                finish_reason="stop",
+            )
+        ]
+    )
+    service, credits_store = _execution_service(
+        tmp_path,
+        monkeypatch,
+        primary_adapter,
+        adapters={
+            "openrouter": primary_adapter,
+            "commonstack": fallback_adapter,
+        },
+    )
+    assert service.providers.store.get_provider("commonstack")["platform_enabled"] is True
+    request = _request("failover-run").model_copy(
+        update={
+            "model_id": "qwen/qwen3.7-plus",
+            "reasoning_effort": "high",
+            "temperature": 0.2,
+        }
+    )
+
+    result = service.execute(request)
+
+    assert result.provider_id == "commonstack"
+    assert result.requested_provider_id == "openrouter"
+    assert [call.provider_id for call in primary_adapter.calls] == ["openrouter"]
+    assert [call.provider_id for call in fallback_adapter.calls] == ["commonstack"]
+    primary_request = primary_adapter.calls[0]
+    fallback_request = fallback_adapter.calls[0]
+    assert fallback_request.model_id == primary_request.model_id
+    assert fallback_request.system_message == primary_request.system_message
+    assert fallback_request.messages == primary_request.messages
+    assert fallback_request.usage_policy == primary_request.usage_policy
+    assert fallback_request.temperature == primary_request.temperature
+    assert fallback_request.reasoning_effort == primary_request.reasoning_effort
+    with credits_store._get_connection() as connection:
+        rows = connection.execute(
+            "SELECT attempt_index, provider_id, status "
+            "FROM credit_llm_reservations WHERE run_id = ? "
+            "ORDER BY attempt_index",
+            ("failover-run",),
+        ).fetchall()
+    assert [tuple(row) for row in rows] == [
+        (0, "openrouter", "released"),
+        (1, "commonstack", "settled"),
+    ]
+
+
+@pytest.mark.parametrize(
+    "category",
+    [
+        ExecutionErrorCategory.PROVIDER_TIMEOUT,
+        ExecutionErrorCategory.PROVIDER_UNAVAILABLE,
+        ExecutionErrorCategory.RESPONSE_INVALID,
+        ExecutionErrorCategory.USAGE_UNAVAILABLE,
+        ExecutionErrorCategory.CREDENTIAL_INVALID,
+        ExecutionErrorCategory.BILLING_FAILED,
+    ],
+)
+def test_non_quota_platform_failures_do_not_fail_over(
+    tmp_path, monkeypatch, category
+):
+    monkeypatch.setenv("COMMONSTACK_API_KEY", "cs-fake-unused-abcd")
+    primary = ScriptedExecutionAdapter([ProviderExecutionError(category)])
+    fallback = ScriptedExecutionAdapter([])
+    service, _store = _execution_service(
+        tmp_path,
+        monkeypatch,
+        primary,
+        adapters={"openrouter": primary, "commonstack": fallback},
+    )
+
+    with pytest.raises(LLMExecutionError) as exc_info:
+        service.execute(_request(f"no-failover-{category.value}"))
+
+    assert exc_info.value.category is category
+    assert fallback.calls == []
+
+
+def test_byok_quota_error_never_uses_platform_fallback(tmp_path, monkeypatch):
+    primary = ScriptedExecutionAdapter(
+        [
+            ProviderExecutionError(
+                ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED
+            )
+        ]
+    )
+    fallback = ScriptedExecutionAdapter([])
+    service, _store = _execution_service(
+        tmp_path,
+        monkeypatch,
+        primary,
+        adapters={"openrouter": primary, "commonstack": fallback},
+    )
+    calls = []
+
+    def fail_once(request, **_kwargs):
+        calls.append(request.provider_id)
+        raise LLMExecutionError(ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED)
+
+    monkeypatch.setattr(service, "_execute_once", fail_once)
+    with pytest.raises(LLMExecutionError) as exc_info:
+        service.execute(
+            _request("byok-no-fallback").model_copy(
+                update={"billing_mode": BillingMode.BYOK}
+            )
+        )
+    assert exc_info.value.category is ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED
+    assert calls == ["openrouter"]
+    assert fallback.calls == []
+
+
+def test_fallback_failure_returns_commonstack_safe_category(tmp_path, monkeypatch):
+    monkeypatch.setenv("COMMONSTACK_API_KEY", "cs-fake-timeout-abcd")
+    primary = ScriptedExecutionAdapter(
+        [
+            ProviderExecutionError(
+                ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED
+            )
+        ]
+    )
+    fallback = ScriptedExecutionAdapter(
+        [ProviderExecutionError(ExecutionErrorCategory.PROVIDER_TIMEOUT)]
+    )
+    service, _store = _execution_service(
+        tmp_path,
+        monkeypatch,
+        primary,
+        adapters={"openrouter": primary, "commonstack": fallback},
+    )
+    with pytest.raises(LLMExecutionError) as exc_info:
+        service.execute(_request("dual-failure"))
+    assert exc_info.value.category is ExecutionErrorCategory.PROVIDER_TIMEOUT
+    assert len(primary.calls) == 1
+    assert len(fallback.calls) == 1
+
+
+def test_missing_commonstack_route_preserves_primary_quota_error(
+    tmp_path, monkeypatch
+):
+    monkeypatch.delenv("COMMONSTACK_API_KEY", raising=False)
+    primary = ScriptedExecutionAdapter(
+        [
+            ProviderExecutionError(
+                ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED
+            )
+        ]
+    )
+    fallback = ScriptedExecutionAdapter([])
+    service, _store = _execution_service(
+        tmp_path,
+        monkeypatch,
+        primary,
+        adapters={"openrouter": primary, "commonstack": fallback},
+    )
+    with pytest.raises(LLMExecutionError) as exc_info:
+        service.execute(_request("missing-fallback"))
+    assert exc_info.value.category is ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED
+    assert fallback.calls == []
+
+
+def test_primary_release_failure_aborts_before_fallback(tmp_path, monkeypatch):
+    monkeypatch.setenv("COMMONSTACK_API_KEY", "cs-fake-unused-abcd")
+    primary = ScriptedExecutionAdapter(
+        [
+            ProviderExecutionError(
+                ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED
+            )
+        ]
+    )
+    fallback = ScriptedExecutionAdapter([])
+    service, _store = _execution_service(
+        tmp_path,
+        monkeypatch,
+        primary,
+        adapters={"openrouter": primary, "commonstack": fallback},
+    )
+
+    def fail_release(*_args, **_kwargs):
+        raise RuntimeError("synthetic release failure")
+
+    monkeypatch.setattr(service.credits, "release_llm_credits", fail_release)
+    with pytest.raises(LLMExecutionError) as exc_info:
+        service.execute(_request("release-failure"))
+    assert exc_info.value.category is ExecutionErrorCategory.BILLING_FAILED
+    assert fallback.calls == []
+
+
+def test_two_quota_failures_stop_after_commonstack(tmp_path, monkeypatch):
+    monkeypatch.setenv("COMMONSTACK_API_KEY", "cs-fake-double-quota-abcd")
+    primary = ScriptedExecutionAdapter(
+        [
+            ProviderExecutionError(
+                ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED
+            )
+        ]
+    )
+    fallback = ScriptedExecutionAdapter(
+        [
+            ProviderExecutionError(
+                ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED
+            )
+        ]
+    )
+    service, _store = _execution_service(
+        tmp_path,
+        monkeypatch,
+        primary,
+        adapters={"openrouter": primary, "commonstack": fallback},
+    )
+    with pytest.raises(LLMExecutionError) as exc_info:
+        service.execute(_request("double-quota"))
+    assert exc_info.value.category is ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED
+    assert len(primary.calls) == 1
+    assert len(fallback.calls) == 1
 
 
 def test_byok_usage_reports_tokens_with_zero_atl_cost(monkeypatch):

--- a/dashboard/backend/tests/infrastructure/llm/test_provider_error_mapping.py
+++ b/dashboard/backend/tests/infrastructure/llm/test_provider_error_mapping.py
@@ -1,0 +1,125 @@
+"""Bounded, provider-neutral mapping for upstream execution errors."""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from dashboard.backend.infrastructure.llm.execution.adapters.base import (
+    map_provider_error,
+)
+from dashboard.backend.infrastructure.llm.execution.errors import (
+    ExecutionErrorCategory,
+)
+
+
+class _ProviderError(Exception):
+    def __init__(
+        self,
+        status_code: int | None,
+        payload: object,
+        *,
+        response_status: int | None = None,
+    ):
+        super().__init__("synthetic provider failure")
+        content = json.dumps(payload).encode("utf-8")
+        self.status_code = status_code
+        self.response = SimpleNamespace(
+            status_code=response_status if response_status is not None else status_code,
+            content=content,
+        )
+
+
+def _error(
+    status_code: int | None,
+    payload: object,
+    *,
+    response_status: int | None = None,
+) -> _ProviderError:
+    return _ProviderError(status_code, payload, response_status=response_status)
+
+
+@pytest.mark.parametrize(
+    ("status_code", "payload"),
+    [
+        (402, {"error": {"message": "payment required"}}),
+        (429, {"error": {"code": "in_flight_budget_exhausted"}}),
+        (400, {"error": {"type": "insufficient_quota"}}),
+        (400, {"error": {"message": "Insufficient balance for this request"}}),
+        (429, {"error": {"message": "You exceeded your current quota"}}),
+        (None, {"code": "quota_exhausted"}),
+    ],
+)
+def test_explicit_balance_or_quota_errors_are_typed(status_code, payload):
+    mapped = map_provider_error(_error(status_code, payload))
+    assert mapped.category is ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED
+
+
+def test_response_status_code_is_used_when_exception_has_no_status():
+    mapped = map_provider_error(
+        _error(None, {"error": {"message": "payment required"}}, response_status=402)
+    )
+    assert mapped.category is ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED
+
+
+@pytest.mark.parametrize(
+    ("status_code", "payload", "expected"),
+    [
+        (429, {"error": {"message": "rate limit exceeded"}}, "provider_unavailable"),
+        (500, {"error": {"message": "insufficient capacity"}}, "provider_unavailable"),
+        (500, {"error": {"code": "quota_exceeded"}}, "provider_unavailable"),
+        (401, {"error": {"message": "invalid key"}}, "credential_invalid"),
+        (401, {"error": {"code": "insufficient_quota"}}, "credential_invalid"),
+        (503, {"error": {"message": "service unavailable"}}, "provider_unavailable"),
+    ],
+)
+def test_non_quota_errors_do_not_become_failover_signals(
+    status_code, payload, expected
+):
+    mapped = map_provider_error(_error(status_code, payload))
+    assert mapped.category.value == expected
+
+
+def test_malformed_or_oversized_payload_does_not_become_a_quota_signal():
+    malformed = SimpleNamespace(status_code=429, content=b"{not-json")
+    malformed_error = _ProviderError.__new__(_ProviderError)
+    Exception.__init__(malformed_error, "synthetic provider failure")
+    malformed_error.status_code = 429
+    malformed_error.response = malformed
+    assert (
+        map_provider_error(malformed_error).category
+        is ExecutionErrorCategory.PROVIDER_UNAVAILABLE
+    )
+    malformed_402 = _ProviderError.__new__(_ProviderError)
+    Exception.__init__(malformed_402, "synthetic provider failure")
+    malformed_402.status_code = 402
+    malformed_402.response = SimpleNamespace(status_code=402, content=b"{not-json")
+    assert (
+        map_provider_error(malformed_402).category
+        is ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED
+    )
+
+    oversized = _error(
+        429,
+        {"error": {"message": "x" * 4096 + " quota exceeded"}},
+    )
+    assert (
+        map_provider_error(oversized).category
+        is ExecutionErrorCategory.PROVIDER_UNAVAILABLE
+    )
+
+
+def test_quota_looking_text_outside_structured_error_fields_is_ignored():
+    mapped = map_provider_error(
+        _error(429, {"details": {"message": "insufficient balance"}})
+    )
+    assert mapped.category is ExecutionErrorCategory.PROVIDER_UNAVAILABLE
+
+
+def test_timeout_precedes_quota_classification():
+    class _TimeoutProviderError(TimeoutError):
+        status_code = 402
+        response = SimpleNamespace(status_code=402, content=b"{}")
+
+    exc = _TimeoutProviderError("quota exceeded")
+    assert map_provider_error(exc).category is ExecutionErrorCategory.PROVIDER_TIMEOUT

--- a/dashboard/backend/tests/test_backtests_router.py
+++ b/dashboard/backend/tests/test_backtests_router.py
@@ -559,24 +559,20 @@ def test_run_metadata_response_exposes_sanitized_llm_execution_evidence():
             "data_source": "alpaca",
             "llm_execution": {
                 "billing_mode": "platform_credits",
-                "provider_id": "openrouter",
+                "requested_provider_id": "openrouter",
+                "provider_id": "mixed",
+                "provider_ids": ["openrouter", "commonstack"],
+                "provider_mixed": True,
                 "model_id": "openai/gpt-5.5",
-                "credential_id": "credential-safe-id",
-                "credential_key_last_four": "1234",
+                "credential_id": None,
+                "credential_key_last_four": None,
                 "call_count": 2,
                 "input_tokens": 30,
                 "output_tokens": 13,
                 "usage_available": True,
                 "provider_cost_usd": 0.03,
                 "estimated_cost_usd": 0.028,
-                "pricing_snapshot": {
-                    "provider_id": "openrouter",
-                    "model_id": "openai/gpt-5.5",
-                    "input_usd_per_million_tokens": 5,
-                    "output_usd_per_million_tokens": 30,
-                    "currency": "USD",
-                    "source_version": "test-pricing-v1",
-                },
+                "pricing_snapshot": None,
                 "debited_credits_micro": 24_000,
                 "outstanding_credits_micro": 5_000,
                 "outcome": "settled_overage",
@@ -587,7 +583,14 @@ def test_run_metadata_response_exposes_sanitized_llm_execution_evidence():
 
     serialized = response.model_dump(mode="json")
     assert serialized["llm_execution"]["outcome"] == "settled_overage"
-    assert serialized["llm_execution"]["credential_key_last_four"] == "1234"
+    assert serialized["llm_execution"]["credential_key_last_four"] is None
+    assert serialized["llm_execution"]["requested_provider_id"] == "openrouter"
+    assert serialized["llm_execution"]["provider_id"] == "mixed"
+    assert serialized["llm_execution"]["provider_ids"] == [
+        "openrouter",
+        "commonstack",
+    ]
+    assert serialized["llm_execution"]["provider_mixed"] is True
     assert "raw-secret-must-not-leak" not in str(serialized)
     assert "provider_api_key" not in serialized["llm_execution"]
 

--- a/dashboard/backend/tests/test_credits_api.py
+++ b/dashboard/backend/tests/test_credits_api.py
@@ -218,6 +218,8 @@ def test_credit_activity_exposes_safe_aggregated_backtest_usage(billing_api):
             user_id=1,
             run_id="run-api-usage",
             call_index=call_index,
+            provider_id="openrouter",
+            attempt_index=0,
             reserved_micro=amount,
             operation_key=f"api-usage-reserve-{call_index}",
             request_digest=str(call_index).ljust(64, "f"),

--- a/dashboard/backend/tests/test_model_provider_store_postgres.py
+++ b/dashboard/backend/tests/test_model_provider_store_postgres.py
@@ -9,7 +9,10 @@ import pytest
 from cryptography.fernet import Fernet
 
 from dashboard.backend.domain.brokers import repository as broker_repository
-from dashboard.backend.domain.model_providers.models import ProviderCapabilities
+from dashboard.backend.domain.model_providers.models import (
+    ProviderCapabilities,
+    ProviderRecord,
+)
 from dashboard.backend.domain.model_providers.execution_catalog import (
     UnsupportedExecutionModel,
     list_execution_model_routes,
@@ -80,7 +83,10 @@ def test_postgres_seeded_commonstack_is_platform_only_with_allowlisted_models(
         "qwen/qwen3.7-plus",
     )
 
-    assert [route.catalog_id for route in list_execution_model_routes(provider)] == [
+    provider_record = ProviderRecord.model_validate(provider)
+    assert [
+        route.catalog_id for route in list_execution_model_routes(provider_record)
+    ] == [
         "anthropic/claude-sonnet-4-6",
         "openai/gpt-5.5",
         "google/gemini-3.1-pro-preview",
@@ -88,7 +94,7 @@ def test_postgres_seeded_commonstack_is_platform_only_with_allowlisted_models(
         "qwen/qwen3.7-plus",
     ]
     with pytest.raises(UnsupportedExecutionModel):
-        resolve_execution_model_route(provider, "anthropic/claude-haiku-4-5")
+        resolve_execution_model_route(provider_record, "anthropic/claude-haiku-4-5")
 
 
 @pg_only

--- a/dashboard/backend/tests/test_model_provider_store_postgres.py
+++ b/dashboard/backend/tests/test_model_provider_store_postgres.py
@@ -10,6 +10,11 @@ from cryptography.fernet import Fernet
 
 from dashboard.backend.domain.brokers import repository as broker_repository
 from dashboard.backend.domain.model_providers.models import ProviderCapabilities
+from dashboard.backend.domain.model_providers.execution_catalog import (
+    UnsupportedExecutionModel,
+    list_execution_model_routes,
+    resolve_execution_model_route,
+)
 from dashboard.backend.domain.model_providers.repository_common import (
     CredentialConflictError,
     CredentialOwnershipError,
@@ -55,6 +60,35 @@ def postgres_store():
 def test_postgres_store_rejects_non_postgres_url_before_connecting():
     with pytest.raises(ValueError, match="postgresql://"):
         PostgresModelProviderStore("sqlite:///tmp/not-postgres.db")
+
+
+@pg_only
+def test_postgres_seeded_commonstack_is_platform_only_with_allowlisted_models(
+    postgres_store,
+):
+    provider = postgres_store.get_provider("commonstack")
+
+    assert provider["adapter_type"] == "openai_compatible"
+    assert provider["approved_base_url"] == "https://api.commonstack.ai/v1"
+    assert provider["byok_enabled"] is False
+    assert provider["platform_enabled"] is True
+    assert provider["capabilities"].model_allowlist == (
+        "openai/gpt-5.5",
+        "google/gemini-3.1-pro-preview",
+        "anthropic/claude-sonnet-4-6",
+        "deepseek/deepseek-v4-pro",
+        "qwen/qwen3.7-plus",
+    )
+
+    assert [route.catalog_id for route in list_execution_model_routes(provider)] == [
+        "anthropic/claude-sonnet-4-6",
+        "openai/gpt-5.5",
+        "google/gemini-3.1-pro-preview",
+        "deepseek/deepseek-v4-pro",
+        "qwen/qwen3.7-plus",
+    ]
+    with pytest.raises(UnsupportedExecutionModel):
+        resolve_execution_model_route(provider, "anthropic/claude-haiku-4-5")
 
 
 @pg_only

--- a/docs/superpowers/plans/2026-09-01-platform-provider-failover.md
+++ b/docs/superpowers/plans/2026-09-01-platform-provider-failover.md
@@ -1,0 +1,1377 @@
+# Platform Provider Failover Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Retry an OpenRouter Platform Credits model call once through CommonStack only after an explicit upstream balance or quota exhaustion error, without changing the model request, reasoning behavior, BYOK isolation, or single-debit billing guarantee.
+
+**Architecture:** Register CommonStack as an allowlisted OpenAI-compatible platform provider, classify only bounded explicit quota failures into a new safe category, and route that category through a second provider attempt. Give each attempt an idempotent reservation identity while preserving the logical call index, then record the actual provider in call, run, Credits activity, and analytics evidence.
+
+**Tech Stack:** Python 3.13, FastAPI, Pydantic v2, OpenAI Python SDK compatibility layer, SQLite, PostgreSQL/psycopg, pytest.
+
+**Spec:** `docs/superpowers/specs/2026-09-01-platform-provider-failover-design.md`
+
+## Global Constraints
+
+- OpenRouter remains the preferred Platform Credits provider.
+- CommonStack uses `https://api.commonstack.ai/v1` and `COMMONSTACK_API_KEY`.
+- CommonStack is platform-enabled, BYOK-disabled, and allowlists only `openai/gpt-5.5`, `google/gemini-3.1-pro-preview`, `anthropic/claude-sonnet-4-6`, `deepseek/deepseek-v4-pro`, and `qwen/qwen3.7-plus`.
+- `anthropic/claude-haiku-4-5` must not fail over until that exact CommonStack route is separately verified.
+- Fail over only for HTTP `402` or an approved structured balance/quota code or phrase; a plain `429`, timeout, `5xx`, invalid response, invalid credential, unsupported model, local Credits error, and worker failure must not fail over.
+- Retry CommonStack at most once and never retry a provider call that returned a usable completion.
+- Preserve model, system message, messages, maximum output tokens, temperature, and reasoning effort exactly; never replace reasoning effort with `none`.
+- BYOK uses only the user's verified default credential and never uses an Admin or environment Platform Credential.
+- Release the primary reservation before creating the fallback reservation; one logical call may settle at most one debit.
+- Results, run evidence, Credits activity, and analytics must name the provider that actually completed the call.
+- SQLite and PostgreSQL behavior and migrations must remain equivalent.
+- Use only fake credentials and provider responses in automated tests; do not call real OpenRouter, CommonStack, Render, or production databases.
+- Do not mutate Render configuration before merge and separate deployment authorization.
+- Do not touch or commit `dashboard/storage/data/backtest.db`, real secrets, database URLs, `.superpowers/`, or `work/`.
+
+---
+
+### Task 1: Register the CommonStack platform provider
+
+**Files:**
+- Modify: `dashboard/backend/domain/model_providers/repository_common.py`
+- Modify: `dashboard/backend/domain/model_providers/service.py`
+- Test: `dashboard/backend/tests/domain/model_providers/test_repository_contract.py`
+- Test: `dashboard/backend/tests/domain/model_providers/test_service.py`
+- Test: `dashboard/backend/tests/test_model_provider_store_postgres.py`
+
+**Interfaces:**
+- Produces: seeded provider `commonstack` with adapter type `openai_compatible`, fixed approved origin, exact model allowlist, `byok_enabled=False`, and `platform_enabled=True`.
+- Produces: `_ENVIRONMENT_PLATFORM_KEY_NAMES["commonstack"] == "COMMONSTACK_API_KEY"`.
+- Preserves: stored verified Platform Credential precedence over the environment key.
+- Preserves: all existing provider order while stably placing CommonStack after existing providers, so OpenRouter remains ahead of CommonStack.
+- Consumed by Task 4: `ModelProviderService.resolve_platform_credential("commonstack")`, `preflight_platform_credential("commonstack")`, and `preflight_execution_model("commonstack", model_id)`.
+
+- [ ] **Step 1: Add failing seed and catalog contract tests**
+
+Add these assertions to the SQLite repository contract test, importing the
+catalog routing functions there:
+
+```python
+def test_seeded_commonstack_is_platform_only_with_verified_model_allowlist(store):
+    provider = store.get_provider("commonstack")
+
+    assert provider["adapter_type"] == "openai_compatible"
+    assert provider["approved_base_url"] == "https://api.commonstack.ai/v1"
+    assert provider["byok_enabled"] is False
+    assert provider["platform_enabled"] is True
+    assert provider["capabilities"].model_allowlist == (
+        "openai/gpt-5.5",
+        "google/gemini-3.1-pro-preview",
+        "anthropic/claude-sonnet-4-6",
+        "deepseek/deepseek-v4-pro",
+        "qwen/qwen3.7-plus",
+    )
+
+
+def test_commonstack_routes_only_the_verified_catalog_models(store):
+    provider = ProviderRecord.model_validate(store.get_provider("commonstack"))
+
+    assert [route.catalog_id for route in list_execution_model_routes(provider)] == [
+        "anthropic/claude-sonnet-4-6",
+        "openai/gpt-5.5",
+        "google/gemini-3.1-pro-preview",
+        "deepseek/deepseek-v4-pro",
+        "qwen/qwen3.7-plus",
+    ]
+    with pytest.raises(UnsupportedExecutionModel):
+        resolve_execution_model_route(provider, "anthropic/claude-haiku-4-5")
+```
+
+Import `ProviderRecord`, `UnsupportedExecutionModel`,
+`list_execution_model_routes`, and `resolve_execution_model_route` from their
+existing domain modules. Add a PostgreSQL seed assertion with the same fixed
+provider fields under the existing `@pg_only` marker.
+
+- [ ] **Step 2: Run the seed tests and verify they fail**
+
+Run:
+
+```bash
+/opt/anaconda3/bin/python3 -m pytest -q \
+  dashboard/backend/tests/domain/model_providers/test_execution_catalog.py \
+  dashboard/backend/tests/domain/model_providers/test_repository_contract.py \
+  dashboard/backend/tests/test_model_provider_store_postgres.py \
+  -k "commonstack"
+```
+
+Expected: FAIL because `commonstack` is not present in `SEEDED_PROVIDERS`.
+The PostgreSQL case may report SKIPPED when `TEST_POSTGRES_URL` is not set.
+
+- [ ] **Step 3: Add the fixed CommonStack seed**
+
+Define one reusable allowlist in `repository_common.py` and add the seed:
+
+```python
+COMMONSTACK_MODEL_ALLOWLIST = (
+    "openai/gpt-5.5",
+    "google/gemini-3.1-pro-preview",
+    "anthropic/claude-sonnet-4-6",
+    "deepseek/deepseek-v4-pro",
+    "qwen/qwen3.7-plus",
+)
+
+{
+    "provider_id": "commonstack",
+    "display_name": "CommonStack",
+    "adapter_type": "openai_compatible",
+    "approved_base_url": "https://api.commonstack.ai/v1",
+    "byok_enabled": False,
+    "platform_enabled": True,
+    "capabilities": ProviderCapabilities(
+        model_discovery=True,
+        system_messages=True,
+        reasoning=True,
+        supported_parameters=(
+            "temperature",
+            "max_output_tokens",
+            "reasoning_effort",
+        ),
+        model_allowlist=COMMONSTACK_MODEL_ALLOWLIST,
+    ),
+},
+```
+
+Keep the repositories' current insert-if-missing seed behavior so reopening a
+store never overwrites an Admin-disabled or edited CommonStack row.
+
+- [ ] **Step 4: Add failing CommonStack credential and ordering tests**
+
+Add service tests using fake key values only:
+
+```python
+def test_commonstack_platform_credential_uses_explicit_environment_mapping(
+    tmp_path, monkeypatch
+):
+    service, _store = _service(tmp_path, FakeAdapter())
+    monkeypatch.setenv("COMMONSTACK_API_KEY", "cs-fake-environment-abcd")
+
+    resolved = service.resolve_platform_credential("commonstack")
+
+    assert resolved.provider_id == "commonstack"
+    assert resolved.key_last_four == "abcd"
+    assert resolved.secret == "cs-fake-environment-abcd"
+
+
+def test_execution_options_keep_openrouter_ahead_of_commonstack(
+    tmp_path, monkeypatch
+):
+    service, _store = _service(tmp_path, FakeAdapter())
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-fake-options-abcd")
+    monkeypatch.setenv("COMMONSTACK_API_KEY", "cs-fake-options-wxyz")
+
+    provider_ids = [
+        option.provider_id
+        for option in service.list_execution_options(7)
+        if option.platform_credits_available
+    ]
+
+    assert provider_ids.index("openrouter") < provider_ids.index("commonstack")
+    assert "cs-fake-options-wxyz" not in repr(service.list_execution_options(7))
+```
+
+Also test that a verified stored CommonStack Platform Credential wins over
+`COMMONSTACK_API_KEY`, matching the existing OpenRouter precedence contract.
+
+- [ ] **Step 5: Run the service tests and verify they fail**
+
+Run:
+
+```bash
+/opt/anaconda3/bin/python3 -m pytest -q \
+  dashboard/backend/tests/domain/model_providers/test_service.py \
+  -k "commonstack or openrouter_ahead"
+```
+
+Expected: FAIL because CommonStack has no environment mapping and sorts before
+OpenRouter by display name.
+
+- [ ] **Step 6: Implement credential resolution and stable ordering**
+
+Extend the explicit mapping and stably move only CommonStack to the end:
+
+```python
+_ENVIRONMENT_PLATFORM_KEY_NAMES = {
+    "openrouter": "OPENROUTER_API_KEY",
+    "commonstack": "COMMONSTACK_API_KEY",
+}
+
+# After building all options. Python's sort is stable, so existing providers
+# keep their current order and CommonStack follows them.
+options.sort(key=lambda option: option.provider_id == "commonstack")
+return options
+```
+
+Do not special-case CommonStack inside BYOK resolution. Its seeded
+`byok_enabled=False` flag remains the authority for that lane.
+
+- [ ] **Step 7: Run all provider contracts**
+
+Run:
+
+```bash
+/opt/anaconda3/bin/python3 -m pytest -q \
+  dashboard/backend/tests/domain/model_providers/test_execution_catalog.py \
+  dashboard/backend/tests/domain/model_providers/test_repository_contract.py \
+  dashboard/backend/tests/domain/model_providers/test_service.py \
+  dashboard/backend/tests/test_model_provider_store_postgres.py
+```
+
+Expected: PASS, with only the configured PostgreSQL skips allowed.
+
+- [ ] **Step 8: Commit the provider layer**
+
+```bash
+git add dashboard/backend/domain/model_providers/repository_common.py \
+  dashboard/backend/domain/model_providers/service.py \
+  dashboard/backend/tests/domain/model_providers/test_repository_contract.py \
+  dashboard/backend/tests/domain/model_providers/test_service.py \
+  dashboard/backend/tests/test_model_provider_store_postgres.py
+git commit -m "feat: register CommonStack platform provider"
+```
+
+---
+
+### Task 2: Classify explicit provider quota exhaustion safely
+
+**Files:**
+- Modify: `dashboard/backend/infrastructure/llm/execution/errors.py`
+- Modify: `dashboard/backend/infrastructure/llm/execution/adapters/base.py`
+- Modify: `dashboard/backend/domain/analytics/models.py`
+- Create: `dashboard/backend/tests/infrastructure/llm/test_provider_error_mapping.py`
+- Test: `dashboard/backend/tests/domain/analytics/test_models.py`
+
+**Interfaces:**
+- Produces: `ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED = "provider_quota_exhausted"` with a fixed safe message.
+- Produces: `map_provider_error(exc: Exception) -> ProviderExecutionError` that returns the new category only for the spec's explicit bounded signals.
+- Preserves: timeout, credential, unsafe-address, and generic unavailable mappings.
+- Consumed by Task 4: the execution service uses only the typed category, never an upstream body, to decide whether to fail over.
+
+- [ ] **Step 1: Write the failing positive and negative classifier table**
+
+Create `test_provider_error_mapping.py` with a bounded fake response and this
+parameter table:
+
+```python
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from dashboard.backend.infrastructure.llm.execution.adapters.base import (
+    map_provider_error,
+)
+from dashboard.backend.infrastructure.llm.execution.errors import (
+    ExecutionErrorCategory,
+)
+
+
+class _ProviderError(Exception):
+    def __init__(self, status_code: int, payload: dict[str, object]):
+        super().__init__("synthetic provider failure")
+        content = json.dumps(payload).encode("utf-8")
+        self.status_code = status_code
+        self.response = SimpleNamespace(status_code=status_code, content=content)
+
+
+def _error(status_code: int, payload: dict[str, object]) -> _ProviderError:
+    return _ProviderError(status_code, payload)
+
+
+@pytest.mark.parametrize(
+    ("status_code", "payload"),
+    [
+        (402, {"error": {"message": "payment required"}}),
+        (429, {"error": {"code": "in_flight_budget_exhausted"}}),
+        (400, {"error": {"type": "insufficient_quota"}}),
+        (400, {"error": {"message": "Insufficient balance for this request"}}),
+        (429, {"error": {"message": "You exceeded your current quota"}}),
+    ],
+)
+def test_explicit_balance_or_quota_errors_are_typed(status_code, payload):
+    mapped = map_provider_error(_error(status_code, payload))
+    assert mapped.category is ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED
+
+
+@pytest.mark.parametrize(
+    ("status_code", "payload", "expected"),
+    [
+        (429, {"error": {"message": "rate limit exceeded"}}, "provider_unavailable"),
+        (500, {"error": {"message": "insufficient capacity"}}, "provider_unavailable"),
+        (401, {"error": {"message": "invalid key"}}, "credential_invalid"),
+        (503, {"error": {"message": "service unavailable"}}, "provider_unavailable"),
+    ],
+)
+def test_non_quota_errors_do_not_become_failover_signals(
+    status_code, payload, expected
+):
+    mapped = map_provider_error(_error(status_code, payload))
+    assert mapped.category.value == expected
+```
+
+Add cases for malformed JSON, a payload larger than the fixed limit, and a
+quota-looking string outside the structured error fields; all must map to
+`provider_unavailable` unless the status is `402`.
+
+- [ ] **Step 2: Add the failing safe-message and analytics allowlist tests**
+
+Add assertions that the new public exception text is fixed and that the safe
+analytics model accepts the category:
+
+```python
+def test_quota_exhausted_error_message_is_fixed():
+    error = LLMExecutionError(ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED)
+    assert str(error) == "The selected model provider has insufficient balance or quota."
+
+
+def test_safe_error_accepts_provider_quota_exhausted():
+    record = AnalyticsEventRecord.model_validate(_record_payload(
+        event_name="safe_error_recorded",
+        event_group="resource",
+        event_source="server",
+        session_id=None,
+        page_view=None,
+        source_event_id="safe-error:quota-test",
+        error_category="provider_quota_exhausted",
+    ))
+    assert record.error_category == "provider_quota_exhausted"
+```
+
+Use the existing `_record_payload` helper in `test_models.py`; import
+`LLMExecutionError` and `ExecutionErrorCategory` for the fixed-message test.
+
+- [ ] **Step 3: Run the new classifier tests and verify they fail**
+
+Run:
+
+```bash
+/opt/anaconda3/bin/python3 -m pytest -q \
+  dashboard/backend/tests/infrastructure/llm/test_provider_error_mapping.py \
+  dashboard/backend/tests/domain/analytics/test_models.py \
+  -k "quota or balance"
+```
+
+Expected: FAIL because the category, message, bounded classifier, and analytics
+allowlist do not exist.
+
+- [ ] **Step 4: Add the category and fixed safe message**
+
+Update `errors.py` and the analytics allowlist:
+
+```python
+class ExecutionErrorCategory(StrEnum):
+    PROVIDER_QUOTA_EXHAUSTED = "provider_quota_exhausted"
+
+
+_SAFE_MESSAGES[ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED] = (
+    "The selected model provider has insufficient balance or quota."
+)
+```
+
+Add `"provider_quota_exhausted"` to `ALLOWED_ERROR_CATEGORIES` without widening
+any other analytics property allowlist.
+
+- [ ] **Step 5: Implement the bounded structured classifier**
+
+In `adapters/base.py`, use fixed identifiers, phrases, and a 4 KiB payload cap:
+
+```python
+_PROVIDER_ERROR_PAYLOAD_MAX_BYTES = 4096
+_QUOTA_ERROR_IDENTIFIERS = frozenset({
+    "in_flight_budget_exhausted",
+    "insufficient_quota",
+    "quota_exceeded",
+    "quota_exhausted",
+    "insufficient_balance",
+    "credit_balance_exhausted",
+})
+_QUOTA_ERROR_PHRASES = (
+    "insufficient balance",
+    "insufficient credits",
+    "quota exceeded",
+    "quota exhausted",
+    "exceeded your current quota",
+    "not enough credits",
+)
+
+
+def _bounded_error_payload(exc: Exception) -> dict[str, Any]:
+    response = getattr(exc, "response", None)
+    content = getattr(response, "content", b"")
+    if not isinstance(content, bytes) or len(content) > _PROVIDER_ERROR_PAYLOAD_MAX_BYTES:
+        return {}
+    try:
+        parsed = json.loads(content.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+```
+
+Read only `error.code`, `error.type`, `error.message`, and equivalent top-level
+fields. Lowercase and trim bounded strings. In `map_provider_error`, preserve
+timeout precedence, then classify status `402` or an approved payload signal,
+then apply the existing credential/address/unavailable mappings. Never include
+the parsed payload in the returned exception.
+
+- [ ] **Step 6: Run the complete error and analytics tests**
+
+Run:
+
+```bash
+/opt/anaconda3/bin/python3 -m pytest -q \
+  dashboard/backend/tests/infrastructure/llm/test_provider_error_mapping.py \
+  dashboard/backend/tests/infrastructure/llm/test_execution_adapter_model_routes.py \
+  dashboard/backend/tests/domain/analytics/test_models.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the error-classification layer**
+
+```bash
+git add dashboard/backend/infrastructure/llm/execution/errors.py \
+  dashboard/backend/infrastructure/llm/execution/adapters/base.py \
+  dashboard/backend/domain/analytics/models.py \
+  dashboard/backend/tests/infrastructure/llm/test_provider_error_mapping.py \
+  dashboard/backend/tests/domain/analytics/test_models.py
+git commit -m "feat: classify provider quota exhaustion"
+```
+
+---
+
+### Task 3: Give each provider attempt an independent reservation identity
+
+**Files:**
+- Modify: `dashboard/backend/domain/credits/models.py`
+- Modify: `dashboard/backend/domain/credits/service.py`
+- Modify: `dashboard/backend/domain/credits/repository.py`
+- Modify: `dashboard/backend/domain/credits/repository_postgres.py`
+- Test: `dashboard/backend/tests/domain/credits/test_repository.py`
+- Test: `dashboard/backend/tests/domain/credits/test_repository_postgres.py`
+- Test: `dashboard/backend/tests/domain/credits/test_service.py`
+- Test: `dashboard/backend/tests/domain/credits/test_promotion_grants.py`
+- Test: `dashboard/backend/tests/infrastructure/llm/test_platform_credits_env_fallback.py`
+- Test: `dashboard/backend/tests/test_credits_api.py`
+
+**Interfaces:**
+- Produces: `CreditsService.reserve_llm_credits(..., provider_id: str, attempt_index: int = 0) -> LLMReservation`.
+- Produces: matching SQLite and PostgreSQL store parameters `provider_id: str` and `attempt_index: int`.
+- Produces: `LLMReservation.provider_id: str | None`, `LLMReservation.attempt_index: StrictInt`, `LLMSettlementResult.provider_id: str | None`, and `LLMSettlementResult.attempt_index: StrictInt`.
+- Storage uniqueness: `(user_id, run_id, call_index, attempt_index)`.
+- Preserves: `(user_id, run_id, call_index)` as the logical model-call identity used for activity call counts.
+- Consumed by Task 4: attempt `0` for OpenRouter and attempt `1` for CommonStack.
+
+- [ ] **Step 1: Write the failing SQLite two-attempt contract**
+
+Add a repository test that releases attempt zero before creating attempt one:
+
+```python
+def test_provider_attempts_have_independent_reservations_for_one_logical_call(tmp_path):
+    store = _store(tmp_path)
+    _pending_order(store, amount_usd_cents=100, credits_micro=1_000_000)
+    _pay_order(store, amount_usd_cents=100)
+
+    primary = store.reserve_llm_credits(
+        reservation_id="attempt-primary",
+        user_id=1,
+        run_id="attempt-run",
+        call_index=3,
+        attempt_index=0,
+        provider_id="openrouter",
+        reserved_micro=100_000,
+        operation_key="attempt-primary-operation",
+        request_digest="a" * 64,
+    )
+    store.release_llm_credits(primary["reservation_id"], reason="provider_quota_exhausted")
+    fallback = store.reserve_llm_credits(
+        reservation_id="attempt-fallback",
+        user_id=1,
+        run_id="attempt-run",
+        call_index=3,
+        attempt_index=1,
+        provider_id="commonstack",
+        reserved_micro=100_000,
+        operation_key="attempt-fallback-operation",
+        request_digest="b" * 64,
+    )
+
+    assert primary["attempt_index"] == 0
+    assert primary["provider_id"] == "openrouter"
+    assert fallback["attempt_index"] == 1
+    assert fallback["provider_id"] == "commonstack"
+```
+
+Add negative cases for a negative attempt index, a blank provider identifier,
+and idempotent replay with a different provider or attempt.
+
+- [ ] **Step 2: Write the failing migration and PostgreSQL parity tests**
+
+Extend the existing SQLite legacy-table fixture so it lacks both new columns,
+open the store, and assert the legacy row reads as `attempt_index=0` and
+`provider_id is None`. Assert a new attempt-one row can then share its logical
+call index after the legacy row is released.
+
+Add the PostgreSQL equivalent under `@pg_only`:
+
+```python
+fallback = store.reserve_llm_credits(
+    reservation_id="pg-attempt-fallback",
+    user_id=1,
+    run_id="pg-attempt-run",
+    call_index=4,
+    attempt_index=1,
+    provider_id="commonstack",
+    reserved_micro=100_000,
+    operation_key="pg-attempt-fallback-operation",
+    request_digest="c" * 64,
+)
+assert fallback["attempt_index"] == 1
+assert fallback["provider_id"] == "commonstack"
+```
+
+The PostgreSQL migration test must inspect `pg_constraint` and assert that the
+named replacement unique constraint covers `user_id`, `run_id`, `call_index`,
+and `attempt_index`.
+
+- [ ] **Step 3: Run the repository tests and verify they fail**
+
+Run:
+
+```bash
+/opt/anaconda3/bin/python3 -m pytest -q \
+  dashboard/backend/tests/domain/credits/test_repository.py \
+  dashboard/backend/tests/domain/credits/test_repository_postgres.py \
+  -k "attempt or migration"
+```
+
+Expected: FAIL because the reservation schema and method signatures do not
+accept provider attempt identity. PostgreSQL may be SKIPPED when unconfigured.
+
+- [ ] **Step 4: Extend the domain models and service signature**
+
+Add validated fields and include both values in operation identity:
+
+```python
+class LLMReservation(BaseModel):
+    provider_id: str | None = None
+    attempt_index: StrictInt = Field(default=0, ge=0)
+
+
+class LLMSettlementResult(BaseModel):
+    provider_id: str | None = None
+    attempt_index: StrictInt = Field(default=0, ge=0)
+```
+
+Update `CreditsService.reserve_llm_credits` to require `provider_id`, validate
+it by calling
+`dashboard.backend.domain.model_providers.repository_common.validate_provider_id`,
+reject a boolean or negative `attempt_index`, and calculate defaults as:
+
+```python
+operation_key = operation_key or _operation_id(
+    "llm_reserve", user_id, run_id, call_index, attempt_index, provider_id
+)
+request_digest = request_digest or _canonical_digest({
+    "user_id": int(user_id),
+    "run_id": run_id,
+    "call_index": call_index,
+    "attempt_index": attempt_index,
+    "provider_id": provider_id,
+    "amount_micro": amount_micro,
+})
+reservation_id = _operation_id(
+    "llm_res", user_id, run_id, call_index, attempt_index, provider_id, operation_key
+)
+```
+
+Populate the two new fields in `_llm_reservation_model` and
+`_llm_settlement_model`, using `None` and `0` only when reading legacy rows.
+
+- [ ] **Step 5: Migrate the SQLite reservation table safely**
+
+Update `_LLM_RESERVATION_DDL` with nullable `provider_id`, non-negative
+`attempt_index DEFAULT 0`, and the four-column unique constraint. Replace the
+current narrow rebuild check with a rebuild condition covering missing new
+columns, the legacy three-column uniqueness, or the obsolete settlement
+ceiling:
+
+```python
+needs_rebuild = (
+    "provider_id" not in reservation_columns
+    or "attempt_index" not in reservation_columns
+    or "unique(user_id,run_id,call_index)" in table_sql
+    or "settled_micro<=reserved_micro" in table_sql
+)
+```
+
+Back up `credit_llm_usage_entries`, rebuild reservations, and copy old rows with
+`NULL AS provider_id` and `0 AS attempt_index` when those columns are absent.
+Restore usage rows unchanged so reservation foreign keys and historical
+evidence survive. Order run-level reservation reads by
+`call_index, attempt_index, reservation_id`.
+
+- [ ] **Step 6: Migrate PostgreSQL without losing rows**
+
+In the PostgreSQL schema initialization SQL:
+
+```sql
+ALTER TABLE credit_llm_reservations
+ADD COLUMN IF NOT EXISTS provider_id TEXT;
+ALTER TABLE credit_llm_reservations
+ADD COLUMN IF NOT EXISTS attempt_index INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE credit_llm_reservations
+DROP CONSTRAINT IF EXISTS credit_llm_reservations_attempt_index_check;
+ALTER TABLE credit_llm_reservations
+ADD CONSTRAINT credit_llm_reservations_attempt_index_check
+CHECK (attempt_index >= 0);
+```
+
+Use a `pg_constraint` block joined to `pg_attribute` through `conkey` ordinality
+to drop only unique constraints whose ordered column array is exactly
+`ARRAY['user_id', 'run_id', 'call_index']`. Then create the named replacement
+unique constraint after first running
+`DROP CONSTRAINT IF EXISTS credit_llm_reservations_logical_attempt_key`. The
+new constraint covers `(user_id, run_id, call_index, attempt_index)`. Update
+fresh-install DDL, reservation selects, inserts, idempotency comparisons, and
+run-level ordering to include the new fields.
+
+- [ ] **Step 7: Update repository reservation logic and existing callers**
+
+Both repositories must validate `provider_id` and `attempt_index`, query an
+existing reservation with this logical key:
+
+```sql
+user_id = ? AND run_id = ? AND call_index = ? AND attempt_index = ?
+```
+
+Use `%s` placeholders in the PostgreSQL version. Compare `provider_id` during
+idempotent replay and reject different input with
+`LLMReservationConflictError`.
+
+Update every existing `reserve_llm_credits` caller reported by this command:
+
+```bash
+rg -l 'reserve_llm_credits\(' dashboard/backend --glob '*.py'
+```
+
+Existing single-attempt tests and application calls use
+`provider_id="openrouter"` and the default `attempt_index=0`; tests whose
+billing evidence names another provider use that provider identifier instead.
+
+- [ ] **Step 8: Run Credits model, service, and repository tests**
+
+Run:
+
+```bash
+/opt/anaconda3/bin/python3 -m pytest -q \
+  dashboard/backend/tests/domain/credits/test_repository.py \
+  dashboard/backend/tests/domain/credits/test_repository_postgres.py \
+  dashboard/backend/tests/domain/credits/test_service.py \
+  dashboard/backend/tests/domain/credits/test_promotion_grants.py \
+  dashboard/backend/tests/test_credits_api.py \
+  dashboard/backend/tests/infrastructure/llm/test_platform_credits_env_fallback.py
+```
+
+Expected: PASS, with only configured PostgreSQL skips allowed. Confirm the
+activity tests still count distinct `call_index` values rather than attempt
+rows.
+
+- [ ] **Step 9: Commit the reservation layer**
+
+```bash
+git add dashboard/backend/domain/credits/models.py \
+  dashboard/backend/domain/credits/service.py \
+  dashboard/backend/domain/credits/repository.py \
+  dashboard/backend/domain/credits/repository_postgres.py \
+  dashboard/backend/tests/domain/credits/test_repository.py \
+  dashboard/backend/tests/domain/credits/test_repository_postgres.py \
+  dashboard/backend/tests/domain/credits/test_service.py \
+  dashboard/backend/tests/domain/credits/test_promotion_grants.py \
+  dashboard/backend/tests/infrastructure/llm/test_platform_credits_env_fallback.py \
+  dashboard/backend/tests/test_credits_api.py
+git commit -m "feat: track provider attempt reservations"
+```
+
+---
+
+### Task 4: Execute the strict OpenRouter-to-CommonStack fallback
+
+**Files:**
+- Modify: `dashboard/backend/infrastructure/llm/execution/models.py`
+- Modify: `dashboard/backend/infrastructure/llm/execution/service.py`
+- Test: `dashboard/backend/tests/infrastructure/llm/test_execution_adapter_model_routes.py`
+- Test: `dashboard/backend/tests/infrastructure/llm/test_platform_credits_env_fallback.py`
+
+**Interfaces:**
+- Produces: optional `LLMExecutionResult.requested_provider_id` populated by the production service.
+- Produces: `LLMExecutionService._execute_once(request, *, attempt_index, requested_provider_id) -> LLMExecutionResult` for one credential, reservation, provider call, and settlement lifecycle.
+- Produces: `LLMExecutionService._execute_with_platform_failover(request) -> LLMExecutionResult` for the one-way policy.
+- Consumes: `ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED` from Task 2 and attempt-aware reservations from Task 3.
+- Preserves: one outer safe-error emission for the final outcome only.
+
+- [ ] **Step 1: Write the failing successful-fallback test**
+
+Extend `test_platform_credits_env_fallback.py` with a scripted adapter and make
+its existing `_execution_service` helper accept a provider-to-adapter mapping.
+Keep the existing two-value return contract and replace its fixed pricing
+snapshot lambda with one that uses the supplied model and provider identifiers:
+
+```python
+class ScriptedExecutionAdapter:
+    def __init__(self, outcomes):
+        self.outcomes = list(outcomes)
+        self.calls = []
+
+    def complete(self, request, credential, provider):
+        self.calls.append(request)
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+def snapshot_for(model_id: str, provider_id: str) -> PricingSnapshot:
+    return PricingSnapshot(
+        provider_id=provider_id,
+        model_id=model_id,
+        input_usd_per_million_tokens=1000.0,
+        output_usd_per_million_tokens=1000.0,
+        source_version="test-pricing",
+    )
+```
+
+The adapter resolver inside `_execution_service` must use
+`adapters[provider.provider_id]` when the optional mapping is supplied and keep
+the current single-adapter behavior otherwise. Then add this test using the
+real temporary provider and Credits stores:
+
+```python
+def test_platform_quota_error_retries_once_through_commonstack(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("COMMONSTACK_API_KEY", "cs-fake-failover-abcd")
+    primary_adapter = ScriptedExecutionAdapter([
+        ProviderExecutionError(ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED),
+    ])
+    fallback_adapter = ScriptedExecutionAdapter([AdapterResponse(
+        text="BUY",
+        model_id="qwen/qwen3.7-plus",
+        usage=LLMUsage(input_tokens=40, output_tokens=20),
+        finish_reason="stop",
+    )])
+    service, credits_store = _execution_service(
+        tmp_path,
+        monkeypatch,
+        primary_adapter,
+    adapters={
+            "openrouter": primary_adapter,
+            "commonstack": fallback_adapter,
+        },
+    )
+    assert service.providers.store.get_provider("commonstack")["platform_enabled"] is True
+    request = _request("failover-run").model_copy(update={
+        "model_id": "qwen/qwen3.7-plus",
+        "reasoning_effort": "high",
+        "temperature": 0.2,
+    })
+
+    result = service.execute(request)
+
+    assert result.provider_id == "commonstack"
+    assert result.requested_provider_id == "openrouter"
+    assert [call.provider_id for call in primary_adapter.calls] == ["openrouter"]
+    assert [call.provider_id for call in fallback_adapter.calls] == ["commonstack"]
+    assert fallback_adapter.calls[0].reasoning_effort == "high"
+    assert fallback_adapter.calls[0].temperature == 0.2
+    with credits_store._get_connection() as connection:
+        rows = connection.execute(
+            "SELECT attempt_index, provider_id, status "
+            "FROM credit_llm_reservations WHERE run_id = ? "
+            "ORDER BY attempt_index",
+            ("failover-run",),
+        ).fetchall()
+    assert [(row["attempt_index"], row["provider_id"], row["status"]) for row in rows] == [
+        (0, "openrouter", "released"),
+        (1, "commonstack", "settled"),
+    ]
+```
+
+Compare `system_message`, `messages`, `model_id`, `usage_policy`, temperature,
+and reasoning effort between the two captured requests; only `provider_id` may
+differ.
+
+- [ ] **Step 2: Write failing non-fallback and dual-failure tests**
+
+Parameterize primary failures for `PROVIDER_TIMEOUT`, `PROVIDER_UNAVAILABLE`,
+`RESPONSE_INVALID`, `USAGE_UNAVAILABLE`, `CREDENTIAL_INVALID`, and
+`BILLING_FAILED`. Each case must assert zero CommonStack calls and the original
+category.
+
+```python
+@pytest.mark.parametrize("category", [
+    ExecutionErrorCategory.PROVIDER_TIMEOUT,
+    ExecutionErrorCategory.PROVIDER_UNAVAILABLE,
+    ExecutionErrorCategory.RESPONSE_INVALID,
+    ExecutionErrorCategory.USAGE_UNAVAILABLE,
+    ExecutionErrorCategory.CREDENTIAL_INVALID,
+    ExecutionErrorCategory.BILLING_FAILED,
+])
+def test_non_quota_platform_failures_do_not_fail_over(
+    tmp_path, monkeypatch, category
+):
+    monkeypatch.setenv("COMMONSTACK_API_KEY", "cs-fake-unused-abcd")
+    primary = ScriptedExecutionAdapter([ProviderExecutionError(category)])
+    fallback = ScriptedExecutionAdapter([])
+    service, _store = _execution_service(
+        tmp_path,
+        monkeypatch,
+        primary,
+        adapters={"openrouter": primary, "commonstack": fallback},
+    )
+
+    with pytest.raises(LLMExecutionError) as exc_info:
+        service.execute(_request(f"no-failover-{category.value}"))
+
+    assert exc_info.value.category is category
+    assert fallback.calls == []
+```
+
+Add these separate cases using `ScriptedExecutionAdapter`, `_execution_service`,
+and `_request` from the same file:
+
+```python
+def test_byok_quota_error_never_uses_platform_fallback(
+    tmp_path, monkeypatch
+):
+    primary = ScriptedExecutionAdapter([
+        ProviderExecutionError(ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED),
+    ])
+    fallback = ScriptedExecutionAdapter([])
+    service, _store = _execution_service(
+        tmp_path,
+        monkeypatch,
+        primary,
+        adapters={"openrouter": primary, "commonstack": fallback},
+    )
+    calls = []
+
+    def fail_once(request, **_kwargs):
+        calls.append(request.provider_id)
+        raise LLMExecutionError(ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED)
+
+    monkeypatch.setattr(service, "_execute_once", fail_once)
+    with pytest.raises(LLMExecutionError) as exc_info:
+        service.execute(_request("byok-no-fallback").model_copy(update={
+            "billing_mode": BillingMode.BYOK,
+        }))
+    assert exc_info.value.category is ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED
+    assert calls == ["openrouter"]
+    assert fallback.calls == []
+
+
+def test_fallback_failure_returns_commonstack_safe_category(tmp_path, monkeypatch):
+    monkeypatch.setenv("COMMONSTACK_API_KEY", "cs-fake-timeout-abcd")
+    primary = ScriptedExecutionAdapter([
+        ProviderExecutionError(ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED),
+    ])
+    fallback = ScriptedExecutionAdapter([
+        ProviderExecutionError(ExecutionErrorCategory.PROVIDER_TIMEOUT),
+    ])
+    service, _store = _execution_service(
+        tmp_path,
+        monkeypatch,
+        primary,
+        adapters={"openrouter": primary, "commonstack": fallback},
+    )
+    with pytest.raises(LLMExecutionError) as exc_info:
+        service.execute(_request("dual-failure"))
+    assert exc_info.value.category is ExecutionErrorCategory.PROVIDER_TIMEOUT
+    assert len(primary.calls) == 1
+    assert len(fallback.calls) == 1
+
+
+def test_missing_commonstack_route_preserves_primary_quota_error(
+    tmp_path, monkeypatch
+):
+    monkeypatch.delenv("COMMONSTACK_API_KEY", raising=False)
+    primary = ScriptedExecutionAdapter([
+        ProviderExecutionError(ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED),
+    ])
+    fallback = ScriptedExecutionAdapter([])
+    service, _store = _execution_service(
+        tmp_path,
+        monkeypatch,
+        primary,
+        adapters={"openrouter": primary, "commonstack": fallback},
+    )
+    with pytest.raises(LLMExecutionError) as exc_info:
+        service.execute(_request("missing-fallback"))
+    assert exc_info.value.category is ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED
+    assert fallback.calls == []
+```
+
+Add the release-failure and double-quota guards explicitly:
+
+```python
+def test_primary_release_failure_aborts_before_fallback(tmp_path, monkeypatch):
+    monkeypatch.setenv("COMMONSTACK_API_KEY", "cs-fake-unused-abcd")
+    primary = ScriptedExecutionAdapter([
+        ProviderExecutionError(ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED),
+    ])
+    fallback = ScriptedExecutionAdapter([])
+    service, _store = _execution_service(
+        tmp_path,
+        monkeypatch,
+        primary,
+        adapters={"openrouter": primary, "commonstack": fallback},
+    )
+
+    def fail_release(*_args, **_kwargs):
+        raise RuntimeError("synthetic release failure")
+
+    monkeypatch.setattr(service.credits, "release_llm_credits", fail_release)
+    with pytest.raises(LLMExecutionError) as exc_info:
+        service.execute(_request("release-failure"))
+
+    assert exc_info.value.category is ExecutionErrorCategory.BILLING_FAILED
+    assert fallback.calls == []
+
+
+def test_two_quota_failures_stop_after_commonstack(tmp_path, monkeypatch):
+    monkeypatch.setenv("COMMONSTACK_API_KEY", "cs-fake-double-quota-abcd")
+    primary = ScriptedExecutionAdapter([
+        ProviderExecutionError(ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED),
+    ])
+    fallback = ScriptedExecutionAdapter([
+        ProviderExecutionError(ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED),
+    ])
+    service, _store = _execution_service(
+        tmp_path,
+        monkeypatch,
+        primary,
+        adapters={"openrouter": primary, "commonstack": fallback},
+    )
+
+    with pytest.raises(LLMExecutionError) as exc_info:
+        service.execute(_request("double-quota"))
+
+    assert exc_info.value.category is ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED
+    assert len(primary.calls) == 1
+    assert len(fallback.calls) == 1
+```
+
+- [ ] **Step 3: Run the failover tests and verify they fail**
+
+Run:
+
+```bash
+/opt/anaconda3/bin/python3 -m pytest -q \
+  dashboard/backend/tests/infrastructure/llm/test_platform_credits_env_fallback.py \
+  -k "failover or quota_error"
+```
+
+Expected: FAIL because execution currently performs exactly the requested
+provider attempt and has no requested-versus-actual attribution.
+
+- [ ] **Step 4: Add additive result attribution**
+
+Extend the result model without breaking older test doubles:
+
+```python
+class LLMExecutionResult(BaseModel):
+    requested_provider_id: str | None = Field(default=None, min_length=2, max_length=64)
+```
+
+Update `_result` to accept `requested_provider_id: str`, set the actual
+`provider_id` from the attempt request, and always populate the requested value
+in production results.
+
+- [ ] **Step 5: Refactor one provider attempt behind a private method**
+
+Move the current provider, credential, pricing, adapter, BYOK, and Platform
+Credits logic into `_execute_once`. Pass attempt identity to the existing
+platform execution method:
+
+```python
+reservation = self.credits.reserve_llm_credits(
+    user_id=request.user_id,
+    run_id=request.run_id,
+    call_index=request.call_index,
+    attempt_index=attempt_index,
+    provider_id=request.provider_id,
+    amount_micro=reserved_micro,
+)
+```
+
+Keep `_execute_platform` responsible for releasing its own reservation before
+its error escapes. A release error must replace the provider category with
+`billing_failed`, which prevents routing into fallback.
+
+- [ ] **Step 6: Implement the one-way policy around `_execute_once`**
+
+Use the typed category and immutable request copy only:
+
+```python
+def _execute_with_platform_failover(
+    self,
+    request: LLMExecutionRequest,
+) -> LLMExecutionResult:
+    try:
+        return self._execute_once(
+            request,
+            attempt_index=0,
+            requested_provider_id=request.provider_id,
+        )
+    except LLMExecutionError as primary_error:
+        if (
+            request.billing_mode is not BillingMode.PLATFORM_CREDITS
+            or request.provider_id != "openrouter"
+            or primary_error.category
+            is not ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED
+        ):
+            raise
+
+        try:
+            self.providers.preflight_execution_model("commonstack", request.model_id)
+            self.providers.preflight_platform_credential("commonstack")
+        except (ProviderNotFoundError, CredentialResolutionError, UnsupportedExecutionModel):
+            raise primary_error
+
+        fallback_request = request.model_copy(update={"provider_id": "commonstack"})
+        return self._execute_once(
+            fallback_request,
+            attempt_index=1,
+            requested_provider_id=request.provider_id,
+        )
+```
+
+Import the three explicit preflight exceptions from their existing domain
+modules. Do not catch an unexpected repository exception as route ineligibility.
+The public `execute` method must wrap this policy in its existing single outer
+analytics try/except so a recovered primary quota error does not emit a failed
+safe-error event.
+
+- [ ] **Step 7: Attribute success and final errors correctly**
+
+Update `_emit_model_usage` to use `result.provider_id` while retaining the
+original request's user, run, call index, model, and billing mode. Extend
+`_analytics_error_category` with:
+
+```python
+ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED: "provider_quota_exhausted",
+```
+
+Use the result's actual provider for pricing evidence by building the fallback
+snapshot from the copied request. Do not emit a separate failure event for the
+released primary attempt.
+
+Add an OpenAI-compatible adapter contract using a CommonStack provider record
+with `model_allowlist=("qwen/qwen3.7-plus",)`. Capture the SDK kwargs and assert:
+
+```python
+assert captured["model"] == "qwen/qwen3.7-plus"
+assert captured["max_tokens"] == 4096
+assert captured["temperature"] == 0.2
+assert captured["extra_body"] == {"reasoning": {"effort": "high"}}
+```
+
+The test request must set `reasoning_effort="high"`; it must not contain a
+second call with `reasoning_effort="none"`.
+
+- [ ] **Step 8: Run failover and existing platform execution tests**
+
+Run:
+
+```bash
+/opt/anaconda3/bin/python3 -m pytest -q \
+  dashboard/backend/tests/infrastructure/llm/test_platform_credits_env_fallback.py \
+  dashboard/backend/tests/infrastructure/llm/test_execution_adapter_model_routes.py
+```
+
+Expected: PASS. Inspect captured requests to confirm no test changes reasoning
+effort to `none`.
+
+- [ ] **Step 9: Commit the execution layer**
+
+```bash
+git add dashboard/backend/infrastructure/llm/execution/models.py \
+  dashboard/backend/infrastructure/llm/execution/service.py \
+  dashboard/backend/tests/infrastructure/llm/test_execution_adapter_model_routes.py \
+  dashboard/backend/tests/infrastructure/llm/test_platform_credits_env_fallback.py
+git commit -m "feat: fail over platform quota errors to CommonStack"
+```
+
+---
+
+### Task 5: Preserve actual and mixed provider evidence
+
+**Files:**
+- Modify: `dashboard/backend/infrastructure/llm/execution/models.py`
+- Modify: `dashboard/backend/infrastructure/llm/execution/client.py`
+- Test: `dashboard/backend/tests/infrastructure/llm/test_execution_client.py`
+- Test: `dashboard/backend/tests/test_backtests_router.py`
+- Test: `dashboard/backend/tests/domain/analytics/test_backfill.py`
+- Test: `dashboard/backend/tests/domain/credits/test_repository.py`
+
+**Interfaces:**
+- Produces: additive `LLMRunEvidence.requested_provider_id`, `provider_ids`, and `provider_mixed` fields with historical defaults.
+- Uniform run: `provider_id` is the one actual provider, `provider_ids` contains one value, and `provider_mixed=False`.
+- Mixed run: `provider_id="mixed"`, ordered unique `provider_ids`, and `provider_mixed=True`.
+- Preserves: credential identity and pricing snapshot only when every completed call has one equal value.
+- Consumes: actual and requested provider fields from Task 4.
+
+- [ ] **Step 1: Write the failing mixed-run summary test**
+
+Allow the existing `_result` test helper to accept `provider_id`,
+`requested_provider_id`, credential last four, and a matching pricing snapshot.
+When `provider_id` is overridden, set the helper's snapshot provider to the same
+value; use distinct snapshot values for the two providers so the mixed summary
+correctly returns `pricing_snapshot=None`.
+Add:
+
+```python
+def test_execution_summary_records_mixed_actual_providers():
+    service = _FakeExecutionService([
+        _result(
+            provider_id="openrouter",
+            requested_provider_id="openrouter",
+            credential_key_last_four="1111",
+        ),
+        _result(
+            provider_id="commonstack",
+            requested_provider_id="openrouter",
+            credential_key_last_four="2222",
+        ),
+    ])
+    client = AnthropicCompatibleExecutionClient(
+        execution_service=service,
+        handoff=_handoff(),
+    )
+
+    _create(client)
+    _create(client)
+    summary = client.execution_summary()
+
+    assert summary.requested_provider_id == "openrouter"
+    assert summary.provider_id == "mixed"
+    assert summary.provider_ids == ("openrouter", "commonstack")
+    assert summary.provider_mixed is True
+    assert summary.credential_id is None
+    assert summary.credential_key_last_four is None
+    assert summary.pricing_snapshot is None
+```
+
+Keep the existing uniform-provider test and add assertions for the one-element
+`provider_ids` tuple and `provider_mixed=False`.
+
+- [ ] **Step 2: Write failing historical and API projection tests**
+
+Add a model test that validates an old `LLMRunEvidence` dictionary without the
+three new fields and asserts inferred values. Extend the sanitized backtest
+metadata test with:
+
+```python
+assert serialized["llm_execution"]["requested_provider_id"] == "openrouter"
+assert serialized["llm_execution"]["provider_id"] == "mixed"
+assert serialized["llm_execution"]["provider_ids"] == ["openrouter", "commonstack"]
+assert serialized["llm_execution"]["provider_mixed"] is True
+```
+
+Retain the raw-secret rejection assertion. Add a one-call analytics backfill
+fixture whose actual provider is CommonStack and requested provider is
+OpenRouter; assert the backfilled event uses `provider_id="commonstack"`.
+
+- [ ] **Step 3: Run the evidence tests and verify they fail**
+
+Run:
+
+```bash
+/opt/anaconda3/bin/python3 -m pytest -q \
+  dashboard/backend/tests/infrastructure/llm/test_execution_client.py \
+  dashboard/backend/tests/test_backtests_router.py \
+  dashboard/backend/tests/domain/analytics/test_backfill.py \
+  -k "provider or llm_execution"
+```
+
+Expected: FAIL because the run model rejects mixed provider results and lacks
+the additive attribution fields.
+
+- [ ] **Step 4: Add backward-compatible run evidence fields**
+
+Extend `LLMRunEvidence` and infer missing historical values before validation:
+
+```python
+requested_provider_id: str | None = Field(default=None, min_length=2, max_length=64)
+provider_ids: tuple[str, ...] = ()
+provider_mixed: bool = False
+
+@model_validator(mode="before")
+@classmethod
+def populate_provider_attribution(cls, value: object) -> object:
+    if not isinstance(value, dict):
+        return value
+    payload = dict(value)
+    provider_id = payload.get("provider_id")
+    if "requested_provider_id" not in payload:
+        payload["requested_provider_id"] = provider_id
+    if "provider_ids" not in payload:
+        payload["provider_ids"] = () if provider_id == "mixed" else (provider_id,)
+    if "provider_mixed" not in payload:
+        payload["provider_mixed"] = provider_id == "mixed"
+    return payload
+```
+
+Validate each provider identifier with the existing provider-id rules and
+enforce consistent mixed state:
+
+```python
+@field_validator("provider_ids")
+@classmethod
+def validate_provider_ids(cls, values: tuple[str, ...]) -> tuple[str, ...]:
+    cleaned = tuple(validate_provider_id(value) for value in values)
+    if len(set(cleaned)) != len(cleaned):
+        raise ValueError("provider_ids must be ordered and unique")
+    return cleaned
+
+@model_validator(mode="after")
+def validate_provider_mix(self) -> "LLMRunEvidence":
+    if self.provider_mixed:
+        if self.provider_id != "mixed" or len(self.provider_ids) < 2:
+            raise ValueError("mixed provider evidence requires multiple providers")
+    elif self.provider_ids != (self.provider_id,):
+        raise ValueError("uniform provider evidence requires one matching provider")
+    return self
+```
+
+Import `validate_provider_id` from the existing model-provider validation
+module. Historical uniform records therefore become explicit without modifying
+stored rows.
+
+- [ ] **Step 5: Aggregate actual providers without weakening identity checks**
+
+In `execution_summary`, continue requiring one billing mode and canonical model.
+Replace the old actual-provider-equals-handoff check with a requested-provider
+check:
+
+```python
+requested_provider_ids = {
+    result.requested_provider_id or self.handoff.provider_id
+    for result in self._completed_results
+}
+if requested_provider_ids != {self.handoff.provider_id}:
+    raise RuntimeError("inconsistent requested LLM provider identity")
+
+provider_ids = tuple(dict.fromkeys(
+    result.provider_id for result in self._completed_results
+))
+provider_mixed = len(provider_ids) > 1
+provider_id = "mixed" if provider_mixed else provider_ids[0]
+```
+
+Populate `requested_provider_id`, `provider_ids`, and `provider_mixed` in the
+summary. Keep the existing set-based credential and snapshot uniformity logic,
+which correctly returns `None` for mixed values.
+
+- [ ] **Step 6: Verify Credits activity uses settled actual-provider evidence**
+
+Extend the existing mixed activity repository test so two logical call indexes
+settle evidence with OpenRouter and CommonStack while both use the same model.
+Change that test's second call from `provider_id="openai", model_id="model-b"`
+to `provider_id="commonstack", model_id="model-a"`, then assert:
+
+```python
+assert activity["provider_id"] is None
+assert activity["provider_mixed"] is True
+assert activity["model_mixed"] is False
+```
+
+No activity implementation change is expected because it already derives
+provider identity from each settlement's pricing snapshot. If the test fails,
+fix only `summarize_activity_evidence`; do not add raw reservation evidence to
+the public API.
+
+- [ ] **Step 7: Run the evidence and activity suites**
+
+Run:
+
+```bash
+/opt/anaconda3/bin/python3 -m pytest -q \
+  dashboard/backend/tests/infrastructure/llm/test_execution_client.py \
+  dashboard/backend/tests/infrastructure/llm/test_platform_credits_env_fallback.py \
+  dashboard/backend/tests/test_backtests_router.py \
+  dashboard/backend/tests/domain/analytics/test_backfill.py \
+  dashboard/backend/tests/domain/credits/test_repository.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Run the complete focused regression set**
+
+Run:
+
+```bash
+/opt/anaconda3/bin/python3 -m pytest -q \
+  dashboard/backend/tests/domain/model_providers \
+  dashboard/backend/tests/domain/credits \
+  dashboard/backend/tests/domain/analytics/test_models.py \
+  dashboard/backend/tests/domain/analytics/test_backfill.py \
+  dashboard/backend/tests/infrastructure/llm/test_provider_error_mapping.py \
+  dashboard/backend/tests/infrastructure/llm/test_execution_adapter_model_routes.py \
+  dashboard/backend/tests/infrastructure/llm/test_execution_client.py \
+  dashboard/backend/tests/infrastructure/llm/test_platform_credits_env_fallback.py \
+  dashboard/backend/tests/test_model_provider_store_postgres.py \
+  dashboard/backend/tests/test_credits_api.py \
+  dashboard/backend/tests/test_backtests_router.py
+```
+
+Expected: PASS, with only PostgreSQL tests skipped when
+`TEST_POSTGRES_URL` is absent.
+
+- [ ] **Step 9: Run formatting, diff, and secret checks**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+git diff --name-only
+rg -n --hidden --glob '!dashboard/storage/data/**' \
+  '(sk-[A-Za-z0-9_-]{16,}|OPENROUTER_API_KEY=.{8,}|COMMONSTACK_API_KEY=.{8,})' \
+  dashboard docs .env.example
+```
+
+Expected: no whitespace errors; only intended source, test, spec, and plan files
+appear. Inspect every secret-scan match: only strings containing explicit
+`fake`, `test`, or `your_..._here` markers are allowed. Confirm
+`dashboard/storage/data/backtest.db` remains unstaged and absent from every
+commit.
+
+- [ ] **Step 10: Commit the evidence layer**
+
+```bash
+git add dashboard/backend/infrastructure/llm/execution/models.py \
+  dashboard/backend/infrastructure/llm/execution/client.py \
+  dashboard/backend/tests/infrastructure/llm/test_execution_client.py \
+  dashboard/backend/tests/test_backtests_router.py \
+  dashboard/backend/tests/domain/analytics/test_backfill.py \
+  dashboard/backend/tests/domain/credits/test_repository.py
+git commit -m "feat: record platform failover attribution"
+```
+
+- [ ] **Step 11: Review the final branch without deploying**
+
+Run:
+
+```bash
+git log --oneline origin/main..HEAD
+git diff --stat origin/main...HEAD
+git status --short --branch
+```
+
+Expected: the design and plan commits plus five implementation commits, no
+staged files, and only the pre-existing local
+`dashboard/storage/data/backtest.db` change. Do not push, open a PR, copy Render
+secrets, or deploy until the user explicitly authorizes those actions.

--- a/docs/superpowers/specs/2026-09-01-platform-provider-failover-design.md
+++ b/docs/superpowers/specs/2026-09-01-platform-provider-failover-design.md
@@ -1,0 +1,274 @@
+# Platform Provider Failover Design
+
+Date: 2026-09-01
+
+## Goal
+
+Keep Platform Credits backtests available when OpenRouter explicitly rejects a
+request because its shared account has no usable balance or quota. OpenRouter
+remains the preferred platform provider. For an eligible OpenRouter failure,
+the same logical model call may retry once through CommonStack.
+
+The failover is deliberately narrow. It is not a general retry system, it does
+not hide model or infrastructure failures, and it never moves a BYOK request
+onto a platform-owned credential.
+
+## Decisions
+
+- OpenRouter remains the primary provider for Platform Credits requests that
+  select OpenRouter.
+- CommonStack is the only fallback provider, using its OpenAI-compatible API at
+  `https://api.commonstack.ai/v1`.
+- Failover requires an explicit upstream balance or quota exhaustion signal.
+- A logical model call gets at most one CommonStack attempt.
+- The retry preserves the canonical model, messages, system message, output
+  token limit, temperature, and reasoning effort. Reasoning is never disabled
+  or changed to `none` by failover.
+- BYOK never uses this fallback, even when the user's OpenRouter key has no
+  balance.
+- Each provider attempt has an independent Credits reservation lifecycle, while
+  at most one attempt can settle a debit for the logical call.
+- Results, run evidence, Credits activity, and analytics identify the provider
+  that actually completed each call.
+
+## CommonStack provider registration
+
+Add a seeded provider with this fixed configuration:
+
+- `provider_id`: `commonstack`
+- `display_name`: `CommonStack`
+- `adapter_type`: `openai_compatible`
+- `approved_base_url`: `https://api.commonstack.ai/v1`
+- `byok_enabled`: `false`
+- `platform_enabled`: `true`
+- system messages and reasoning enabled in its declared capabilities
+- `temperature`, `max_output_tokens`, and `reasoning_effort` declared as its
+  supported parameters
+
+The platform credential resolver maps `commonstack` explicitly to
+`COMMONSTACK_API_KEY`, with the same stored-credential-first and transient
+environment-key behavior already used by OpenRouter. The complete key is never
+persisted from the environment or returned through an API, log, event, or run
+record.
+
+The initial CommonStack model allowlist contains only catalog identifiers that
+the repository's CommonStack integration report verified:
+
+- `openai/gpt-5.5`
+- `google/gemini-3.1-pro-preview`
+- `anthropic/claude-sonnet-4-6`
+- `deepseek/deepseek-v4-pro`
+- `qwen/qwen3.7-plus`
+
+`anthropic/claude-haiku-4-5` is excluded until that exact route is verified.
+An OpenRouter request for a model outside the CommonStack allowlist fails with
+the original safe OpenRouter error and does not substitute another model.
+
+Because CommonStack is a registered, platform-enabled provider, it may also be
+selected directly when its credential is available. There is no reverse
+CommonStack-to-OpenRouter failover. Platform execution options explicitly rank
+OpenRouter ahead of CommonStack so adding the alphabetically earlier
+CommonStack display name cannot change the existing default platform choice.
+
+Seed initialization must add the provider to both new and existing SQLite and
+PostgreSQL installations without overwriting later administrator changes.
+
+## Eligible failure classification
+
+Introduce a provider-neutral `provider_quota_exhausted` execution category.
+The OpenAI-compatible adapter assigns it only when an upstream error contains
+one of these explicit signals:
+
+1. HTTP status `402`; or
+2. a structured error code or type from a bounded allowlist, including
+   `in_flight_budget_exhausted`, `insufficient_quota`, `quota_exceeded`,
+   `quota_exhausted`, `insufficient_balance`, and
+   `credit_balance_exhausted`; or
+3. a bounded provider error-message field containing an approved balance or
+   quota phrase such as `insufficient balance`, `insufficient credits`,
+   `quota exceeded`, `quota exhausted`, `exceeded your current quota`, or
+   `not enough credits`.
+
+Classification inspects only an exception's structured status and error
+payload. It never inspects successful model output. Provider payloads are
+bounded before parsing and are never copied into logs, analytics, persisted
+evidence, or user-visible errors.
+
+HTTP `429` by itself is not a quota-exhaustion signal because it can represent
+a temporary request-rate limit. Generic rate limits, timeouts, malformed or
+empty responses, unsupported models, invalid credentials, network errors, and
+provider `5xx` responses retain their existing categories and do not trigger
+failover.
+
+The safe user message for `provider_quota_exhausted` states that the selected
+provider has insufficient balance or quota. It does not include upstream text,
+account identifiers, or secret-derived data. Unrecovered errors map to the
+same fixed `provider_quota_exhausted` analytics category rather than the
+generic internal-error bucket.
+
+## Routing flow
+
+`LLMExecutionService` remains the only provider execution and Credits billing
+entry point.
+
+For `billing_mode=platform_credits` with requested provider `openrouter`:
+
+1. Resolve OpenRouter, validate the requested model, resolve its platform
+   credential, and execute the normal reserved call.
+2. If the attempt succeeds, return it without contacting CommonStack.
+3. If it fails with `provider_quota_exhausted`, first complete the failed
+   attempt's reservation release.
+4. Confirm that CommonStack is enabled, has a platform credential, and
+   allowlists the same canonical model.
+5. Create an immutable request copy whose only changed routing field is
+   `provider_id=commonstack`, then execute one normal reserved call.
+6. Return the CommonStack result or its final safe error. Never attempt a third
+   provider call.
+
+All other requested providers execute once with no automatic alternate route.
+A missing or ineligible CommonStack route leaves the original OpenRouter quota
+error as the final error.
+
+No failover occurs after OpenRouter returned a usable completion. In
+particular, missing usage, local settlement failure, response parsing failure,
+or downstream worker failure must not issue a second provider request, because
+the first request may already be billable.
+
+For `billing_mode=byok`, execution remains exactly one call through the user's
+selected provider and verified default credential. A BYOK quota error is
+returned safely to the user and never resolves `OPENROUTER_API_KEY`,
+`COMMONSTACK_API_KEY`, or an Admin-managed Platform Credential.
+
+## Credits reservations and storage
+
+A provider attempt must be independently idempotent and auditable. Extend LLM
+reservation identity with a non-negative `attempt_index` and the attempted
+`provider_id`:
+
+- primary attempt: `attempt_index=0`, `provider_id=openrouter`;
+- fallback attempt: `attempt_index=1`, `provider_id=commonstack`.
+
+The reservation operation key, reservation identifier, request digest, and
+uniqueness constraint include `attempt_index`. The logical call identity
+remains `(user_id, run_id, call_index)` so aggregate call counts do not count a
+fallback as a second model decision.
+
+SQLite and PostgreSQL migrate existing reservation rows with
+`attempt_index=0`. A nullable legacy `provider_id` is allowed only for rows
+created before this migration; every new reservation requires a validated
+provider identifier. Repository reads remain backward compatible.
+
+The primary quota failure releases its complete reservation before the
+fallback may reserve. If release fails, fail closed with `billing_failed` and
+do not contact CommonStack. If fallback reservation fails, no fallback request
+is sent. If CommonStack succeeds, only its reservation settles against actual
+usage using the CommonStack pricing snapshot. Run finalization releases every
+still-open attempt reservation.
+
+These rules ensure that an eligible two-attempt call never holds both ceilings
+at once and never produces two Credits debits.
+
+## Result and analytics attribution
+
+`LLMExecutionResult.provider_id`, credential last four, pricing snapshot, and
+billing evidence describe the provider and credential that produced the
+successful response. Add `requested_provider_id` so a recovered call still
+records that the user selected OpenRouter. The new field is additive and
+optional at the model boundary for compatibility with existing test doubles;
+the production execution service always populates it.
+
+`model_usage_recorded` uses the result's actual provider rather than the
+original request provider. A recovered OpenRouter error does not emit a failed
+run event; only an unrecovered final error emits the existing sanitized error
+event.
+
+Run-level `LLMRunEvidence` adds ordered unique `provider_ids` and a
+`provider_mixed` flag. Its compatibility field behaves as follows:
+
+- one actual provider across all completed calls: `provider_id` is that
+  provider;
+- both OpenRouter and CommonStack completed calls: `provider_id` is `mixed`,
+  `provider_mixed=true`, and `provider_ids` contains both actual identifiers.
+
+For a recovered call, the run's `requested_provider_id` remains OpenRouter. A
+direct CommonStack run records CommonStack as both requested and actual.
+Existing single-provider runs retain their existing field values, and
+historical evidence without the new additive fields remains readable by
+inferring `provider_ids=(provider_id,)` and `provider_mixed=false`. Credential
+identity and pricing snapshot remain populated only when uniform across the
+completed calls; mixed values stay `None` rather than reporting misleading
+evidence.
+
+Credits activity continues deriving provider attribution from each settled
+reservation's billing evidence. A run containing settlements from both
+providers renders as `Multiple providers` through the existing mixed-provider
+contract.
+
+## Dual-failure behavior
+
+When CommonStack is actually attempted and fails, its safe category is the
+final execution error. If both providers report explicit quota exhaustion, the
+final category remains `provider_quota_exhausted`. If CommonStack times out or
+is unavailable, the final category reflects that condition.
+
+Only fixed categories and the ordered provider identifiers may be retained for
+internal diagnostics. Neither upstream response body, full API key, prompt,
+model response, nor account detail may enter exception messages, logs,
+analytics, or persisted failure evidence.
+
+## Out of scope
+
+- Polling either provider's account balance before a model call.
+- Round-robin, load-based, latency-based, or generic outage failover.
+- Retrying timeouts, invalid responses, model errors, or generic rate limits.
+- Switching the requested model or reducing its reasoning behavior.
+- Falling back from BYOK to Platform Credits.
+- Adding more than one CommonStack attempt per logical call.
+- Mutating Render environment variables or copying a key between Render
+  services as part of the code change.
+
+## Verification
+
+Focused unit and contract tests must cover:
+
+- CommonStack seed parity and non-overwrite behavior in SQLite and PostgreSQL;
+- stored and environment-backed `COMMONSTACK_API_KEY` resolution without secret
+  disclosure;
+- the explicit CommonStack model allowlist and rejected models;
+- exact quota classification for `402`, approved structured codes, and approved
+  phrases, plus negative cases for plain `429`, timeout, `5xx`, invalid
+  credential, and invalid response;
+- one OpenRouter success with no fallback and one eligible OpenRouter failure
+  followed by exactly one CommonStack call;
+- value-equivalent model input and generation-control fields across the retry,
+  with only `provider_id` changed and non-`none` reasoning effort preserved;
+- no failover for BYOK or any non-quota category;
+- primary release before fallback reserve, one final settlement, release
+  failure fail-closed behavior, and finalizer cleanup;
+- two-attempt reservation idempotency, logical call counting, and migration
+  compatibility in both storage backends;
+- actual and mixed provider attribution in result evidence, run metadata,
+  Credits activity, and analytics; and
+- dual-failure category selection with no secret or upstream-body leakage.
+
+All automated tests use fake provider responses and fake credentials. Real
+OpenRouter, CommonStack, Render, database, and API credentials must not appear
+in fixtures, snapshots, logs, documentation, or commits.
+
+## Acceptance criteria
+
+- A Platform Credits call requested through OpenRouter succeeds through
+  CommonStack after one explicit OpenRouter balance/quota rejection.
+- The same request does not fail over for a timeout, generic `429`, `5xx`, empty
+  response, unsupported model, invalid credential, local Credits failure, or
+  BYOK execution.
+- The fallback preserves the model input and all generation controls,
+  including reasoning effort.
+- One logical call produces at most one settled Credits debit, with every
+  failed or abandoned reservation released.
+- Completed-call evidence and analytics name the actual provider; mixed runs
+  are represented explicitly.
+- Removing or disabling the CommonStack platform credential restores the safe
+  OpenRouter quota failure without exposing any secret.
+- The change requires no production Render mutation until after merge and a
+  separate deployment authorization.


### PR DESCRIPTION
## Summary

- register CommonStack as a platform-only OpenAI-compatible provider for the five verified catalog models
- fail over from OpenRouter only on explicit, bounded balance or quota exhaustion signals
- give each provider attempt an independent Credits reservation while preserving one logical model call and at most one debit
- record requested, actual, and mixed provider attribution in execution, analytics, and Credits evidence

## Safety

- BYOK never uses platform credentials or provider fallback
- timeouts, generic 429 responses, 5xx errors, invalid responses, credential errors, unsupported models, and local billing failures do not trigger fallback
- the OpenRouter reservation must be released before CommonStack is contacted
- CommonStack is attempted at most once and preserves model, messages, output ceiling, temperature, and reasoning effort
- no Render configuration or secrets are included in this PR

## Deployment prerequisite

After merge, configure COMMONSTACK_API_KEY in the deployment environment. Without it, the original OpenRouter quota error remains the final safe error and no fallback request is sent.

## Verification

- focused regression: 439 passed, 29 skipped
- complete backend suite: 3936 passed, 152 skipped
- PostgreSQL live tests are skipped locally when TEST_POSTGRES_URL is not configured
- branch diff and secret-pattern checks passed