### PR TITLE
feat: hide platform provider selection and auto-route ATL credits

### DIFF
--- a/dashboard/backend/api/routers/backtests.py
+++ b/dashboard/backend/api/routers/backtests.py
@@ -1839,13 +1839,14 @@ def run_backtest_endpoint(
                 status_code=401,
                 detail="Sign in before running an LLM backtest.",
             )
-        if billing_mode is None or not provider_id or not provider_id.strip():
+        if billing_mode is None:
             raise HTTPException(
                 status_code=422,
-                detail="billing_mode and provider_id are required for LLM backtests.",
+                detail="billing_mode is required for LLM backtests.",
             )
-        provider_id = provider_id.strip()
-        if not re.fullmatch(r"^[a-z0-9_]{2,64}$", provider_id):
+        if provider_id and not re.fullmatch(
+            r"^[a-z0-9_]{2,64}$", provider_id.strip()
+        ):
             raise HTTPException(status_code=422, detail="Invalid provider id.")
         if not model or not model.strip():
             raise HTTPException(
@@ -1853,17 +1854,38 @@ def run_backtest_endpoint(
                 detail="model is required for LLM backtests.",
             )
         provider_service = get_model_provider_service()
+        provider_ids: tuple[str, ...]
         try:
-            route = provider_service.preflight_execution_model(
-                provider_id,
-                model.strip(),
-            )
             if billing_mode is BillingMode.BYOK:
+                if not provider_id or not provider_id.strip():
+                    raise HTTPException(
+                        status_code=422,
+                        detail="provider_id is required for BYOK backtests.",
+                    )
+                provider_id = provider_id.strip()
+                route = provider_service.preflight_execution_model(
+                    provider_id,
+                    model.strip(),
+                )
                 provider_service.preflight_user_default_credential(
                     int(user_id), provider_id
                 )
+                provider_ids = (provider_id,)
             else:
-                provider_service.preflight_platform_credential(provider_id)
+                provider_ids = provider_service.resolve_platform_execution_candidates(
+                    model.strip(),
+                    preferred_provider_id=provider_id,
+                )
+                if not provider_ids:
+                    raise HTTPException(
+                        status_code=422,
+                        detail="ATL Credits model execution is unavailable right now.",
+                    )
+                provider_id = provider_ids[0]
+                route = provider_service.preflight_execution_model(
+                    provider_id,
+                    model.strip(),
+                )
         except UnsupportedExecutionModel as exc:
             raise HTTPException(
                 status_code=422,
@@ -1873,7 +1895,14 @@ def run_backtest_endpoint(
                 ),
             ) from exc
         except CredentialResolutionError as exc:
+            if billing_mode is BillingMode.PLATFORM_CREDITS:
+                raise HTTPException(
+                    status_code=422,
+                    detail="ATL Credits model execution is unavailable right now.",
+                ) from exc
             raise HTTPException(status_code=422, detail=exc.safe_message) from exc
+        except HTTPException:
+            raise
         except Exception as exc:  # noqa: BLE001 - never expose provider internals
             raise HTTPException(
                 status_code=503,
@@ -1885,6 +1914,7 @@ def run_backtest_endpoint(
             run_id=live_run_id,
             billing_mode=billing_mode,
             provider_id=provider_id,
+            provider_ids=provider_ids,
             model_id=route.catalog_id,
             prompt_metadata={
                 "start_date": start_date,

--- a/dashboard/backend/domain/model_providers/service.py
+++ b/dashboard/backend/domain/model_providers/service.py
@@ -236,10 +236,6 @@ class ModelProviderService:
         for provider_id in (preferred, "openrouter", "commonstack"):
             if provider_id and provider_id not in ordered_ids:
                 ordered_ids.append(provider_id)
-        for provider_id in providers:
-            if provider_id not in ordered_ids:
-                ordered_ids.append(provider_id)
-
         candidates: list[str] = []
         for provider_id in ordered_ids:
             provider = providers.get(provider_id)

--- a/dashboard/backend/domain/model_providers/service.py
+++ b/dashboard/backend/domain/model_providers/service.py
@@ -22,6 +22,7 @@ from .execution_catalog import (
     ExecutionModelRoute,
     list_execution_model_routes,
     resolve_execution_model_route,
+    UnsupportedExecutionModel,
 )
 from .models import (
     AdminPlatformCredentialPublic,
@@ -213,6 +214,48 @@ class ModelProviderService:
         # the preferred platform lane before the CommonStack fallback.
         options.sort(key=lambda option: option.provider_id == "commonstack")
         return options
+
+    def resolve_platform_execution_candidates(
+        self,
+        catalog_model_id: str,
+        preferred_provider_id: str | None = None,
+    ) -> tuple[str, ...]:
+        """Return compatible, credentialed platform providers in preference order."""
+
+        providers = {
+            str(raw["provider_id"]): ProviderRecord.model_validate(raw)
+            for raw in self.store.list_all_providers()
+            if raw.get("provider_id")
+        }
+        preferred = (
+            validate_provider_id(preferred_provider_id)
+            if preferred_provider_id and preferred_provider_id.strip()
+            else None
+        )
+        ordered_ids: list[str] = []
+        for provider_id in (preferred, "openrouter", "commonstack"):
+            if provider_id and provider_id not in ordered_ids:
+                ordered_ids.append(provider_id)
+        for provider_id in providers:
+            if provider_id not in ordered_ids:
+                ordered_ids.append(provider_id)
+
+        candidates: list[str] = []
+        for provider_id in ordered_ids:
+            provider = providers.get(provider_id)
+            if not provider or provider.status != "enabled" or not provider.platform_enabled:
+                continue
+            try:
+                self.preflight_execution_model(provider_id, catalog_model_id)
+                self.preflight_platform_credential(provider_id)
+            except (
+                ProviderNotFoundError,
+                CredentialResolutionError,
+                UnsupportedExecutionModel,
+            ):
+                continue
+            candidates.append(provider_id)
+        return tuple(candidates)
 
     def get_platform_credential(
         self, provider_id: str

--- a/dashboard/backend/infrastructure/llm/execution/client.py
+++ b/dashboard/backend/infrastructure/llm/execution/client.py
@@ -113,6 +113,7 @@ class AnthropicCompatibleExecutionClient:
                 call_index=self._next_call_index,
                 billing_mode=self.handoff.billing_mode,
                 provider_id=self.handoff.provider_id,
+                provider_ids=self.handoff.provider_ids,
                 model_id=self.handoff.model_id,
                 system_message=system,
                 messages=messages,

--- a/dashboard/backend/infrastructure/llm/execution/handoff.py
+++ b/dashboard/backend/infrastructure/llm/execution/handoff.py
@@ -13,7 +13,11 @@ import time
 from collections.abc import Mapping
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from dashboard.backend.domain.model_providers.repository_common import (
+    validate_provider_id,
+)
 
 from dashboard.backend.infrastructure.llm.execution.models import BillingMode
 from dashboard.backend.session_tokens import session_hash_secret
@@ -41,6 +45,7 @@ class ExecutionHandoff(BaseModel):
     run_id: str = Field(min_length=1, max_length=128)
     billing_mode: BillingMode
     provider_id: str = Field(min_length=2, max_length=64, pattern=r"^[a-z0-9_]+$")
+    provider_ids: tuple[str, ...] = Field(default=(), max_length=8)
     model_id: str = Field(
         min_length=1,
         max_length=64,
@@ -50,6 +55,31 @@ class ExecutionHandoff(BaseModel):
     nonce: str = Field(min_length=16, max_length=128)
     issued_at: int = Field(gt=0)
     expires_at: int = Field(gt=0)
+
+    @model_validator(mode="before")
+    @classmethod
+    def populate_provider_candidates(cls, value: object) -> object:
+        if not isinstance(value, dict):
+            return value
+        payload = dict(value)
+        if "provider_ids" not in payload or payload["provider_ids"] is None:
+            payload["provider_ids"] = (payload.get("provider_id"),)
+        return payload
+
+    @model_validator(mode="after")
+    def validate_provider_candidates(self) -> "ExecutionHandoff":
+        try:
+            cleaned = tuple(validate_provider_id(value) for value in self.provider_ids)
+        except Exception as exc:
+            raise ValueError("invalid provider candidates") from exc
+        if (
+            not cleaned
+            or cleaned[0] != self.provider_id
+            or len(set(cleaned)) != len(cleaned)
+        ):
+            raise ValueError("provider candidates must be ordered and unique")
+        object.__setattr__(self, "provider_ids", cleaned)
+        return self
 
 
 class HandoffReplayGuard:
@@ -117,6 +147,7 @@ def create_execution_handoff(
     billing_mode: BillingMode | str,
     provider_id: str,
     model_id: str,
+    provider_ids: tuple[str, ...] | None = None,
     prompt_metadata: Mapping[str, Any] | None = None,
     ttl_seconds: int = _DEFAULT_TTL_SECONDS,
     now: int | None = None,
@@ -132,6 +163,7 @@ def create_execution_handoff(
             run_id=run_id.strip(),
             billing_mode=billing_mode,
             provider_id=provider_id.strip(),
+            provider_ids=provider_ids or (provider_id.strip(),),
             model_id=model_id.strip(),
             prompt_digest=_prompt_digest(prompt_metadata),
             nonce=secrets.token_urlsafe(24),

--- a/dashboard/backend/infrastructure/llm/execution/models.py
+++ b/dashboard/backend/infrastructure/llm/execution/models.py
@@ -54,6 +54,7 @@ class LLMExecutionRequest(BaseModel):
     call_index: int = Field(ge=0)
     billing_mode: BillingMode
     provider_id: str = Field(min_length=2, max_length=64, pattern=r"^[a-z0-9_]+$")
+    provider_ids: tuple[str, ...] = Field(default=(), max_length=8)
     model_id: str = Field(
         min_length=1,
         max_length=64,
@@ -72,6 +73,35 @@ class LLMExecutionRequest(BaseModel):
         if not value:
             raise ValueError("identifier must not be blank")
         return value
+
+    @model_validator(mode="before")
+    @classmethod
+    def populate_provider_candidates(cls, value: object) -> object:
+        if not isinstance(value, dict):
+            return value
+        payload = dict(value)
+        if "provider_ids" not in payload or payload["provider_ids"] is None:
+            payload["provider_ids"] = (payload.get("provider_id"),)
+        return payload
+
+    @field_validator("provider_ids")
+    @classmethod
+    def validate_provider_candidates(cls, values: tuple[str, ...]) -> tuple[str, ...]:
+        try:
+            cleaned = tuple(validate_provider_id(value) for value in values)
+        except Exception as exc:
+            raise ValueError("provider_ids contains an invalid provider id") from exc
+        if len(set(cleaned)) != len(cleaned):
+            raise ValueError("provider_ids must be ordered and unique")
+        return cleaned
+
+    @model_validator(mode="after")
+    def validate_provider_candidate_head(self) -> "LLMExecutionRequest":
+        candidates = self.provider_ids or (self.provider_id,)
+        if candidates[0] != self.provider_id:
+            raise ValueError("provider_ids must start with provider_id")
+        object.__setattr__(self, "provider_ids", candidates)
+        return self
 
     @field_validator("system_message")
     @classmethod

--- a/dashboard/backend/infrastructure/llm/execution/service.py
+++ b/dashboard/backend/infrastructure/llm/execution/service.py
@@ -52,6 +52,16 @@ from dashboard.backend.infrastructure.llm.token_cost import (
 AdapterResolver = Callable[[ProviderRecord], ProviderExecutionAdapter]
 PricingSnapshotFactory = Callable[[str, str], PricingSnapshot]
 
+_PLATFORM_FAILOVER_CATEGORIES = frozenset(
+    {
+        ExecutionErrorCategory.CREDENTIAL_MISSING,
+        ExecutionErrorCategory.CREDENTIAL_INVALID,
+        ExecutionErrorCategory.PROVIDER_UNAVAILABLE,
+        ExecutionErrorCategory.PROVIDER_TIMEOUT,
+        ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED,
+    }
+)
+
 
 # The provider receives the serialized messages, but its tokenizer is not
 # necessarily the same as ATL's estimator. Reserving the UTF-8 byte count is a
@@ -350,22 +360,13 @@ class LLMExecutionService:
         self,
         request: LLMExecutionRequest,
     ) -> LLMExecutionResult:
-        """Apply the one-way OpenRouter quota failover policy."""
+        """Try ordered platform candidates, retaining one requested identity."""
 
-        try:
-            return self._execute_once(
-                request,
-                attempt_index=0,
-                requested_provider_id=request.provider_id,
-            )
-        except LLMExecutionError as primary_error:
-            if (
-                request.provider_id != "openrouter"
-                or primary_error.category
-                is not ExecutionErrorCategory.PROVIDER_QUOTA_EXHAUSTED
-            ):
-                raise
-
+        candidates = tuple(request.provider_ids or (request.provider_id,))
+        # Direct service callers predating the candidate-list handoff still get
+        # the established OpenRouter -> CommonStack fallback when the route is
+        # available. New handoffs always carry the complete ordered tuple.
+        if candidates == ("openrouter",):
             try:
                 self.providers.preflight_execution_model(
                     "commonstack", request.model_id
@@ -376,16 +377,31 @@ class LLMExecutionService:
                 CredentialResolutionError,
                 UnsupportedExecutionModel,
             ):
-                raise primary_error
+                pass
+            else:
+                candidates = ("openrouter", "commonstack")
 
-            fallback_request = request.model_copy(
-                update={"provider_id": "commonstack"}
+        requested_provider_id = candidates[0]
+        last_error: LLMExecutionError | None = None
+        for attempt_index, provider_id in enumerate(candidates):
+            attempt_request = request.model_copy(
+                update={
+                    "provider_id": provider_id,
+                    "provider_ids": candidates,
+                }
             )
-            return self._execute_once(
-                fallback_request,
-                attempt_index=1,
-                requested_provider_id=request.provider_id,
-            )
+            try:
+                return self._execute_once(
+                    attempt_request,
+                    attempt_index=attempt_index,
+                    requested_provider_id=requested_provider_id,
+                )
+            except LLMExecutionError as exc:
+                last_error = exc
+                if exc.category not in _PLATFORM_FAILOVER_CATEGORIES:
+                    raise
+        assert last_error is not None
+        raise last_error
 
     def _resolve_provider(self, provider_id: str) -> ProviderRecord:
         store = getattr(self.providers, "store", None)

--- a/dashboard/backend/tests/domain/model_providers/test_execution_catalog.py
+++ b/dashboard/backend/tests/domain/model_providers/test_execution_catalog.py
@@ -10,6 +10,8 @@ from dashboard.backend.domain.model_providers.execution_catalog import (
     resolve_execution_model_route,
 )
 from dashboard.backend.domain.model_providers.models import ProviderRecord
+from dashboard.backend.domain.model_providers.repository import ModelProviderStore
+from dashboard.backend.domain.model_providers.service import ModelProviderService
 
 
 def _provider(
@@ -100,3 +102,21 @@ def test_custom_provider_requires_an_explicit_allowlist():
 def test_custom_provider_allowlist_rejects_invalid_model_ids():
     with pytest.raises(ValueError, match="model_allowlist"):
         _provider("openai_compatible", allowlist=("not allowed?",))
+
+
+def test_platform_candidates_prefer_openrouter_and_support_commonstack_only(
+    tmp_path, monkeypatch
+):
+    store = ModelProviderStore(tmp_path / "providers.db")
+    service = ModelProviderService(store=store)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-openrouter-test-abcd")
+    monkeypatch.setenv("COMMONSTACK_API_KEY", "cs-commonstack-test-abcd")
+
+    assert service.resolve_platform_execution_candidates(
+        "qwen/qwen3.7-plus"
+    ) == ("openrouter", "commonstack")
+
+    monkeypatch.delenv("OPENROUTER_API_KEY")
+    assert service.resolve_platform_execution_candidates(
+        "qwen/qwen3.7-plus"
+    ) == ("commonstack",)

--- a/dashboard/backend/tests/infrastructure/llm/test_execution_handoff.py
+++ b/dashboard/backend/tests/infrastructure/llm/test_execution_handoff.py
@@ -1,0 +1,45 @@
+import pytest
+
+from dashboard.backend.infrastructure.llm.execution.handoff import (
+    consume_execution_handoff,
+    create_execution_handoff,
+)
+
+
+def test_handoff_round_trips_ordered_provider_candidates():
+    payload = create_execution_handoff(
+        user_id=1,
+        run_id="run-1",
+        billing_mode="platform_credits",
+        provider_id="openrouter",
+        provider_ids=("openrouter", "commonstack"),
+        model_id="qwen/qwen3.7-plus",
+        now=1_000,
+    )
+
+    handoff = consume_execution_handoff(payload, now=1_001)
+
+    assert handoff.provider_id == "openrouter"
+    assert handoff.provider_ids == ("openrouter", "commonstack")
+
+
+def test_handoff_rejects_duplicate_or_misordered_candidates():
+    with pytest.raises(ValueError):
+        create_execution_handoff(
+            user_id=1,
+            run_id="run-1",
+            billing_mode="platform_credits",
+            provider_id="openrouter",
+            provider_ids=("commonstack", "openrouter"),
+            model_id="qwen/qwen3.7-plus",
+        )
+
+    with pytest.raises(ValueError):
+        create_execution_handoff(
+            user_id=1,
+            run_id="run-1",
+            billing_mode="platform_credits",
+            provider_id="openrouter",
+            provider_ids=("openrouter", "openrouter"),
+            model_id="qwen/qwen3.7-plus",
+        )

--- a/dashboard/backend/tests/infrastructure/llm/test_platform_credits_env_fallback.py
+++ b/dashboard/backend/tests/infrastructure/llm/test_platform_credits_env_fallback.py
@@ -336,12 +336,10 @@ def test_platform_quota_error_retries_once_through_commonstack(
 @pytest.mark.parametrize(
     "category",
     [
-        ExecutionErrorCategory.PROVIDER_TIMEOUT,
-        ExecutionErrorCategory.PROVIDER_UNAVAILABLE,
         ExecutionErrorCategory.RESPONSE_INVALID,
         ExecutionErrorCategory.USAGE_UNAVAILABLE,
-        ExecutionErrorCategory.CREDENTIAL_INVALID,
         ExecutionErrorCategory.BILLING_FAILED,
+        ExecutionErrorCategory.ACCOUNT_RESTRICTED,
     ],
 )
 def test_non_quota_platform_failures_do_not_fail_over(
@@ -362,6 +360,43 @@ def test_non_quota_platform_failures_do_not_fail_over(
 
     assert exc_info.value.category is category
     assert fallback.calls == []
+
+
+@pytest.mark.parametrize(
+    "category",
+    [
+        ExecutionErrorCategory.PROVIDER_TIMEOUT,
+        ExecutionErrorCategory.PROVIDER_UNAVAILABLE,
+        ExecutionErrorCategory.CREDENTIAL_INVALID,
+    ],
+)
+def test_provider_selection_failures_fail_over_to_commonstack(
+    tmp_path, monkeypatch, category
+):
+    monkeypatch.setenv("COMMONSTACK_API_KEY", "cs-fake-failover-abcd")
+    primary = ScriptedExecutionAdapter([ProviderExecutionError(category)])
+    fallback = ScriptedExecutionAdapter(
+        [
+            AdapterResponse(
+                text="BUY",
+                model_id=MODEL_ID,
+                usage=LLMUsage(input_tokens=10, output_tokens=5),
+            )
+        ]
+    )
+    service, _store = _execution_service(
+        tmp_path,
+        monkeypatch,
+        primary,
+        adapters={"openrouter": primary, "commonstack": fallback},
+    )
+
+    result = service.execute(_request(f"failover-{category.value}"))
+
+    assert result.provider_id == "commonstack"
+    assert result.requested_provider_id == "openrouter"
+    assert len(primary.calls) == 1
+    assert len(fallback.calls) == 1
 
 
 def test_byok_quota_error_never_uses_platform_fallback(tmp_path, monkeypatch):

--- a/dashboard/backend/tests/test_backtests_router.py
+++ b/dashboard/backend/tests/test_backtests_router.py
@@ -391,6 +391,24 @@ class _OpenRouterExecutionPreflightService:
         self.credential_calls.append((None, provider_id))
 
 
+class _AutoPlatformExecutionPreflightService(_OpenRouterExecutionPreflightService):
+    def resolve_platform_execution_candidates(
+        self, catalog_model_id, preferred_provider_id=None
+    ):
+        assert catalog_model_id in _ATL_EXECUTION_MODEL_IDS
+        return ("openrouter", "commonstack")
+
+    def preflight_execution_model(self, provider_id, catalog_model_id):
+        self.execution_calls.append((provider_id, catalog_model_id))
+        if provider_id not in {"openrouter", "commonstack"}:
+            raise UnsupportedExecutionModel(catalog_model_id)
+        return ExecutionModelRoute(
+            catalog_id=catalog_model_id,
+            label=catalog_model_id,
+            provider_model_id=catalog_model_id,
+        )
+
+
 def _enable_authenticated_openrouter_byok(monkeypatch):
     service = _OpenRouterExecutionPreflightService()
     monkeypatch.setattr(bt, "get_model_provider_service", lambda: service)
@@ -1108,6 +1126,44 @@ def test_openai_byok_accepts_gpt_catalog_id_and_keeps_it_in_handoff(monkeypatch)
     assert captured_handoff["model_id"] == "openai/gpt-5.5"
     assert service.execution_calls == [("openai", "openai/gpt-5.5")]
     assert service.credential_calls == [(7, "openai")]
+    assert spy.calls == 1
+
+
+def test_platform_credits_resolves_candidates_without_provider_input(monkeypatch):
+    spy = _Spy()
+    service = _AutoPlatformExecutionPreflightService()
+    captured_handoff = {}
+    monkeypatch.setattr(bt, "run_backtest_background", spy)
+    monkeypatch.setattr(bt, "get_model_provider_service", lambda: service)
+    monkeypatch.setattr(
+        "dashboard.backend.api.dependencies._optional_user",
+        lambda *_args, **_kwargs: {"id": 7},
+    )
+
+    def capture_handoff(**kwargs):
+        captured_handoff.update(kwargs)
+        return "signed-platform-handoff"
+
+    monkeypatch.setattr(bt, "create_execution_handoff", capture_handoff)
+
+    response = TestClient(app).post(
+        "/backtest/run",
+        json={
+            "start_date": "2026-05-01",
+            "end_date": "2026-05-02",
+            "decision_source": "llm",
+            "billing_mode": "platform_credits",
+            "model": "qwen/qwen3.7-plus",
+        },
+        headers=_sess(),
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["provider_id"] == "openrouter"
+    assert captured_handoff["provider_id"] == "openrouter"
+    assert captured_handoff["provider_ids"] == ("openrouter", "commonstack")
+    assert service.execution_calls == [("openrouter", "qwen/qwen3.7-plus")]
+    assert service.credential_calls == []
     assert spy.calls == 1
 
 

--- a/dashboard/backend/tests/test_byok_backtest_frontend.py
+++ b/dashboard/backend/tests/test_byok_backtest_frontend.py
@@ -27,6 +27,7 @@ def test_run_backtest_modal_has_execution_controls():
     _assert_contains(APP_HTML, 'data-billing-mode="byok"')
     _assert_contains(APP_HTML, 'data-billing-mode="platform_credits"')
     _assert_contains(APP_HTML, 'id="runBacktestProviderSelect"')
+    _assert_contains(APP_HTML, 'id="runBacktestProviderControl"')
     _assert_contains(APP_HTML, 'id="modelSelect"')
     _assert_contains(APP_HTML, "Model for this run")
 
@@ -44,6 +45,29 @@ def test_pipeline_llm_payload_sends_explicit_execution_lane():
     _assert_contains(body, "payload.provider_id")
     _assert_contains(body, "payload.model")
     _assert_contains(body, "Choose an AI billing method, provider, and model.")
+
+
+def test_atl_credits_hides_provider_and_omits_provider_payload():
+    _assert_contains(APP_JS, "function syncRunBacktestProviderVisibility()")
+    visibility = _function_body("syncRunBacktestProviderVisibility")
+    _assert_contains(visibility, "runBacktestBillingMode !== 'byok'")
+    body = _function_body("runBacktest")
+    _assert_contains(body, "selectedBillingMode === 'platform_credits'")
+    _assert_contains(body, "if (selectedBillingMode === 'byok')")
+    assert body.index("payload.billing_mode = selectedBillingMode") < body.index(
+        "payload.provider_id = selectedProviderId"
+    )
+    _assert_contains(
+        APP_JS,
+        "ATL Credits automatically use OpenRouter first, then CommonStack if needed.",
+    )
+
+
+def test_atl_model_options_are_merged_without_duplicate_ids():
+    body = _function_body("syncRunBacktestModelOptions")
+    _assert_contains(body, "availableRunBacktestProviders('platform_credits')")
+    _assert_contains(body, "const seenModels = new Set()")
+    _assert_contains(body, "seenModels.has(normalizedId)")
 
 
 def test_completed_run_config_prefers_backend_execution_evidence():

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -427,11 +427,13 @@
                             aria-checked="false"
                         >Use ATL Credits</button>
                     </div>
-                    <label for="runBacktestProviderSelect">Provider</label>
-                    <select
-                        class="control-select"
-                        id="runBacktestProviderSelect"
-                    ></select>
+                    <div id="runBacktestProviderControl">
+                        <label for="runBacktestProviderSelect">Provider</label>
+                        <select
+                            class="control-select"
+                            id="runBacktestProviderSelect"
+                        ></select>
+                    </div>
                     <p
                         id="runBacktestBillingHint"
                         class="control-helper"

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -7549,14 +7549,25 @@ function syncRunBacktestSubmitAvailability() {
     }
     const providerId = document.getElementById('runBacktestProviderSelect')?.value || '';
     const option = runBacktestExecutionOption(providerId);
+    const platformModelAvailable = availableRunBacktestProviders('platform_credits')
+        .some((provider) => Boolean(findRunBacktestExecutionModel(provider, modelId)));
+    const laneModelAvailable = runBacktestBillingMode === 'platform_credits'
+        ? platformModelAvailable
+        : runBacktestLaneAvailable(option, runBacktestBillingMode)
+            && Boolean(findRunBacktestExecutionModel(option, modelId));
     submit.disabled = !(
         runBacktestOptionsReady
         && runBacktestBillingMode
-        && providerId
         && modelId
         && modelId !== RULE_BASED_DECISION_SOURCE
-        && runBacktestLaneAvailable(option, runBacktestBillingMode)
-        && Boolean(findRunBacktestExecutionModel(option, modelId))
+        && laneModelAvailable
+        && (
+            runBacktestBillingMode === 'platform_credits'
+            || (
+                providerId
+                && runBacktestLaneAvailable(option, runBacktestBillingMode)
+            )
+        )
     );
 }
 
@@ -7565,17 +7576,28 @@ function syncRunBacktestModelOptions(preferredModelId = '') {
     const modelSelect = document.getElementById('modelSelect');
     if (!modelSelect) return;
     const previousRuleBased = modelSelect.value === RULE_BASED_DECISION_SOURCE;
+    const isPlatformCredits = runBacktestBillingMode === 'platform_credits';
     const option = runBacktestExecutionOption(providerSelect?.value || '');
+    const providers = isPlatformCredits
+        ? availableRunBacktestProviders('platform_credits')
+        : (option ? [option] : []);
     clearSelectOptions(modelSelect);
-    (option?.models || []).forEach((model) => {
+    const seenModels = new Set();
+    providers.flatMap((provider) => provider.models || []).forEach((model) => {
+        const normalizedId = normalizeBacktestModelId(model.model_id);
+        if (!normalizedId || seenModels.has(normalizedId)) return;
+        seenModels.add(normalizedId);
         const modelOption = document.createElement('option');
         modelOption.value = model.model_id;
         modelOption.textContent = model.label;
         modelSelect.appendChild(modelOption);
     });
-    const preferred = findRunBacktestExecutionModel(option, preferredModelId)
-        || findRunBacktestExecutionModel(option, runBacktestModalAgent?.model_name)
-        || option?.models?.[0]
+    const findModel = (modelId) => providers
+        .map((provider) => findRunBacktestExecutionModel(provider, modelId))
+        .find(Boolean) || null;
+    const preferred = findModel(preferredModelId)
+        || findModel(runBacktestModalAgent?.model_name)
+        || providers[0]?.models?.[0]
         || null;
     if (preferred) modelSelect.value = preferred.model_id;
     if (document.getElementById('marketDataSourceSelect')?.value === IFIND_ASHARE_SOURCE) {
@@ -7584,6 +7606,12 @@ function syncRunBacktestModelOptions(preferredModelId = '') {
     }
     syncBacktestModelFieldMode();
     syncRunBacktestSubmitAvailability();
+}
+
+function syncRunBacktestProviderVisibility() {
+    const control = document.getElementById('runBacktestProviderControl');
+    if (!control) return;
+    control.hidden = runBacktestBillingMode !== 'byok';
 }
 
 function setRunBacktestBillingMode(
@@ -7606,17 +7634,20 @@ function setRunBacktestBillingMode(
 
     const providerSelect = document.getElementById('runBacktestProviderSelect');
     clearSelectOptions(providerSelect);
-    providers.forEach((provider) => {
-        const option = document.createElement('option');
-        option.value = provider.provider_id;
-        option.textContent = provider.display_name;
-        providerSelect?.appendChild(option);
-    });
-    if (providerSelect && providers.length) {
+    if (billingMode === 'byok') {
+        providers.forEach((provider) => {
+            const option = document.createElement('option');
+            option.value = provider.provider_id;
+            option.textContent = provider.display_name;
+            providerSelect?.appendChild(option);
+        });
+    }
+    if (providerSelect && billingMode === 'byok' && providers.length) {
         providerSelect.value = providers.some(
             (provider) => provider.provider_id === providerId,
         ) ? providerId : providers[0].provider_id;
     }
+    syncRunBacktestProviderVisibility();
     syncRunBacktestModelOptions(modelId);
 
     const hint = document.getElementById('runBacktestBillingHint');
@@ -7624,7 +7655,7 @@ function setRunBacktestBillingMode(
         hint.textContent = runBacktestBillingMode === 'byok'
             ? 'Provider charges go directly to your API key. ATL Credits are not deducted.'
             : (runBacktestBillingMode === 'platform_credits'
-                ? 'ATL Credits are settled from actual model usage.'
+                ? 'ATL Credits automatically use OpenRouter first, then CommonStack if needed.'
                 : 'Choose an available AI billing method.');
     }
 }
@@ -7641,6 +7672,7 @@ function setRunBacktestExecutionUnavailable(
     runBacktestBillingMode = null;
     setRunBacktestApiKeysRecovery(showApiKeysRecovery);
     clearSelectOptions(document.getElementById('runBacktestProviderSelect'));
+    syncRunBacktestProviderVisibility();
     const modelSelect = document.getElementById('modelSelect');
     clearSelectOptions(modelSelect);
     if (
@@ -8279,22 +8311,29 @@ async function runBacktest() {
         && !isHostedRuntime
     ) {
         selectedBillingMode = runBacktestBillingMode;
-        selectedProviderId = (
-            document.getElementById('runBacktestProviderSelect')?.value || ''
-        );
+        if (selectedBillingMode === 'byok') {
+            selectedProviderId = (
+                document.getElementById('runBacktestProviderSelect')?.value || ''
+            );
+        }
         const providerOption = runBacktestExecutionOption(selectedProviderId);
+        const platformModelAvailable = availableRunBacktestProviders(
+            'platform_credits',
+        ).some((provider) => Boolean(findRunBacktestExecutionModel(provider, model)));
+        const modelAvailable = selectedBillingMode === 'platform_credits'
+            ? platformModelAvailable
+            : runBacktestLaneAvailable(providerOption, selectedBillingMode)
+                && Boolean(findRunBacktestExecutionModel(providerOption, model));
         if (
             !selectedBillingMode
-            || !selectedProviderId
             || !model
-            || !runBacktestLaneAvailable(
-                providerOption,
-                selectedBillingMode,
-            )
-            || !findRunBacktestExecutionModel(providerOption, model)
+            || !modelAvailable
+            || (selectedBillingMode === 'byok' && !selectedProviderId)
         ) {
             showModalError(
-                'Choose an AI billing method, provider, and model.',
+                selectedBillingMode === 'platform_credits'
+                    ? 'Choose an AI billing method and model.'
+                    : 'Choose an AI billing method, provider, and model.',
             );
             return;
         }
@@ -8344,7 +8383,9 @@ async function runBacktest() {
         timeframe: isIFind ? IFIND_ASHARE_TIMEFRAME : '60m',
         decisionSource,
         billingMode: isRuleBasedDecision ? null : selectedBillingMode,
-        providerId: isRuleBasedDecision ? null : selectedProviderId,
+        providerId: isRuleBasedDecision || selectedBillingMode === 'platform_credits'
+            ? null
+            : selectedProviderId,
         marketDataLabel: isIFind
             ? 'iFinD A-Share'
             : (isSimulation ? 'vn.py Simulation' : 'Alpaca'),
@@ -8421,10 +8462,12 @@ async function runBacktest() {
         ) {
             params.set('model', model);
             params.set('billing_mode', selectedBillingMode);
-            params.set('provider_id', selectedProviderId);
             payload.billing_mode = selectedBillingMode;
-            payload.provider_id = selectedProviderId;
             payload.model = model;
+            if (selectedBillingMode === 'byok') {
+                params.set('provider_id', selectedProviderId);
+                payload.provider_id = selectedProviderId;
+            }
         }
         if (activeAgent?.agent_id && !String(activeAgent.agent_id).startsWith('mock-')) {
             payload.agent_id = activeAgent.agent_id;

--- a/docs/superpowers/plans/2026-09-01-platform-provider-auto-routing.md
+++ b/docs/superpowers/plans/2026-09-01-platform-provider-auto-routing.md
@@ -12,7 +12,7 @@
 
 ## Global Constraints
 
-- Platform order is `openrouter` then `commonstack`.
+- Automatic ATL Credits candidates are limited to `openrouter` then `commonstack`.
 - Only `credential_missing`, `credential_invalid`, `provider_unavailable`, `provider_timeout`, and `provider_quota_exhausted` may trigger provider failover.
 - Never fail over ATL account restrictions, response validation, usage-unavailable, or billing failures.
 - BYOK remains explicit-provider and never uses platform fallback.

--- a/docs/superpowers/plans/2026-09-01-platform-provider-auto-routing.md
+++ b/docs/superpowers/plans/2026-09-01-platform-provider-auto-routing.md
@@ -1,0 +1,244 @@
+# Platform Provider Auto-Routing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let ATL Credits backtests choose a model without exposing provider selection, automatically attempting OpenRouter before CommonStack with safe failover.
+
+**Architecture:** Extend the signed execution handoff and in-process execution request with an ordered provider candidate tuple. The route resolves compatible, credentialed platform providers in OpenRouter-first order; the execution service attempts each candidate and creates/settles an independent reservation per attempt. The frontend treats all platform providers as one deduplicated ATL Credits model inventory while preserving explicit BYOK controls.
+
+**Tech Stack:** FastAPI, Pydantic v2, Python `pytest`, vanilla browser JavaScript, static frontend contract tests.
+
+**Spec:** `docs/superpowers/specs/2026-09-01-platform-provider-auto-routing-design.md`
+
+## Global Constraints
+
+- Platform order is `openrouter` then `commonstack`.
+- Only `credential_missing`, `credential_invalid`, `provider_unavailable`, `provider_timeout`, and `provider_quota_exhausted` may trigger provider failover.
+- Never fail over ATL account restrictions, response validation, usage-unavailable, or billing failures.
+- BYOK remains explicit-provider and never uses platform fallback.
+- Do not stage or modify `dashboard/storage/data/backtest.db`; do not commit secrets, `.superpowers/`, or `work/`.
+
+### Task 1: Add Ordered Provider Candidates To Handoffs And Requests
+
+**Files:**
+- Modify: `dashboard/backend/infrastructure/llm/execution/handoff.py`
+- Modify: `dashboard/backend/infrastructure/llm/execution/models.py`
+- Modify: `dashboard/backend/infrastructure/llm/execution/client.py`
+- Test: `dashboard/backend/tests/infrastructure/llm/test_execution_handoff.py` (create if absent)
+- Test: `dashboard/backend/tests/infrastructure/llm/test_execution_client.py`
+
+**Interfaces:**
+- `ExecutionHandoff.provider_ids: tuple[str, ...]` is ordered, unique, and contains `provider_id` first.
+- `create_execution_handoff(..., provider_ids: tuple[str, ...] | None = None)` signs the normalized candidate tuple.
+- `LLMExecutionRequest.provider_ids: tuple[str, ...] = ()` defaults legacy requests to `(provider_id,)`.
+- `AnthropicCompatibleExecutionClient` copies `handoff.provider_ids` into each request.
+
+- [ ] **Step 1: Write failing handoff and request tests**
+
+```python
+def test_handoff_round_trips_ordered_provider_candidates():
+    payload = create_execution_handoff(
+        user_id=1,
+        run_id="run-1",
+        billing_mode="platform_credits",
+        provider_id="openrouter",
+        provider_ids=("openrouter", "commonstack"),
+        model_id="qwen/qwen3.7-plus",
+        now=1_000,
+    )
+    handoff = consume_execution_handoff(payload, now=1_001)
+    assert handoff.provider_id == "openrouter"
+    assert handoff.provider_ids == ("openrouter", "commonstack")
+
+
+def test_handoff_rejects_duplicate_or_misordered_candidates():
+    with pytest.raises(ValueError):
+        create_execution_handoff(
+            user_id=1,
+            run_id="run-1",
+            billing_mode="platform_credits",
+            provider_id="openrouter",
+            provider_ids=("commonstack", "openrouter"),
+            model_id="qwen/qwen3.7-plus",
+        )
+```
+
+- [ ] **Step 2: Run the focused tests and verify they fail**
+
+Run: `pytest dashboard/backend/tests/infrastructure/llm/test_execution_handoff.py dashboard/backend/tests/infrastructure/llm/test_execution_client.py -q`
+
+Expected: FAIL because the handoff and request types do not yet carry `provider_ids`.
+
+- [ ] **Step 3: Implement the typed candidate tuple**
+
+Add a tuple field to both Pydantic models. Normalize legacy payloads to a one-item tuple, validate every identifier with the existing provider-id validator, reject duplicates, and require the first tuple item to equal `provider_id`. Include `provider_ids` in the signed JSON payload and pass it from the client when constructing `LLMExecutionRequest`.
+
+- [ ] **Step 4: Run the focused tests and the existing client suite**
+
+Run: `pytest dashboard/backend/tests/infrastructure/llm/test_execution_handoff.py dashboard/backend/tests/infrastructure/llm/test_execution_client.py -q`
+
+Expected: PASS, including all existing single-provider callers.
+
+- [ ] **Step 5: Commit the handoff contract**
+
+```bash
+git add dashboard/backend/infrastructure/llm/execution/handoff.py dashboard/backend/infrastructure/llm/execution/models.py dashboard/backend/infrastructure/llm/execution/client.py dashboard/backend/tests/infrastructure/llm/test_execution_handoff.py dashboard/backend/tests/infrastructure/llm/test_execution_client.py
+git commit -m "feat: carry ordered platform provider candidates"
+```
+
+### Task 2: Resolve Platform Provider Candidates At The API Boundary
+
+**Files:**
+- Modify: `dashboard/backend/domain/model_providers/service.py`
+- Modify: `dashboard/backend/api/routers/backtests.py`
+- Test: `dashboard/backend/tests/test_backtests_router.py`
+- Test: `dashboard/backend/tests/domain/model_providers/test_execution_catalog.py`
+
+**Interfaces:**
+- `ModelProviderService.resolve_platform_execution_candidates(model_id: str, preferred_provider_id: str | None = None) -> tuple[str, ...]` returns only enabled, platform-enabled, model-compatible providers with a verified stored or environment credential.
+- The route accepts omitted `provider_id` for `platform_credits`, sets the first candidate as `provider_id`, and signs the complete tuple.
+
+- [ ] **Step 1: Add failing router/service contract tests**
+
+Cover OpenRouter-first ordering, CommonStack-only availability, model incompatibility, and a `422` response when no platform candidate exists. Add a request assertion that `billing_mode=platform_credits` without `provider_id` reaches handoff creation.
+
+- [ ] **Step 2: Run the focused router tests and verify failure**
+
+Run: `pytest dashboard/backend/tests/test_backtests_router.py dashboard/backend/tests/domain/model_providers/test_execution_catalog.py -q`
+
+Expected: FAIL because the service method and omitted-provider path do not exist.
+
+- [ ] **Step 3: Implement candidate resolution**
+
+Use the existing provider registry, `list_execution_model_routes`, `platform_enabled`, and `preflight_platform_credential`. Sort the default candidates with the fixed preference `("openrouter", "commonstack")`; when a legacy provider is supplied, validate it and place it first only if it is compatible and available. Keep the returned model ID as the canonical catalog ID.
+
+- [ ] **Step 4: Update `/backtest/run` validation and handoff creation**
+
+Require `provider_id` only for BYOK. For ATL Credits, call candidate resolution when it is absent, reject an empty result with a safe `422`, and call `create_execution_handoff` with both `provider_id=candidates[0]` and `provider_ids=candidates`. Keep the response's `provider_id` as the first internal candidate for backwards compatibility.
+
+- [ ] **Step 5: Run focused tests and existing backtest router coverage**
+
+Run: `pytest dashboard/backend/tests/test_backtests_router.py dashboard/backend/tests/domain/model_providers/test_execution_catalog.py -q`
+
+Expected: PASS with no raw provider credential or upstream error in responses.
+
+- [ ] **Step 6: Commit the API routing contract**
+
+```bash
+git add dashboard/backend/domain/model_providers/service.py dashboard/backend/api/routers/backtests.py dashboard/backend/tests/test_backtests_router.py dashboard/backend/tests/domain/model_providers/test_execution_catalog.py
+git commit -m "feat: resolve platform providers automatically"
+```
+
+### Task 3: Execute Ordered Failover With Safe Categories
+
+**Files:**
+- Modify: `dashboard/backend/infrastructure/llm/execution/service.py`
+- Modify: `dashboard/backend/domain/analytics/instrumentation.py` only if required to preserve attempt evidence
+- Test: `dashboard/backend/tests/infrastructure/llm/test_platform_credits_env_fallback.py`
+
+**Interfaces:**
+- `LLMExecutionService._execute_with_platform_failover(request)` iterates `request.provider_ids or (request.provider_id,)`.
+- `requested_provider_id` remains the first candidate; `provider_id` is the successful candidate.
+- Each attempt increments `attempt_index` and uses the candidate-specific reservation and pricing snapshot.
+
+- [ ] **Step 1: Expand failing execution tests**
+
+Parameterize fallback tests over `credential_missing`, `credential_invalid`, `provider_unavailable`, `provider_timeout`, and `provider_quota_exhausted`. Add assertions that `response_invalid`, `usage_unavailable`, `billing_failed`, and `account_restricted` do not call the fallback. Add a two-candidate request assertion for reservation attempt indexes `0` and `1`.
+
+- [ ] **Step 2: Run the focused fallback tests and verify the new cases fail**
+
+Run: `pytest dashboard/backend/tests/infrastructure/llm/test_platform_credits_env_fallback.py -q`
+
+Expected: FAIL for the newly allowed categories and candidate-list requests.
+
+- [ ] **Step 3: Implement bounded candidate iteration**
+
+Define a module-level immutable failover category set containing exactly the five allowed categories. For each candidate, clone the request with that provider ID, preserve the full candidate tuple, and call `_execute_once` with the current attempt index and original requested provider. Stop at the first success; if all candidates fail, raise the last safe `LLMExecutionError`. Never retry BYOK.
+
+- [ ] **Step 4: Run fallback, adapter mapping, and credit ledger tests**
+
+Run: `pytest dashboard/backend/tests/infrastructure/llm/test_platform_credits_env_fallback.py dashboard/backend/tests/infrastructure/llm/test_provider_error_mapping.py dashboard/backend/tests/domain/credits -q`
+
+Expected: PASS; failed reservations are released and successful fallback reservations settle exactly once.
+
+- [ ] **Step 5: Commit execution failover**
+
+```bash
+git add dashboard/backend/infrastructure/llm/execution/service.py dashboard/backend/tests/infrastructure/llm/test_platform_credits_env_fallback.py
+git commit -m "feat: fail over platform execution safely"
+```
+
+### Task 4: Hide Provider Selection In The ATL Credits UI
+
+**Files:**
+- Modify: `dashboard/frontend/app.html`
+- Modify: `dashboard/frontend/app.js`
+- Test: `dashboard/backend/tests/test_byok_backtest_frontend.py`
+
+**Interfaces:**
+- `syncRunBacktestModelOptions()` returns the selected provider's models for BYOK and a deduplicated union of available platform models for ATL Credits.
+- `syncRunBacktestProviderVisibility()` hides `#runBacktestProviderControl` when `runBacktestBillingMode === 'platform_credits'`.
+- `runBacktest()` sends `provider_id` only for BYOK; ATL Credits sends billing mode and model only.
+
+- [ ] **Step 1: Add failing static frontend contracts**
+
+Assert a provider control wrapper exists, the ATL hint explains automatic provider routing, provider visibility is tied to `platform_credits`, model options are deduplicated, and the ATL payload does not set `provider_id` while the BYOK payload still does.
+
+- [ ] **Step 2: Run the focused frontend contracts and verify failure**
+
+Run: `pytest dashboard/backend/tests/test_byok_backtest_frontend.py -q`
+
+Expected: FAIL because the wrapper, visibility helper, deduplicated platform model logic, and lane-specific payload are not present.
+
+- [ ] **Step 3: Update the modal markup and lane state**
+
+Wrap the existing Provider label/select in `#runBacktestProviderControl`. Keep it in the DOM for BYOK and set `hidden` for ATL Credits. Change the ATL hint to say that ATL Credits automatically chooses an available provider, with OpenRouter preferred.
+
+- [ ] **Step 4: Implement deduplicated model inventory and submit validation**
+
+For platform credits, collect models from `availableRunBacktestProviders('platform_credits')`, deduplicate by normalized `model_id`, and preserve the first provider's label. For BYOK, keep the current provider-specific list. Require only billing mode plus model for ATL Credits; require provider plus model for BYOK.
+
+- [ ] **Step 5: Omit ATL provider input from the request**
+
+Set `selectedProviderId` only in the BYOK branch. Keep `launchConfigBase.providerId` null for the user-facing ATL launch; completed run rendering can continue to use backend execution evidence.
+
+- [ ] **Step 6: Run frontend contracts and static syntax checks**
+
+Run: `pytest dashboard/backend/tests/test_byok_backtest_frontend.py dashboard/backend/tests/test_credits_frontend.py -q`
+
+Expected: PASS. Run: `node --check dashboard/frontend/app.js` and expect exit code `0`.
+
+- [ ] **Step 7: Commit the UI behavior**
+
+```bash
+git add dashboard/frontend/app.html dashboard/frontend/app.js dashboard/backend/tests/test_byok_backtest_frontend.py
+git commit -m "feat: simplify ATL credits model selection"
+```
+
+### Task 5: Full Verification And PR Handoff
+
+**Files:**
+- No new production files.
+- Test: all existing backend test files under `dashboard/backend/tests`.
+
+- [ ] **Step 1: Run the full backend suite**
+
+Run: `pytest dashboard/backend/tests -q`
+
+Expected: PASS with the existing database file still unstaged.
+
+- [ ] **Step 2: Inspect the diff and secret boundary**
+
+Run: `git diff origin/main...HEAD --stat`, `git diff origin/main...HEAD -- dashboard/frontend dashboard/backend`, and `git status --short`.
+
+Confirm no API key, database file, `.superpowers/`, or `work/` path is staged.
+
+- [ ] **Step 3: Push the feature branch**
+
+```bash
+git push -u origin feature/platform-provider-failover
+```
+
+- [ ] **Step 4: Report the PR-ready commit set**
+
+Provide the branch, commits, tests, and the expected latency behavior: quota/credential failures fail fast; only provider timeouts add one timeout window.

--- a/docs/superpowers/specs/2026-09-01-platform-provider-auto-routing-design.md
+++ b/docs/superpowers/specs/2026-09-01-platform-provider-auto-routing-design.md
@@ -19,7 +19,7 @@ When a user runs an LLM backtest with `Use ATL Credits`, the UI exposes only the
 
 ## Architecture
 
-The browser continues to load `/api/credits/execution-options`, but treats platform providers as one ATL Credits inventory. It sends `billing_mode=platform_credits`, `model`, and no user-selected provider. The route resolves the first compatible enabled platform credential in preferred order (`openrouter`, then `commonstack`) and signs that choice into the handoff. The execution service retries the same catalog model through the next candidate when the first attempt returns a failover-safe category; each attempt owns an independent reservation and settlement lifecycle.
+The browser continues to load `/api/credits/execution-options`, but treats OpenRouter and CommonStack platform models as one ATL Credits inventory. It sends `billing_mode=platform_credits`, `model`, and no user-selected provider. The route resolves the first compatible enabled platform credential in preferred order (`openrouter`, then `commonstack`) and signs that choice into the handoff. The execution service retries the same catalog model through the next candidate when the first attempt returns a failover-safe category; each attempt owns an independent reservation and settlement lifecycle.
 
 The signed handoff carries the ordered provider candidates so the worker can make the same decision without trusting client input. Existing BYOK handoffs remain single-provider. A fallback result uses the original requested provider in `requested_provider_id` and the successful provider in `provider_id`, preserving analytics and run evidence.
 

--- a/docs/superpowers/specs/2026-09-01-platform-provider-auto-routing-design.md
+++ b/docs/superpowers/specs/2026-09-01-platform-provider-auto-routing-design.md
@@ -1,0 +1,56 @@
+# Platform Provider Auto-Routing Design
+
+## Goal
+
+When a user runs an LLM backtest with `Use ATL Credits`, the UI exposes only the approved model list. The backend automatically tries OpenRouter first and falls back to CommonStack when the first provider cannot serve the request because of quota, balance, credential availability, timeout, or temporary provider unavailability. BYOK keeps its explicit provider selection.
+
+## Scope
+
+- Hide the Provider selector only for the `platform_credits` billing lane.
+- Keep the Provider selector and default-key validation for BYOK.
+- Merge platform-available model options into one model picker without duplicate models.
+- Accept an omitted `provider_id` for platform-credit LLM backtests.
+- Resolve an ordered, model-compatible provider candidate list with OpenRouter before CommonStack.
+- Preserve the requested model and record the provider that actually completed each call.
+- Fail over only for provider-selection failures where another provider may succeed:
+  `credential_missing`, `credential_invalid`, `provider_unavailable`, `provider_timeout`, and `provider_quota_exhausted`.
+- Do not fail over `response_invalid`, `usage_unavailable`, `billing_failed`, or account-level ATL credit restrictions.
+- Never expose provider secrets or raw upstream errors.
+
+## Architecture
+
+The browser continues to load `/api/credits/execution-options`, but treats platform providers as one ATL Credits inventory. It sends `billing_mode=platform_credits`, `model`, and no user-selected provider. The route resolves the first compatible enabled platform credential in preferred order (`openrouter`, then `commonstack`) and signs that choice into the handoff. The execution service retries the same catalog model through the next candidate when the first attempt returns a failover-safe category; each attempt owns an independent reservation and settlement lifecycle.
+
+The signed handoff carries the ordered provider candidates so the worker can make the same decision without trusting client input. Existing BYOK handoffs remain single-provider. A fallback result uses the original requested provider in `requested_provider_id` and the successful provider in `provider_id`, preserving analytics and run evidence.
+
+## API Contract
+
+`POST /backtest/run`:
+
+- BYOK LLM runs: `billing_mode=byok`, `provider_id` required, `model` required.
+- ATL Credits LLM runs: `billing_mode=platform_credits`, `provider_id` optional, `model` required. When omitted, the server resolves the ordered candidate list. A supplied provider is accepted only for backwards compatibility and is treated as the first candidate, not as a UI-controlled preference.
+- If no compatible platform provider is configured, return a safe `422` explaining that ATL Credits model execution is unavailable.
+
+`ExecutionHandoff`:
+
+- `provider_id` remains the first candidate for backwards compatibility.
+- `provider_ids` is an ordered unique tuple with one or more provider IDs for platform-credit handoffs; BYOK contains one ID.
+- The prompt digest covers the candidate list through the signed payload.
+
+## UI Behavior
+
+- `Use my API key`: show Provider and Model controls and retain current copy and validation.
+- `Use ATL Credits`: hide the Provider label/select, show one deduplicated Model select, and explain that ATL Credits automatically chooses the best available provider.
+- The submit button requires a selected model and an available ATL Credits model, but never a visible provider value.
+- The launch config may retain the backend-selected provider for diagnostics, but user-facing billing copy says `ATL Credits`.
+
+## Error Handling and Latency
+
+Provider quota/balance failures are detected from the existing fixed error categories and trigger one fallback attempt. Missing or invalid platform credentials are filtered before the worker starts. A provider timeout may add the configured adapter timeout once; quota and credential failures normally fail quickly. No balance API is assumed, because the current provider contracts do not expose reliable cross-provider balance data.
+
+## Testing
+
+- Backend router contract tests cover omitted platform `provider_id`, ordered compatible candidates, and safe no-provider responses.
+- Handoff tests cover signed candidate lists and replay/validation behavior.
+- Execution tests cover fallback for each allowed category, no fallback for response/usage/billing/account errors, independent reservations, and final provider attribution.
+- Frontend contract tests cover hidden platform Provider control, deduplicated models, payload omission of `provider_id` for ATL Credits, and unchanged BYOK behavior.


### PR DESCRIPTION
## Summary
- hide OpenRouter/CommonStack selection in the ATL Credits backtest lane
- expose one deduplicated model picker for ATL Credits
- resolve OpenRouter-first, CommonStack-second platform candidates on the server
- fail over only for safe provider-selection failures and preserve final provider evidence
- keep BYOK provider selection and behavior unchanged

## Verification
- `pytest dashboard/backend/tests -q` (3943 passed, 152 skipped)
- focused routing/failover/frontend tests: 108 passed
- `node --check dashboard/frontend/app.js`
- `git diff --check`

## Notes
- ATL Credits automatic routing is limited to OpenRouter and CommonStack.
- Quota/credential/provider failures can fail over; response, usage, billing, and ATL account restriction errors do not.
- No secrets or `dashboard/storage/data/backtest.db` are included.
