### PR TITLE
test: isolate iFind csi300 test from local .env LLM keys

### DIFF
--- a/dashboard/backend/tests/backtesting/test_ifind_ashare_engine.py
+++ b/dashboard/backend/tests/backtesting/test_ifind_ashare_engine.py
@@ -486,6 +486,12 @@ def test_ifind_engine_resolves_csi300_sample20_and_records_provenance(
 
     monkeypatch.setattr(engine_module, "create_market_data_provider", factory)
 
+    # The use_llm downgrade asserted below only fires with no LLM key in the
+    # environment; a developer's dashboard/.env leaks ANTHROPIC_API_KEY into
+    # os.environ whenever an earlier-collected test imports dashboard.backend.app.
+    for key in ("COMMONSTACK_API_KEY", "OPENROUTER_API_KEY", "ANTHROPIC_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+
     backtester = HourlyBacktester(
         START,
         END,


### PR DESCRIPTION
## Summary
- `test_ifind_engine_resolves_csi300_sample20_and_records_provenance` asserts the no-LLM-key `use_llm` downgrade but assumed a bare env; in full local runs any earlier test importing `dashboard.backend.app` leaks `ANTHROPIC_API_KEY` from `dashboard/.env`, failing it deterministically (CI has no `.env`, so it stayed green there).
- Fix: `monkeypatch.delenv` the three keys `make_llm_client` reads (`COMMONSTACK_API_KEY`, `OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`).

## Test plan
- [x] leak combo (`test_app_composition.py` + the iFind file) passes locally with a keyed `.env`
- [x] iFind file alone passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XXfamqoPKiuxVyJYxV7Y78