### PR TITLE
chore: password-reset follow-ups

### DIFF
--- a/dashboard/backend/tests/test_users_postgres.py
+++ b/dashboard/backend/tests/test_users_postgres.py
@@ -94,6 +94,11 @@ def temp_postgres_store():
             cur.execute("DELETE FROM password_reset_requests")
             cur.execute("DELETE FROM email_change_requests")
             cur.execute("DELETE FROM auth_sessions")
+            # Redundant on a schema this repo created (every child table FKs
+            # users with ON DELETE CASCADE), like the three above -- the
+            # explicit wipe is what keeps a long-lived dev database honest
+            # after a review branch's divergent DDL or manual tampering (#437).
+            cur.execute("DELETE FROM user_entitlements")
             cur.execute("DELETE FROM users")
     yield store
 

--- a/docs/source/lab/accounts.rst
+++ b/docs/source/lab/accounts.rst
@@ -38,6 +38,41 @@ Sign in and out
   dashboard you just left; sign in again to get back to it.
 
 
+.. _accounts-reset-password:
+
+Reset a forgotten password
+--------------------------
+
+If you cannot sign in, reset your password from the sign-in dialog:
+
+1. Click **Sign in** in the header, then **Forgot password?**.
+2. Enter your account email and click **Send code**. A 6-character reset code
+   goes to that address if it belongs to an account.
+3. Enter the code and your new password, then click **Reset password**.
+4. Sign in with the new password — the email field is already filled in.
+
+The new password must meet the same rules as at sign-up.
+
+A few things worth knowing:
+
+- **The code expires after 15 minutes**, and five wrong codes cancels the
+  request. Codes are not case-sensitive.
+- **Check your spam folder.** A code sitting in spam looks exactly like a code
+  that was never sent.
+- The confirmation looks the same whether or not the address belongs to an
+  account, so no code arriving usually means a typo in the address — or an
+  account under a different email.
+- **Need another code?** Go back to sign-in and start over from **Forgot
+  password?**. One account is sent at most one code every 5 minutes and five
+  per day; asking again sooner looks like a success but sends nothing, so wait
+  out the five minutes.
+- A successful reset **signs you out of all devices** and cancels any
+  :ref:`email change <accounts-change-email>` you had in progress. There is no
+  automatic sign-in — you sign in fresh with the new password.
+- The reverse also holds: changing your password from the **Account** page, or
+  finishing an email change, cancels an outstanding reset code.
+
+
 Manage your profile
 -------------------
 


### PR DESCRIPTION
Follow-ups to #436. Closes #437.

- **`docs/source/lab/accounts.rst`** — "Reset a forgotten password" section (explicitly out of #436's scope). Every claim verified against the shipped routes and frontend; `sphinx-build -n -E` clean, section renders.
- **`temp_postgres_store`** — wipes `user_entitlements` alongside the other child tables. Note: #437's stated mechanism does not reproduce — the FK has been `ON DELETE CASCADE` since the table's first commit (`e5daadda`), so a repo-created schema cannot strand rows, and 34/34 live postgres:18 runs are green on fresh *and* reused DBs with or without the fix. The wipe lands as hardening: the fixture already explicitly wipes three equally-cascading child tables, and a long-lived local dev DB mutated by a review branch's divergent DDL is a real hazard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XXfamqoPKiuxVyJYxV7Y78