### PR TITLE
feat(backtest): enrich agent market context

### DIFF
--- a/dashboard/backend/domain/backtesting/bar_aggregation.py
+++ b/dashboard/backend/domain/backtesting/bar_aggregation.py
@@ -170,6 +170,13 @@ def aggregate_bars(
         )
         volume = float(pd.to_numeric(group["volume"], errors="coerce").fillna(0).sum())
         close = float(group["close"].iloc[-1])
+        source_volume = pd.to_numeric(group["volume"], errors="coerce").fillna(0.0)
+        turnover_prices = pd.to_numeric(group["close"], errors="coerce")
+        if "vwap" in group.columns:
+            source_vwap = pd.to_numeric(group["vwap"], errors="coerce")
+            turnover_prices = source_vwap.where(
+                np.isfinite(source_vwap), turnover_prices
+            )
         record = {
             "timestamp": bucket_end.tz_convert("UTC"),
             "open": float(group["open"].iloc[0]),
@@ -177,6 +184,10 @@ def aggregate_bars(
             "low": float(pd.to_numeric(group["low"], errors="coerce").min()),
             "close": close,
             "volume": volume,
+            # Alpaca's per-bar VWAP times share volume is the traded notional.
+            # Falling back to each source bar's close keeps older fixtures and
+            # providers useful without introducing an hour-end-price estimate.
+            "turnover": float((turnover_prices * source_volume).sum()),
             "source_bar_count": int(len(group)),
             "expected_source_bars": expected,
             "missing_source_bars": int(missing_source_bars),

--- a/dashboard/backend/domain/backtesting/engine.py
+++ b/dashboard/backend/domain/backtesting/engine.py
@@ -60,6 +60,10 @@ from dashboard.backend.infrastructure.market_data.alpaca_bars import (
     MarketDataUnavailableError,
     feed_provenance,
 )
+from dashboard.backend.infrastructure.market_data.equity_metadata import (
+    EquityMetadataUnavailableError,
+    load_and_enrich_us_equity_bars,
+)
 from dashboard.backend.infrastructure.market_data.ifind_client import IFindClientError
 from dashboard.backend.infrastructure.market_data.ifind_fx import (
     IFindFxError,
@@ -265,6 +269,7 @@ class HourlyBacktester:
         self.data_quality = {}
         self.frequency_contract = None
         self.market_data_provenance = {}
+        self.equity_metadata = {}
         self.currency_context: CurrencyContext | None = None
         self.native_initial_capital = self.initial_capital
         if self.profile.native_currency == self.profile.reporting_currency:
@@ -831,6 +836,16 @@ class HourlyBacktester:
             count += 1
             if count % 5 == 0:
                 print(f"  ✅ {count}/{len(self.all_data)} symbols...")
+        if getattr(self, "data_source", None) == ALPACA:
+            try:
+                self.all_data, self.equity_metadata = load_and_enrich_us_equity_bars(
+                    self.all_data,
+                    timezone=self.profile.timezone,
+                )
+            except EquityMetadataUnavailableError as exc:
+                raise MarketDataUnavailableError(
+                    "Configured US equity metadata is unavailable"
+                ) from exc
         print(f"  ✅ All indicators calculated\n")
     
     def _effective_profile(self) -> MarketProfile:
@@ -882,6 +897,9 @@ class HourlyBacktester:
             )
         if getattr(self, "universe_selection", None) is not None:
             metadata["universe_selection"] = dict(self.universe_selection)
+        equity_metadata = dict(getattr(self, "equity_metadata", {}) or {})
+        if equity_metadata.get("status") == "available":
+            metadata["equity_metadata"] = equity_metadata
         if profile.transaction_cost_profile is not None:
             metadata["transaction_cost_profile"] = (
                 profile.transaction_cost_profile.to_metadata()
@@ -1059,6 +1077,12 @@ class HourlyBacktester:
         if getattr(self, "universe_selection", None) is not None:
             result["stock_pool"] = self.universe_selection["stock_pool"]
             result["pool_mode"] = self.universe_selection["pool_mode"]
+        equity_metadata = dict(getattr(self, "equity_metadata", {}) or {})
+        if equity_metadata.get("status") == "available":
+            result["equity_metadata"] = {
+                "classification": equity_metadata["classification"],
+                "point_in_time": equity_metadata["point_in_time"],
+            }
         if self.profile.lot_size > 1:
             # Conditional for the same reason `settlement` below is: this dict
             # is serialized straight into the LLM prompt, so an unconditional

--- a/dashboard/backend/domain/backtesting/external_run_service.py
+++ b/dashboard/backend/domain/backtesting/external_run_service.py
@@ -305,6 +305,7 @@ class ExternalBacktestSession:
         self.data_quality: Dict[str, Any] = {}
         self.frequency_contract: Optional[Dict[str, str]] = None
         self.market_data_provenance: Dict[str, Any] = {}
+        self.equity_metadata: Dict[str, Any] = {}
         self._valuation_cursor = 0
 
         self.step_opened_at: Optional[datetime] = None
@@ -369,6 +370,7 @@ class ExternalBacktestSession:
             getattr(dataset, "execution_timestamps", self.timestamps)
         )
         self.data_quality = dict(getattr(dataset, "data_quality", {}) or {})
+        self.equity_metadata = dict(getattr(dataset, "equity_metadata", {}) or {})
         self.source_timeframe = getattr(
             dataset, "source_timeframe", self.profile.timeframe
         )
@@ -541,6 +543,17 @@ class ExternalBacktestSession:
                     signal.get("bb_lower") if pd.notna(signal.get("bb_lower")) else 0
                 ),
             }
+            for field in ("turnover", "market_cap_usd"):
+                value = signal.get(field)
+                if value is not None and pd.notna(value):
+                    snapshot["top_signals"][symbol][field] = float(value)
+            sic_code = signal.get("sic_code")
+            if sic_code is not None and pd.notna(sic_code):
+                snapshot["top_signals"][symbol]["sic_code"] = int(sic_code)
+            for field in ("market_cap_status", "industry", "sector"):
+                value = signal.get(field)
+                if value is not None and pd.notna(value):
+                    snapshot["top_signals"][symbol][field] = str(value)
 
         return snapshot
 
@@ -863,6 +876,11 @@ class ExternalBacktestSession:
                     else {}
                 ),
                 **self.market_data_provenance,
+                **(
+                    {"equity_metadata": self.equity_metadata}
+                    if self.equity_metadata.get("status") == "available"
+                    else {}
+                ),
             },
         )
         db.insert_equity_points(self.run_id, equity_curve)

--- a/dashboard/backend/domain/backtesting/features.py
+++ b/dashboard/backend/domain/backtesting/features.py
@@ -40,6 +40,17 @@ class TechnicalIndicators:
 
         df = df.copy()
 
+        # Preserve an actual source-bar turnover when aggregation supplied one.
+        # Legacy hourly providers can still expose an approximation from their
+        # own bar VWAP (preferred) or close, always in the market's native currency.
+        if "turnover" not in df.columns and {"close", "volume"} <= set(df.columns):
+            prices = pd.to_numeric(df["close"], errors="coerce")
+            if "vwap" in df.columns:
+                vwap = pd.to_numeric(df["vwap"], errors="coerce")
+                prices = vwap.where(vwap.notna() & vwap.abs().lt(float("inf")), prices)
+            volume = pd.to_numeric(df["volume"], errors="coerce")
+            df["turnover"] = prices * volume
+
         # Check if we have enough data for indicators
         min_required = 50  # Need at least 50 bars for SMA50
         if len(df) < min_required:

--- a/dashboard/backend/domain/backtesting/market_data_store.py
+++ b/dashboard/backend/domain/backtesting/market_data_store.py
@@ -2,8 +2,8 @@
 
 One dataset (indicator-enriched decision bars + source bars + trading
 timestamps + price caches) per ``(symbols, start_date, end_date,
-source_timeframe, decision_timeframe)`` key, shared by every session with that
-config. READ-ONLY CONTRACT: every consumer treats the dataset frames,
+source_timeframe, decision_timeframe, equity_metadata_source)`` key, shared by
+every session with that config. READ-ONLY CONTRACT: every consumer treats the dataset frames,
 timestamps and caches as immutable — verified convention across the engine,
 baselines, and PortfolioManager. Never mutate a dataset.
 
@@ -37,6 +37,10 @@ from dashboard.backend.domain.backtesting.bar_aggregation import (
     summarize_aggregation_quality,
 )
 from dashboard.backend.infrastructure.market_data.alpaca_bars import AlpacaDataLoader
+from dashboard.backend.infrastructure.market_data.equity_metadata import (
+    configured_dataset_path,
+    load_and_enrich_us_equity_bars,
+)
 from dashboard.backend.infrastructure.market_data.frequency import (
     normalize_bar_timeframe,
     timeframe_minutes,
@@ -67,6 +71,7 @@ class MarketDataset:
         "source_data", "source_timestamps", "source_price_cache",
         "execution_timestamps", "source_timeframe", "decision_timeframe",
         "data_quality",
+        "equity_metadata",
     )
 
     def __init__(self, key: Tuple, all_data: Dict[str, pd.DataFrame],
@@ -77,7 +82,8 @@ class MarketDataset:
                  execution_timestamps: Optional[List[Any]] = None,
                  source_timeframe: str = "60m",
                  decision_timeframe: str = "60m",
-                 data_quality: Optional[Dict[str, Any]] = None):
+                 data_quality: Optional[Dict[str, Any]] = None,
+                 equity_metadata: Optional[Dict[str, Any]] = None):
         self.key = key
         self.all_data = all_data
         self.timestamps = timestamps
@@ -100,6 +106,7 @@ class MarketDataset:
         self.source_timeframe = source_timeframe
         self.decision_timeframe = decision_timeframe
         self.data_quality = data_quality or {}
+        self.equity_metadata = equity_metadata or {}
 
 
 class _Entry:
@@ -129,6 +136,7 @@ def _dataset_key(
         str(end_date),
         normalize_bar_timeframe(source_timeframe),
         normalize_bar_timeframe(decision_timeframe),
+        str(configured_dataset_path() or ""),
     )
 
 
@@ -288,6 +296,10 @@ def _build_dataset(
         raise RuntimeError("No completed decision bars returned from Alpaca")
     for symbol, df in all_data.items():
         all_data[symbol] = TechnicalIndicators.calculate_indicators(df)
+    all_data, equity_metadata = load_and_enrich_us_equity_bars(
+        all_data,
+        timezone="US/Eastern",
+    )
     timestamps = _build_trading_timestamps(all_data)
     if not timestamps:
         raise RuntimeError("No trading hours in the selected date range")
@@ -326,6 +338,7 @@ def _build_dataset(
         source_timeframe=actual_source,
         decision_timeframe=requested_decision,
         data_quality=data_quality,
+        equity_metadata=equity_metadata,
     )
     mb = sum(float(df.memory_usage(deep=True).sum()) for df in all_data.values()) / 1e6
     print(f"📊 market-data dataset built: {key[1]}→{key[2]} "

--- a/dashboard/backend/domain/backtesting/portfolio_manager.py
+++ b/dashboard/backend/domain/backtesting/portfolio_manager.py
@@ -412,6 +412,17 @@ class PortfolioManager:
                     "bb_upper": bb_upper,
                     "bb_lower": bb_lower,
                 }
+                for field in ("turnover", "market_cap_usd"):
+                    value = signal.get(field)
+                    if value is not None and pd.notna(value):
+                        market_snapshot["top_signals"][symbol][field] = float(value)
+                sic_code = signal.get("sic_code")
+                if sic_code is not None and pd.notna(sic_code):
+                    market_snapshot["top_signals"][symbol]["sic_code"] = int(sic_code)
+                for field in ("market_cap_status", "industry", "sector"):
+                    value = signal.get(field)
+                    if value is not None and pd.notna(value):
+                        market_snapshot["top_signals"][symbol][field] = str(value)
             
             # Ensure market_snapshot is fully JSON-serializable before sending
             try:

--- a/dashboard/backend/domain/trading/portfolio.py
+++ b/dashboard/backend/domain/trading/portfolio.py
@@ -91,7 +91,7 @@ def build_market_signals(market_data):
     """Build the per-symbol market-signal dict from real market data rows."""
     market_signals = {}
     for symbol, row in market_data.items():
-        market_signals[symbol] = {
+        signal = {
             "price": row["close"],
             "rsi": row.get("rsi_14"),
             "macd": row.get("macd"),
@@ -101,6 +101,19 @@ def build_market_signals(market_data):
             "bb_upper": row.get("bb_upper"),
             "bb_lower": row.get("bb_lower"),
         }
+        # Fundamental/liquidity fields are optional so providers without the
+        # configured US metadata dataset retain their historical snapshot shape.
+        for field in (
+            "turnover",
+            "market_cap_usd",
+            "market_cap_status",
+            "sic_code",
+            "industry",
+            "sector",
+        ):
+            if field in row and row.get(field) is not None:
+                signal[field] = row.get(field)
+        market_signals[symbol] = signal
     return market_signals
 
 

--- a/dashboard/backend/infrastructure/llm/validator.py
+++ b/dashboard/backend/infrastructure/llm/validator.py
@@ -564,6 +564,12 @@ Trading style:
 - Do not return all HOLD if there is cash available and at least one reasonable bullish setup.
 - Do not over-focus on RSI alone.
 
+Additional per-symbol context when present:
+- turnover is traded notional during the completed decision bar, denominated in market.native_currency.
+- market_cap_usd is point-in-time market capitalization at the decision price; market_cap_status describes data quality.
+- industry and sector are SEC SIC classifications, not GICS classifications.
+- Missing optional fields mean unavailable data, never zero.
+
 BUY logic:
 Buy when at least 2 of these are true:
 - price is above SMA20
@@ -679,6 +685,8 @@ CUSTOM_STRATEGY_OUTPUT_CONTRACT = """
 === EXECUTION CONTRACT (fixed — always obey, even if it conflicts with the strategy above) ===
 Run the strategy above as a DJIA portfolio trading agent on historical hourly data.
 - Use ONLY the provided market_snapshot. No internet, tools, APIs, or code.
+- When present, turnover is completed-bar traded notional; market_cap_usd is point-in-time; industry/sector use SEC SIC.
+- Treat missing optional market fields as unavailable, never zero.
 - Trade ONLY symbols listed in VALID SYMBOLS.
 - Only SELL symbols that are currently owned (see current_holdings).
 - position_size must be an integer share count; use 0 for hold.

--- a/dashboard/backend/infrastructure/market_data/equity_metadata.py
+++ b/dashboard/backend/infrastructure/market_data/equity_metadata.py
@@ -1,0 +1,312 @@
+"""Point-in-time US equity metadata for backtest decision bars.
+
+The runtime keeps this adapter optional: ordinary Alpaca backtests still run when
+no local metadata dataset is configured.  Once ``US_EQUITY_DATASET_PATH`` (or
+``US_EQUITY_DATA_ROOT``) points at the dataset built by the standalone download
+scripts, decision bars receive SEC SIC classification and a no-lookahead market
+capitalization calculated from the decision price and then-effective shares.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from pathlib import Path
+from typing import Any, Mapping
+
+import pandas as pd
+
+
+DATASET_PATH_ENV = "US_EQUITY_DATASET_PATH"
+DATA_ROOT_ENV = "US_EQUITY_DATA_ROOT"
+DEFAULT_DATASET_NAME = "us_equities_5min_2016_2025"
+
+_CAP_COLUMNS = [
+    "symbol",
+    "trade_date",
+    "market_cap_usd",
+    "market_cap_status",
+    "shares_outstanding_effective",
+]
+_INDUSTRY_COLUMNS = [
+    "symbol",
+    "effective_from",
+    "effective_to_exclusive",
+    "sic",
+    "sic_description",
+    "sic_division_name",
+]
+
+
+class EquityMetadataUnavailableError(RuntimeError):
+    """Raised when explicitly configured metadata cannot be read safely."""
+
+
+def configured_dataset_path(dataset_path: str | Path | None = None) -> Path | None:
+    """Resolve the optional external metadata dataset without guessing a host path."""
+
+    value = dataset_path or os.getenv(DATASET_PATH_ENV)
+    if value:
+        return Path(value).expanduser().resolve()
+    root = os.getenv(DATA_ROOT_ENV)
+    if root:
+        return (Path(root).expanduser() / DEFAULT_DATASET_NAME).resolve()
+    return None
+
+
+def _local_dates(index: pd.Index, timezone: str) -> list[Any]:
+    timestamps = pd.DatetimeIndex(index)
+    if timestamps.tz is None:
+        timestamps = timestamps.tz_localize(timezone)
+    else:
+        timestamps = timestamps.tz_convert(timezone)
+    return list(timestamps.date)
+
+
+def _valid_number(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if math.isfinite(result) else None
+
+
+def enrich_decision_bars(
+    bars_by_symbol: Mapping[str, pd.DataFrame],
+    *,
+    market_caps: pd.DataFrame | None = None,
+    industries: pd.DataFrame | None = None,
+    timezone: str = "US/Eastern",
+) -> tuple[dict[str, pd.DataFrame], dict[str, Any]]:
+    """Attach point-in-time market cap and SIC fields to decision bars.
+
+    The daily metadata's own ``market_cap_usd`` uses the final close of that
+    session.  It is used only as a validity flag here.  Intraday market cap is
+    recomputed as ``decision_close * shares_outstanding_effective`` so an hourly
+    agent never sees that later close.
+    """
+
+    caps = market_caps if market_caps is not None else pd.DataFrame(columns=_CAP_COLUMNS)
+    sectors = industries if industries is not None else pd.DataFrame(columns=_INDUSTRY_COLUMNS)
+    cap_lookup: dict[tuple[str, Any], dict[str, Any]] = {}
+    if not caps.empty:
+        missing = set(_CAP_COLUMNS) - set(caps.columns)
+        if missing:
+            raise EquityMetadataUnavailableError(
+                f"Market-cap metadata is missing columns: {sorted(missing)}"
+            )
+        normalized = caps.copy()
+        normalized["symbol"] = normalized["symbol"].astype(str).str.upper()
+        normalized["trade_date"] = pd.to_datetime(
+            normalized["trade_date"], errors="coerce"
+        ).dt.date
+        if normalized.duplicated(["symbol", "trade_date"]).any():
+            raise EquityMetadataUnavailableError(
+                "Market-cap metadata has duplicate symbol/trade_date rows"
+            )
+        cap_lookup = {
+            (row["symbol"], row["trade_date"]): row
+            for row in normalized.to_dict("records")
+        }
+
+    industry_lookup: dict[str, list[dict[str, Any]]] = {}
+    if not sectors.empty:
+        missing = set(_INDUSTRY_COLUMNS) - set(sectors.columns)
+        if missing:
+            raise EquityMetadataUnavailableError(
+                f"Industry metadata is missing columns: {sorted(missing)}"
+            )
+        normalized = sectors.copy()
+        normalized["symbol"] = normalized["symbol"].astype(str).str.upper()
+        for field in ("effective_from", "effective_to_exclusive"):
+            normalized[field] = pd.to_datetime(
+                normalized[field], errors="coerce"
+            ).dt.date
+        normalized = normalized.sort_values(["symbol", "effective_from"])
+        for symbol, rows in normalized.groupby("symbol", sort=False):
+            records = rows.to_dict("records")
+            prior_end = None
+            for record in records:
+                start = record["effective_from"]
+                end = record["effective_to_exclusive"]
+                if pd.isna(start) or pd.isna(end) or start >= end:
+                    raise EquityMetadataUnavailableError(
+                        f"Industry metadata has an invalid interval for {symbol}"
+                    )
+                if prior_end is not None and start < prior_end:
+                    raise EquityMetadataUnavailableError(
+                        f"Industry metadata has overlapping intervals for {symbol}"
+                    )
+                prior_end = end
+            industry_lookup[str(symbol)] = records
+
+    enriched: dict[str, pd.DataFrame] = {}
+    market_cap_values = 0
+    industry_values = 0
+    total_rows = 0
+    for raw_symbol, source in bars_by_symbol.items():
+        symbol = str(raw_symbol).upper()
+        frame = source.copy()
+        dates = _local_dates(frame.index, timezone)
+        total_rows += len(frame)
+
+        if cap_lookup:
+            values = []
+            statuses = []
+            for decision_date, close in zip(dates, frame["close"]):
+                reference = cap_lookup.get((symbol, decision_date))
+                status = reference.get("market_cap_status") if reference else None
+                shares = (
+                    _valid_number(reference.get("shares_outstanding_effective"))
+                    if reference
+                    else None
+                )
+                reference_cap = (
+                    _valid_number(reference.get("market_cap_usd"))
+                    if reference
+                    else None
+                )
+                decision_close = _valid_number(close)
+                value = (
+                    decision_close * shares
+                    if reference_cap is not None
+                    and shares is not None
+                    and shares > 0
+                    and decision_close is not None
+                    else None
+                )
+                values.append(value)
+                statuses.append(
+                    str(status) if status is not None and pd.notna(status) else None
+                )
+                market_cap_values += value is not None
+            frame["market_cap_usd"] = values
+            frame["market_cap_status"] = statuses
+
+        intervals = industry_lookup.get(symbol)
+        if intervals:
+            sic_values = []
+            industry_values_for_rows = []
+            sector_values = []
+            for decision_date in dates:
+                match = next(
+                    (
+                        row
+                        for row in reversed(intervals)
+                        if row["effective_from"] <= decision_date
+                        < row["effective_to_exclusive"]
+                    ),
+                    None,
+                )
+                sic = _valid_number(match.get("sic")) if match else None
+                industry = match.get("sic_description") if match else None
+                sector = match.get("sic_division_name") if match else None
+                sic_values.append(int(sic) if sic is not None else None)
+                industry_values_for_rows.append(
+                    str(industry) if industry is not None and pd.notna(industry) else None
+                )
+                sector_values.append(
+                    str(sector) if sector is not None and pd.notna(sector) else None
+                )
+                industry_values += match is not None
+            frame["sic_code"] = sic_values
+            frame["industry"] = industry_values_for_rows
+            frame["sector"] = sector_values
+
+        enriched[str(raw_symbol)] = frame
+
+    return enriched, {
+        "status": "available" if cap_lookup or industry_lookup else "empty",
+        "classification": "SEC SIC",
+        "point_in_time": True,
+        "decision_rows": total_rows,
+        "market_cap_rows": market_cap_values,
+        "industry_rows": industry_values,
+    }
+
+
+def load_and_enrich_us_equity_bars(
+    bars_by_symbol: Mapping[str, pd.DataFrame],
+    *,
+    dataset_path: str | Path | None = None,
+    timezone: str = "US/Eastern",
+) -> tuple[dict[str, pd.DataFrame], dict[str, Any]]:
+    """Load only requested symbols/years from the configured Parquet metadata."""
+
+    resolved = configured_dataset_path(dataset_path)
+    if resolved is None:
+        return dict(bars_by_symbol), {
+            "status": "not_configured",
+            "classification": "SEC SIC",
+            "point_in_time": True,
+        }
+    if not resolved.is_dir():
+        raise EquityMetadataUnavailableError(
+            f"Configured US equity dataset does not exist: {resolved}"
+        )
+
+    symbols = sorted({str(symbol).upper() for symbol in bars_by_symbol})
+    years = sorted(
+        {
+            decision_date.year
+            for frame in bars_by_symbol.values()
+            for decision_date in _local_dates(frame.index, timezone)
+        }
+    )
+    cap_frames = []
+    try:
+        for year in years:
+            path = (
+                resolved
+                / "metadata"
+                / "market_cap"
+                / "daily_market_cap"
+                / f"year={year}"
+                / "data.parquet"
+            )
+            if path.is_file():
+                cap_frames.append(
+                    pd.read_parquet(
+                        path,
+                        columns=_CAP_COLUMNS,
+                        filters=[("symbol", "in", symbols)],
+                    )
+                )
+
+        industry_files = sorted(
+            (resolved / "metadata" / "industry").glob(
+                "sec_sic_effective_history_*.parquet"
+            )
+        )
+        industries = (
+            pd.read_parquet(
+                industry_files[-1],
+                columns=_INDUSTRY_COLUMNS,
+                filters=[("symbol", "in", symbols)],
+            )
+            if industry_files
+            else pd.DataFrame(columns=_INDUSTRY_COLUMNS)
+        )
+    except Exception as exc:
+        raise EquityMetadataUnavailableError(
+            "Could not read configured US equity metadata"
+        ) from exc
+
+    market_caps = (
+        pd.concat(cap_frames, ignore_index=True)
+        if cap_frames
+        else pd.DataFrame(columns=_CAP_COLUMNS)
+    )
+    enriched, summary = enrich_decision_bars(
+        bars_by_symbol,
+        market_caps=market_caps,
+        industries=industries,
+        timezone=timezone,
+    )
+    # Persist only a portable dataset name; host filesystem paths are neither
+    # useful to agents nor safe provenance to expose through run APIs.
+    summary["dataset_name"] = resolved.name
+    summary["years"] = years
+    return enriched, summary

--- a/dashboard/backend/tests/backtesting/test_bar_aggregation.py
+++ b/dashboard/backend/tests/backtesting/test_bar_aggregation.py
@@ -50,6 +50,7 @@ def test_us_bars_are_anchored_to_0930_and_labeled_at_bucket_end():
     assert result.iloc[0]["expected_source_bars"] == 12
     assert bool(result.iloc[0]["is_complete"]) is True
     assert result.iloc[0]["vwap"] == 106.0
+    assert result.iloc[0]["turnover"] == 12_720.0
     # The final 15:30-16:00 bucket is complete, but its 16:00 label has no
     # following source bar and is filtered from the execution plan by the engine.
     assert result.index[-1] == pd.Timestamp("2026-03-02 21:00:00", tz="UTC")

--- a/dashboard/backend/tests/backtesting/test_features.py
+++ b/dashboard/backend/tests/backtesting/test_features.py
@@ -37,6 +37,21 @@ def test_does_not_mutate_input():
     pd.testing.assert_frame_equal(df, before)
 
 
+def test_turnover_prefers_bar_vwap_and_falls_back_to_close():
+    frame = pd.DataFrame(
+        {
+            "close": [10.0, 20.0],
+            "volume": [100.0, 50.0],
+            "vwap": [11.0, None],
+        },
+        index=pd.date_range("2026-01-01", periods=2, freq="h"),
+    )
+
+    out = TechnicalIndicators.calculate_indicators(frame)
+
+    assert out["turnover"].tolist() == [1_100.0, 1_000.0]
+
+
 def test_sma_values_are_rolling_means():
     df = _df(60, seed=1)
     out = TechnicalIndicators.calculate_indicators(df)

--- a/dashboard/backend/tests/backtesting/test_portfolio_manager_move.py
+++ b/dashboard/backend/tests/backtesting/test_portfolio_manager_move.py
@@ -193,6 +193,40 @@ def test_make_trading_decision_with_llm_buy_and_tokens():
     assert pm.llm_calls == 1
 
 
+def test_liquidity_market_cap_and_industry_reach_llm_snapshot(monkeypatch):
+    from dashboard.backend.domain.backtesting import portfolio_manager as pm_mod
+
+    state = _llm_state()
+    state["market_signals"]["AAPL"].update(
+        {
+            "turnover": 12_500_000.0,
+            "market_cap_usd": 3_100_000_000_000.0,
+            "market_cap_status": "available",
+            "sic_code": 3571,
+            "industry": "Electronic Computers",
+            "sector": "Manufacturing",
+        }
+    )
+    captured = {}
+
+    def capture_prompt(snapshot, **_kwargs):
+        captured.update(snapshot["top_signals"]["AAPL"])
+        return "prompt"
+
+    monkeypatch.setattr(pm_mod, "create_prompt", capture_prompt)
+    response = _FakeResp(json.dumps({"actions": []}), _FakeUsage(1, 1))
+    pm = CanonicalPortfolioManager(100000)
+
+    pm.make_trading_decision_with_llm(state, _FakeClient(response))
+
+    assert captured["turnover"] == 12_500_000.0
+    assert captured["market_cap_usd"] == 3_100_000_000_000.0
+    assert captured["market_cap_status"] == "available"
+    assert captured["sic_code"] == 3571
+    assert captured["industry"] == "Electronic Computers"
+    assert captured["sector"] == "Manufacturing"
+
+
 def test_llm_omitting_position_size_yields_a_whole_lot_on_ashares():
     """The harness must not size an order the executor is certain to reject.
 

--- a/dashboard/backend/tests/domain/trading/test_portfolio.py
+++ b/dashboard/backend/tests/domain/trading/test_portfolio.py
@@ -153,6 +153,29 @@ def test_build_market_signals_missing_keys_none():
     assert sig["macd"] is None
 
 
+def test_build_market_signals_forwards_liquidity_and_company_metadata():
+    md = {
+        "AAPL": _row(
+            200.0,
+            turnover=12_500_000.0,
+            market_cap_usd=3_100_000_000_000.0,
+            market_cap_status="available",
+            sic_code=3571,
+            industry="Electronic Computers",
+            sector="Manufacturing",
+        )
+    }
+
+    signal = build_market_signals(md)["AAPL"]
+
+    assert signal["turnover"] == 12_500_000.0
+    assert signal["market_cap_usd"] == 3_100_000_000_000.0
+    assert signal["market_cap_status"] == "available"
+    assert signal["sic_code"] == 3571
+    assert signal["industry"] == "Electronic Computers"
+    assert signal["sector"] == "Manufacturing"
+
+
 # ---------------------------------------------------------------------------
 # build_portfolio_state (golden fixture)
 # ---------------------------------------------------------------------------

--- a/dashboard/backend/tests/infrastructure/market_data/test_equity_metadata.py
+++ b/dashboard/backend/tests/infrastructure/market_data/test_equity_metadata.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from dashboard.backend.infrastructure.market_data.equity_metadata import (
+    EquityMetadataUnavailableError,
+    configured_dataset_path,
+    enrich_decision_bars,
+    load_and_enrich_us_equity_bars,
+)
+
+
+def _bars() -> dict[str, pd.DataFrame]:
+    return {
+        "AAPL": pd.DataFrame(
+            {"close": [100.0, 101.0]},
+            index=pd.DatetimeIndex(
+                ["2025-01-02 15:30:00+00:00", "2025-01-03 15:30:00+00:00"]
+            ),
+        )
+    }
+
+
+def test_recomputes_intraday_market_cap_and_uses_effective_sic_interval():
+    source = _bars()
+    market_caps = pd.DataFrame(
+        {
+            "symbol": ["AAPL", "AAPL"],
+            "trade_date": ["2025-01-02", "2025-01-03"],
+            # These are end-of-day values and must never be injected directly.
+            "market_cap_usd": [9_999.0, 9_999.0],
+            "market_cap_status": ["available", "stale"],
+            "shares_outstanding_effective": [10, 12],
+        }
+    )
+    industries = pd.DataFrame(
+        {
+            "symbol": ["AAPL", "AAPL"],
+            "effective_from": ["2020-01-01", "2025-01-03"],
+            "effective_to_exclusive": ["2025-01-03", "2026-01-01"],
+            "sic": [3571, 7372],
+            "sic_description": ["Electronic Computers", "Prepackaged Software"],
+            "sic_division_name": ["Manufacturing", "Services"],
+        }
+    )
+
+    enriched, summary = enrich_decision_bars(
+        source,
+        market_caps=market_caps,
+        industries=industries,
+    )
+
+    frame = enriched["AAPL"]
+    assert frame["market_cap_usd"].tolist() == [1_000.0, 1_212.0]
+    assert frame["market_cap_status"].tolist() == ["available", "stale"]
+    assert frame["sic_code"].tolist() == [3571, 7372]
+    assert frame["industry"].tolist() == [
+        "Electronic Computers",
+        "Prepackaged Software",
+    ]
+    assert frame["sector"].tolist() == ["Manufacturing", "Services"]
+    assert "market_cap_usd" not in source["AAPL"].columns
+    assert summary["market_cap_rows"] == 2
+    assert summary["industry_rows"] == 2
+
+
+def test_rejected_reference_market_cap_stays_missing():
+    caps = pd.DataFrame(
+        {
+            "symbol": ["AAPL"],
+            "trade_date": ["2025-01-02"],
+            "market_cap_usd": [None],
+            "market_cap_status": ["suspect_scale"],
+            "shares_outstanding_effective": [10],
+        }
+    )
+
+    enriched, _ = enrich_decision_bars(_bars(), market_caps=caps)
+
+    assert pd.isna(enriched["AAPL"]["market_cap_usd"].iloc[0])
+    assert enriched["AAPL"]["market_cap_status"].iloc[0] == "suspect_scale"
+
+
+def test_overlapping_industry_intervals_fail_closed():
+    industries = pd.DataFrame(
+        {
+            "symbol": ["AAPL", "AAPL"],
+            "effective_from": ["2020-01-01", "2024-01-01"],
+            "effective_to_exclusive": ["2025-01-01", "2026-01-01"],
+            "sic": [1, 2],
+            "sic_description": ["One", "Two"],
+            "sic_division_name": ["A", "B"],
+        }
+    )
+
+    with pytest.raises(EquityMetadataUnavailableError, match="overlapping"):
+        enrich_decision_bars(_bars(), industries=industries)
+
+
+def test_unconfigured_runtime_does_not_guess_a_workstation_path(monkeypatch):
+    monkeypatch.delenv("US_EQUITY_DATASET_PATH", raising=False)
+    monkeypatch.delenv("US_EQUITY_DATA_ROOT", raising=False)
+
+    source = _bars()
+    enriched, summary = load_and_enrich_us_equity_bars(source)
+
+    assert configured_dataset_path() is None
+    assert summary["status"] == "not_configured"
+    assert enriched["AAPL"] is source["AAPL"]

--- a/docs/api/agent-environment-protocol-v1.md
+++ b/docs/api/agent-environment-protocol-v1.md
@@ -211,7 +211,12 @@ workers — only `POST .../decision` mutates state.
 `market.features` carries the per-symbol technical indicators (price, RSI,
 MACD, SMAs, Bollinger bands) for **every symbol in
 `constraints.allowed_symbols`** (the run's `config.symbols`, or the full
-DJIA-30 default) that has market data at that step.
+DJIA-30 default) that has market data at that step. US equity observations also
+carry completed-bar `turnover` in the market's native currency. When the server
+has a point-in-time US equity metadata dataset configured, observations add
+`market_cap_usd`, `market_cap_status`, `sic_code`, `industry`, and `sector`.
+Industry fields use SEC SIC rather than GICS; absent optional fields mean that
+the data is unavailable and must not be interpreted as zero.
 
 `market.bars` and `market.events` are reserved for future environment types
 (raw OHLCV windows, corporate events); in `us-equity-hourly-v1` they are

--- a/docs/minute-data-hourly-trading.md
+++ b/docs/minute-data-hourly-trading.md
@@ -72,6 +72,33 @@ IEX）、是否由 SIP 降级到 IEX，以及请求结束时间是否因实时�
 网页在回测高级详情中显示这些来源信息，使频率正确但 tape 不同的运行也不会
 被误认为完全等价。
 
+## Agent 的流动性与公司元数据
+
+美股小时决策 snapshot 还可以包含三类逐标的数据，而不改变每小时一次的
+Agent 调用频率：
+
+- `turnover`：该已完成小时内各 5 分钟 bar 的 `VWAP × volume` 之和，币种见
+  snapshot 的 `market.native_currency`；缺失 VWAP 的旧数据按各源 bar 收盘价
+  估算，而不是使用小时末收盘价估算整小时。
+- `market_cap_usd`：当前决策价格乘以当日已经生效的 SEC 披露股数；日表中的
+  收盘市值只用于质量校验，绝不会直接注入盘中决策。`market_cap_status` 同时
+  暴露数据的新鲜度或缺失原因。
+- `sic_code`、`industry`、`sector`：按决策日命中的 SEC SIC 生效区间提供。
+  `sector` 是 SIC division，不是 GICS 行业板块。
+
+成交额来自 Alpaca bar，无需额外配置。市值和行业数据位于仓库外，运行网页
+服务前需配置其一：
+
+```powershell
+$env:US_EQUITY_DATASET_PATH = 'D:\Project\Trading\US_Data\us_equities_5min_2016_2025'
+# 或设置数据根目录，系统会追加默认数据集目录名：
+$env:US_EQUITY_DATA_ROOT = 'D:\Project\Trading\US_Data'
+```
+
+未配置外部数据集时回测仍可运行，且不会用当前市值或未来记录填充历史空值；
+Agent 仅收到实际可用的字段。显式配置的目录损坏或 schema 不兼容时回测失败，
+防止静默使用不可信的公司元数据。
+
 ## 代码契约
 
 `dashboard/backend/infrastructure/market_data/frequency.py` 提供：

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,7 @@ numba==0.61.2
 openai==1.101.0
 pandas==2.3.2
 pandas-ta==0.4.71b0
+pyarrow==21.0.0
 platformdirs==4.3.7
 propcache==0.4.1
 pycparser==3.0


### PR DESCRIPTION
This PR enhances the backtesting agent’s market context by adding traded value, point-in-time market capitalization, and SIC-based industry and sector classifications. Traded value is aggregated from 5-minute bars, while market capitalization is calculated using the decision-time price and effective shares outstanding to prevent look-ahead bias. These fields are exposed consistently across internal and external agent workflows, enabling richer analysis of intraday activity and cross-sectional market structure without increasing the Agent’s hourly decision frequency, number of model calls, or inference cost.