### PR TITLE
feat(capital): allow $0 backtest capital

### DIFF
--- a/dashboard/backend/api/routers/backtests.py
+++ b/dashboard/backend/api/routers/backtests.py
@@ -98,7 +98,9 @@ from dashboard.backend.infrastructure.ai_hedge_fund.adapter import (
     runtime_unavailable_reason,
 )
 from dashboard.backend.domain.backtesting.constants import (
+    INITIAL_CAPITAL,
     MAX_BACKTEST_INITIAL_CAPITAL,
+    MIN_BACKTEST_INITIAL_CAPITAL,
     resolve_initial_capital,
 )
 from dashboard.backend.infrastructure.llm.validator import DJIA_30
@@ -206,6 +208,30 @@ def _filter_equity_for_run(
         market=profile.market,
         market_timezone=profile.timezone,
     )
+
+
+def _run_initial_capital(run: Dict[str, Any], first_equity: Any) -> float:
+    """Capital a stored run started from, for scaling its benchmark curves.
+
+    Deliberately NOT ``run["initial_equity"] or first_equity or 1_000``. That
+    chain reads *zero* as *missing*, so a $0 run -- legal since 2026-09-10 --
+    scaled DJIA and buy-and-hold to $1,000 and drew them a thousand times above
+    an agent curve sitting flat on the axis. Falling back on `None` is the
+    behaviour that was intended all along; `or` only ever approximated it, and
+    approximated it correctly right up until zero became reachable.
+    """
+    for candidate in (run.get("initial_equity"), first_equity):
+        if candidate is None:
+            continue
+        try:
+            value = float(candidate)
+        except (TypeError, ValueError):
+            continue
+        # NaN is stored as a float and is not None, so it passes both guards
+        # above; it would poison every scaled point downstream.
+        if value == value:
+            return value
+    return float(INITIAL_CAPITAL)
 
 
 def _stored_buyhold_baseline(
@@ -1823,8 +1849,20 @@ def run_backtest_endpoint(
             initial_capital = float(initial_capital)
         except (TypeError, ValueError):
             raise HTTPException(status_code=422, detail="initial_capital must be a number.")
-        if initial_capital <= 0:
-            raise HTTPException(status_code=422, detail="initial_capital must be greater than 0.")
+        # Against MIN, not against a literal 0: $0 is a legal (degenerate) run
+        # -- no cash, no fills, flat curve, 0.00% return. See the note in
+        # domain/backtesting/constants.py for why the old floor existed and
+        # what replaced it. Written as a failed `>=` rather than `<` so NaN --
+        # which `float()` accepts and which is false against every comparison
+        # -- is refused here instead of sliding past both bounds.
+        if not initial_capital >= float(MIN_BACKTEST_INITIAL_CAPITAL):
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "initial_capital cannot be negative "
+                    f"(minimum {MIN_BACKTEST_INITIAL_CAPITAL:g})."
+                ),
+            )
         if initial_capital > float(MAX_BACKTEST_INITIAL_CAPITAL):
             raise HTTPException(
                 status_code=422,
@@ -2309,9 +2347,7 @@ def get_backtest_chart_data(run_id: str, request: Request):
     if not agent_curve:
         raise HTTPException(status_code=404, detail="No equity data to plot for this run")
 
-    initial_capital = float(
-        run.get("initial_equity") or agent_curve[0].get("equity") or 1_000
-    )
+    initial_capital = _run_initial_capital(run, agent_curve[0].get("equity"))
     agent_card = agent_service.agents.get_agent_by_session(session_id)
     card_name = (agent_card or {}).get("name")
 
@@ -2641,7 +2677,7 @@ def _render_run_plot_png(run_id: str) -> bytes:
     if not timestamps:
         raise HTTPException(status_code=404, detail="No equity data to plot for this run")
 
-    initial_capital = float(run.get("initial_equity") or agent_values[0] or 1_000)
+    initial_capital = _run_initial_capital(run, agent_values[0])
     index_baselines_ok = True
     if profile.index_baseline_enabled:
         baselines, index_baselines_ok = market_index_baselines_with_status(

--- a/dashboard/backend/domain/backtesting/constants.py
+++ b/dashboard/backend/domain/backtesting/constants.py
@@ -17,7 +17,7 @@ Capital scale (product):
   ($3,000) — also capped by remaining unallocated cash. **Paper trading only**;
   backtests must not read or write this field.
 - Backtest / protocol simulation capital: floor ``MIN_BACKTEST_INITIAL_CAPITAL``
-  ($1), default ``INITIAL_CAPITAL`` ($1,000), max
+  ($0), default ``INITIAL_CAPITAL`` ($1,000), max
   ``MAX_BACKTEST_INITIAL_CAPITAL`` ($3,000). Chosen per run via
   ``config.initial_cash`` / ``--initial-capital``, resolved by
   ``resolve_initial_capital()`` below, which only ever looks at the value
@@ -27,6 +27,21 @@ Capital scale (product):
   requested value when it launches a backtest for the agent; it is not a
   backend fallback. Either way, backtest capital is independent of the
   account ledger and agent sleeves.
+
+⚠ **$0 is a legal amount and zero is not absent.** The floor was $1 until
+2026-09-10, which put the two halves of one Configure card in disagreement:
+``cash_allocation`` took $0 everywhere and ``backtest_allocation`` refused it
+at seven separate layers, the loudest a 422 and the quietest this module's own
+``if value <= 0: return INITIAL_CAPITAL``. That last one is the shape to keep
+out: it *accepted* the 0 and then ran $1,000, so the field and the run
+disagreed with nothing to read. Absent (``None``, ``""``, unparseable) still
+falls back to ``INITIAL_CAPITAL``; an explicit 0 does not, and every ``or``
+chain on this path (``run["initial_equity"] or …``) collapses that distinction
+by accident — use ``is None``.
+
+A $0 run is degenerate but real: no cash means no fills, so every step holds,
+the curve is flat at $0 and the honest return is 0.00%. Computing that return
+is what ``fractional_return()`` exists for — see its own note.
 """
 
 from __future__ import annotations
@@ -37,7 +52,8 @@ from typing import Any, Optional
 INITIAL_CAPITAL = 1000
 
 # Hard floor on simulation capital for a single backtest / protocol run.
-MIN_BACKTEST_INITIAL_CAPITAL = 1
+# Zero is deliberately inclusive; see the ⚠ note in the module docstring.
+MIN_BACKTEST_INITIAL_CAPITAL = 0
 
 # Hard cap on simulation capital for a single backtest / protocol run.
 MAX_BACKTEST_INITIAL_CAPITAL = 3_000
@@ -55,8 +71,14 @@ def resolve_initial_capital(requested: Optional[Any] = None) -> float:
     """Resolve simulation capital for a backtest / protocol run.
 
     Independent of agent ``cash_allocation`` (portfolio sleeve). Uses
-    ``requested`` when present and positive, clamped to
+    ``requested`` when it is a number at or above
+    ``MIN_BACKTEST_INITIAL_CAPITAL``, clamped to
     ``MAX_BACKTEST_INITIAL_CAPITAL``. Otherwise returns ``INITIAL_CAPITAL``.
+
+    ``0`` is a value and is returned as ``0.0``; only *absent* (``None``, ``""``,
+    anything unparseable) and *negative* fall back to the default. The old
+    ``value <= 0`` lumped zero in with those, so a 0 that reached here ran as
+    $1,000 with nothing reporting the substitution.
     """
     if requested is None:
         return float(INITIAL_CAPITAL)
@@ -64,6 +86,30 @@ def resolve_initial_capital(requested: Optional[Any] = None) -> float:
         value = float(requested)
     except (TypeError, ValueError):
         return float(INITIAL_CAPITAL)
-    if value <= 0:
+    # NaN fails every comparison, so test for membership in the range rather
+    # than for exclusion from it -- `value < MIN` is False for NaN and would
+    # let it through to the clamp, where `min(nan, 3000)` returns nan.
+    if not value >= MIN_BACKTEST_INITIAL_CAPITAL:
         return float(INITIAL_CAPITAL)
     return float(min(value, MAX_BACKTEST_INITIAL_CAPITAL))
+
+
+def fractional_return(final_equity: float, initial_capital: float) -> float:
+    """Total return as a fraction, safe at zero capital.
+
+    ``(final - initial) / initial`` appears at five sites (``engine.py`` x4,
+    ``external_run_service.py`` x1) and was unguarded at all five. The $1 floor
+    on ``MIN_BACKTEST_INITIAL_CAPITAL`` was the only thing keeping a typed 0
+    away from that division, so lifting the floor without this helper would
+    have traded a 422 the user could read for a ``ZeroDivisionError`` partway
+    through their run.
+
+    Zero capital returns ``0.0`` rather than raising or reporting ``inf``: with
+    no cash there are no fills, so the honest answer to "how did it do" is
+    "it didn't". Reporting ``inf`` on the arithmetic technicality that
+    ``final`` may be nonzero would put a garbage number on the run card.
+    """
+    initial = float(initial_capital)
+    if initial == 0:
+        return 0.0
+    return (float(final_equity) - initial) / initial

--- a/dashboard/backend/domain/backtesting/engine.py
+++ b/dashboard/backend/domain/backtesting/engine.py
@@ -29,7 +29,10 @@ from dashboard.backend.infrastructure.llm.validator import DJIA_30, TOP_10_STOCK
 from dashboard.backend.infrastructure.market_data.strategy_universe import (
     resolve_strategy_universe, validate_selection,
 )
-from dashboard.backend.domain.backtesting.constants import INITIAL_CAPITAL
+from dashboard.backend.domain.backtesting.constants import (
+    INITIAL_CAPITAL,
+    fractional_return,
+)
 from dashboard.backend.domain.backtesting.currency import (
     CurrencyContext,
     CurrencyContextError,
@@ -1559,7 +1562,7 @@ class HourlyBacktester:
             # Progress
             if (i + 1) % 100 == 0:
                 equity = manager.equity_history[-1]["equity"]
-                pct_return = ((equity - self.initial_capital) / self.initial_capital) * 100
+                pct_return = fractional_return(equity, self.initial_capital) * 100
                 print(f"   Decision {i+1}/{len(all_timestamps)}: Equity ${equity:,.0f} ({pct_return:+.1f}%)")
 
         if self.intraday_mode:
@@ -1595,7 +1598,7 @@ class HourlyBacktester:
         run_id = self.live_run_id or f"agent_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
         initial_eq = equity_curve[0]["equity"] if equity_curve else self.initial_capital
         final_eq = equity_curve[-1]["equity"] if equity_curve else self.initial_capital
-        total_return = (final_eq - self.initial_capital) / self.initial_capital
+        total_return = fractional_return(final_eq, self.initial_capital)
 
         # Attribute a hosted run to its model only if the model actually drove
         # steps. A row naming a model beside ``llm_calls=0`` is precisely the
@@ -1744,7 +1747,7 @@ class HourlyBacktester:
         run_id = f"buyhold_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
         initial_eq = equity_history[0]["equity"]
         final_eq = equity_history[-1]["equity"]
-        total_return = (final_eq - self.initial_capital) / self.initial_capital
+        total_return = fractional_return(final_eq, self.initial_capital)
         
         db.insert_run(
             run_id=run_id,
@@ -1820,7 +1823,7 @@ class HourlyBacktester:
         run_id = f"djia_index_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
         initial_eq = equity_history[0]["equity"]
         final_eq = equity_history[-1]["equity"]
-        total_return = (final_eq - self.initial_capital) / self.initial_capital
+        total_return = fractional_return(final_eq, self.initial_capital)
         
         db.insert_run(
             run_id=run_id,

--- a/dashboard/backend/domain/backtesting/engine.py
+++ b/dashboard/backend/domain/backtesting/engine.py
@@ -1700,6 +1700,14 @@ class HourlyBacktester:
     
     def run_buyhold_baseline(self) -> Tuple[str, List[Dict]]:
         """Buy and hold baseline using shared baseline generator."""
+        # ``generate_baselines`` at $0 returns a flat zero history, which is
+        # then written to ``agent_runs`` as a real row -- so a $0 run recorded
+        # buy-and-hold as having returned 0.00% over its window. The chart is
+        # rebuilt per request; these rows outlive it.
+        if not self.initial_capital > 0:
+            print("📊 Buy & Hold baseline skipped: this run has no capital\n")
+            return None, []
+
         print("📊 Running Buy & Hold baseline...\n")
 
         # Full DJIA runs keep the historical 10-stock B&H sleeve; other universes
@@ -1780,6 +1788,12 @@ class HourlyBacktester:
     
     def run_djia_baseline(self) -> Tuple[str, List[Dict]]:
         """DJIA index baseline using shared baseline generator."""
+        # Same reasoning as run_buyhold_baseline: a benchmark scaled to $0 is a
+        # row claiming the Dow returned 0.00%, not a benchmark.
+        if not self.initial_capital > 0:
+            print("📊 DJIA Index baseline skipped: this run has no capital\n")
+            return None, []
+
         if not self._effective_profile().index_baseline_enabled:
             return None, []
 

--- a/dashboard/backend/domain/backtesting/external_run_service.py
+++ b/dashboard/backend/domain/backtesting/external_run_service.py
@@ -33,7 +33,10 @@ from dashboard.backend.infrastructure.llm.validator import (
     actions_to_executable,
     parse_actions_payload,
 )
-from dashboard.backend.domain.backtesting.constants import resolve_initial_capital
+from dashboard.backend.domain.backtesting.constants import (
+    fractional_return,
+    resolve_initial_capital,
+)
 from dashboard.backend.domain.backtesting.metrics import (
     calculate_max_drawdown,
     calculate_sharpe,
@@ -835,7 +838,7 @@ class ExternalBacktestSession:
             self.run_id = _new_ext_run_id()
         initial_eq = equity_curve[0]["equity"] if equity_curve else self.initial_capital
         final_eq = equity_curve[-1]["equity"] if equity_curve else self.initial_capital
-        total_return = (final_eq - self.initial_capital) / self.initial_capital
+        total_return = fractional_return(final_eq, self.initial_capital)
 
         est_cost = token_cost.estimate_cost_usd(
             self.model_name, self.est_input_tokens, self.est_output_tokens

--- a/dashboard/backend/domain/backtesting/external_run_service.py
+++ b/dashboard/backend/domain/backtesting/external_run_service.py
@@ -1248,8 +1248,20 @@ def start_backtest(
             owner_user_id = agent.get("owner_user_id") if agent else None
             if owner_user_id is not None:
                 session.analytics_user_id = int(owner_user_id)
-        except Exception:
-            pass
+        except Exception as exc:
+            # Fail open -- analytics attribution must never stop a run from
+            # starting -- but not silently. A bare `pass` made "this deployment
+            # emits no owner ids" and "the agent store has been raising on every
+            # lookup since the last deploy" the same observable: runs start,
+            # rows arrive, every one of them anonymous. Same rule as the news
+            # adapter in CLAUDE.md's fail-closed-is-not-fail-visible section --
+            # keep the fallback, print at the boundary. print(), not logging:
+            # log records are invisible under the deployed uvicorn.
+            print(
+                f"⚠️ analytics attribution unavailable for backtest "
+                f"{backtest_id}: {type(exc).__name__}: {exc}",
+                flush=True,
+            )
 
     with _lock:
         # Counted and inserted under one acquisition: as a check in the router

--- a/dashboard/backend/domain/backtesting/metrics.py
+++ b/dashboard/backend/domain/backtesting/metrics.py
@@ -28,15 +28,33 @@ def calculate_sharpe(
     hourly behavior.
 
     Returns: float
-        Annualized Sharpe ratio. Returns 0 if insufficient data or zero volatility.
+        Annualized Sharpe ratio. Returns 0 if insufficient data, zero volatility,
+        or an undefined per-step return (see below).
     """
     if len(equity_curve) < 2:
         return 0
 
-    equities = np.array([e["equity"] for e in equity_curve])
-    returns = np.diff(equities) / equities[:-1]
+    equities = np.array([e["equity"] for e in equity_curve], dtype=float)
+    # A step whose *opening* equity is 0 has no defined return: the $0 runs made
+    # legal on 2026-09-10 produce an all-zero curve, so every step is 0/0.
+    #
+    # This cannot be left to the zero-volatility exit below, because
+    # ``np.std(nan) == 0`` is False -- NaN would fall straight through it and be
+    # written to ``agent_runs.sharpe_ratio``. That is invisible on SQLite, which
+    # coerces NaN to NULL on write, and fatal on the Postgres run-history
+    # backend (``AGENT_RUNS_DATABASE_URL``), which round-trips it: Starlette
+    # encodes with ``allow_nan=False``, so every route returning a plain dict
+    # rather than a ``response_model`` answers 500 for that run.
+    #
+    # 0 is the same convention ``fractional_return`` settled on for the return
+    # itself: with no capital there is nothing to have been at risk, so the
+    # honest answer to "how was it risk-adjusted" is "it wasn't".
+    with np.errstate(divide="ignore", invalid="ignore"):
+        returns = np.diff(equities) / equities[:-1]
 
-    if len(returns) == 0 or np.std(returns) == 0:
+    if len(returns) == 0 or not np.all(np.isfinite(returns)):
+        return 0
+    if np.std(returns) == 0:
         return 0
 
     periods_per_year = 252 * 6.5 if periods_per_year is None else periods_per_year
@@ -58,6 +76,13 @@ def calculate_max_drawdown(equity_curve: List[Dict]) -> float:
     for equity in equities:
         if equity > running_max:
             running_max = equity
+        # No peak means no drawdown from it. An unfunded run sits at 0 for its
+        # whole curve, making this ``(0 - 0) / 0``. The old code already landed
+        # on the right answer, but only by accident -- ``nan < max_dd`` is
+        # False, so max_dd stayed 0 -- while numpy printed a RuntimeWarning into
+        # the stdout of every $0 backtest.
+        if running_max == 0:
+            continue
         dd = (equity - running_max) / running_max
         if dd < max_dd:
             max_dd = dd

--- a/dashboard/backend/domain/runs/service.py
+++ b/dashboard/backend/domain/runs/service.py
@@ -31,6 +31,7 @@ from dashboard.backend.database import db
 from dashboard.backend.domain.backtesting.constants import (
     INITIAL_CAPITAL,
     MAX_BACKTEST_INITIAL_CAPITAL,
+    MIN_BACKTEST_INITIAL_CAPITAL,
     resolve_initial_capital,
 )
 from dashboard.backend.execution.base import TERMINAL_STATUSES
@@ -598,11 +599,17 @@ def create_run(
             raise ProtocolError(
                 "invalid_config", "config.initial_cash must be a number", 400
             )
-        if requested <= 0:
+        # `< MIN`, not `<= 0`: $0 is a legal (degenerate) run. Written as a
+        # failed `>=` so NaN -- which `float("nan")` accepts and which fails
+        # every comparison -- is refused here rather than surviving into the
+        # engine's arithmetic.
+        if not requested >= float(MIN_BACKTEST_INITIAL_CAPITAL):
             raise ProtocolError(
                 "invalid_config",
-                "config.initial_cash must be greater than 0",
+                "config.initial_cash cannot be negative "
+                f"(minimum {MIN_BACKTEST_INITIAL_CAPITAL:g})",
                 400,
+                details={"min_initial_cash": MIN_BACKTEST_INITIAL_CAPITAL},
             )
         if requested > float(MAX_BACKTEST_INITIAL_CAPITAL) + 1e-9:
             raise ProtocolError(

--- a/dashboard/backend/equity_plot.py
+++ b/dashboard/backend/equity_plot.py
@@ -133,6 +133,29 @@ def market_index_baselines_with_status(
     forges a log line. The dates are ``!r``-quoted for the same reason.
     """
     where = f" [{_log_safe(context)}]" if context else ""
+    # Every index point is ``initial_capital * (level / base)``, so a $0 run --
+    # legal since 2026-09-10 -- scales DJIA and the Nasdaq-100 to flat zero
+    # lines drawn directly on top of the agent's own flat zero line. That reads
+    # as "the benchmark data failed" while ``index_baselines_ok`` goes on
+    # reporting ``true``; publishing nothing at least says what is true, which
+    # is that there is no capital for a benchmark to be scaled to.
+    #
+    # ``True``, like the unusable-window branch below: ``False`` means
+    # *transient and retryable*, which disables plot caching and prints the
+    # degraded-render note. Neither applies -- this run is permanently
+    # baseline-free, and its render is complete rather than incomplete.
+    try:
+        capital = float(initial_capital)
+    except (TypeError, ValueError):
+        capital = 0.0
+    if not capital > 0:  # NaN fails every comparison, so test for the good case
+        print(
+            f"⚠️ index baselines skipped{where}: no capital to scale to "
+            f"(initial_capital={initial_capital!r})",
+            flush=True,
+        )
+        return [], True
+
     if not usable_window(start_date, end_date):
         print(
             f"⚠️ index baselines skipped{where}: unusable run window "

--- a/dashboard/backend/tests/test_agent_backtest_allocation.py
+++ b/dashboard/backend/tests/test_agent_backtest_allocation.py
@@ -116,7 +116,11 @@ def test_patch_backtest_allocation_alone_is_not_no_fields_to_update(client):
     assert resp.status_code != 400
 
 
-@pytest.mark.parametrize("bad", [0, -100, 3001])
+# 0 is deliberately absent: it moved from "out of range" to a legal amount on
+# 2026-09-10, when this field stopped disagreeing with the ``cash_allocation``
+# field beside it in the same Configure card. tests/test_zero_backtest_capital.py
+# owns that boundary; this list stays for the ends that are still closed.
+@pytest.mark.parametrize("bad", [-1, -100, 3001])
 def test_backtest_allocation_out_of_range_is_rejected(client, bad):
     headers = _headers()
     resp = client.post(

--- a/dashboard/backend/tests/test_external_backtest_api.py
+++ b/dashboard/backend/tests/test_external_backtest_api.py
@@ -221,3 +221,42 @@ def test_insert_trades_legacy_schema(tmp_path):
     assert len(rows) == 1
     assert rows[0]["quantity"] == 10
     assert rows[0]["side"] == "BUY"
+
+
+def test_a_broken_analytics_attribution_is_reported_rather_than_swallowed(
+    monkeypatch, capsys
+):
+    """`except Exception: pass` around the owner lookup (CodeQL py/empty-except).
+
+    Failing open here is right -- analytics attribution must never stop a run
+    from starting -- but failing *silently* makes "this deployment emits no
+    owner ids" and "the agent store has been raising on every lookup since the
+    last deploy" the same observable: runs start, analytics arrive, every row
+    anonymous. That is the shape CLAUDE.md's "fail-closed is not fail-visible"
+    section is about, and the fix is the same one: keep the fallback, print at
+    the boundary so absent stays distinguishable from broken.
+    """
+
+    class _Broken:
+        def get_agent_by_session(self, session_id):
+            raise RuntimeError("agent store is down")
+
+    monkeypatch.setattr(svc, "agent_store", _Broken())
+    svc._sessions.clear()
+
+    started = svc.start_backtest(
+        session_id="attrib",
+        agent_name="a",
+        model_name="m",
+        start_date="2026-04-15",
+        end_date="2026-04-16",
+        emit_analytics=True,
+    )
+
+    assert started["status"] == "loading", "analytics broke the run start"
+    session = svc._sessions[started["backtest_id"]]
+    assert session.analytics_user_id is None, "attribution must still fail open"
+
+    printed = capsys.readouterr().out
+    assert "analytics" in printed.lower(), "the swallowed failure said nothing"
+    assert "agent store is down" in printed, "the cause was not reported"

--- a/dashboard/backend/tests/test_frontend_capital_input.py
+++ b/dashboard/backend/tests/test_frontend_capital_input.py
@@ -107,6 +107,39 @@ def _harness() -> str:
     )
 
 
+def _cash_input_tags() -> dict[str, str]:
+    """Every bound capital input's real `<input>` tag, straight from app.html."""
+    ids = re.findall(r"'([A-Za-z]+)'", fn_body("const CASH_STEP_INPUT_IDS ="))
+    assert len(ids) >= 4, "the bound-input list shrank; update this guard"
+    tags = {}
+    for input_id in ids:
+        match = re.search(rf'<input id="{input_id}"[^>]*>', APP_HTML)
+        assert match, f"{input_id} is bound in app.js but absent from app.html"
+        tags[input_id] = match.group(0)
+    return tags
+
+
+def _shipped_cash_mins() -> dict[str, str]:
+    """`min` as each bound field actually ships it.
+
+    Read rather than written down. Every case below used to hardcode the min it
+    expected, so when the backtest field moved from `min="1"` to `min="0"` on
+    2026-09-10 its regression test went on probing a synthetic element no field
+    in the app resembled -- passing, and covering nothing that shipped. A test
+    whose fixture is copied out of the markup drifts the moment the markup does,
+    and drifts silently, because the copy still describes *something*.
+    """
+    mins = {}
+    for input_id, tag in _cash_input_tags().items():
+        match = re.search(r'\bmin="([^"]*)"', tag)
+        assert match, f"{input_id} ships no min= for the clamp to read"
+        mins[input_id] = match.group(1)
+    return mins
+
+
+_SHIPPED_CASH_MINS = _shipped_cash_mins()
+
+
 def _run_node(expr: str):
     node = shutil.which("node")
     if not node:
@@ -139,29 +172,26 @@ def _backspace_to_empty(min_value: str) -> str:
 
 
 @_requires_node
-def test_backspacing_the_backtest_field_empty_leaves_it_empty():
-    """The reported bug, at the field the user screenshotted.
+@pytest.mark.parametrize(
+    ("input_id", "min_value"), sorted(_SHIPPED_CASH_MINS.items())
+)
+def test_backspacing_a_capital_field_empty_leaves_it_empty(input_id, min_value):
+    """The reported bug, run against every field that actually ships the layer.
 
     A field that refills itself while you are deleting cannot be retyped: the
-    user is left inserting digits around a "1" they never asked for, which is
+    user is left inserting digits around a value they never asked for, which is
     exactly how the feedback describes it ("the number 1 would be confusing").
+
+    The refill lands on `min`, so `min` is what makes the symptom look like one
+    thing or another -- "1" reads as broken, "0" reads as a deliberate choice of
+    no capital. That is why the case is driven off each field's shipped `min`
+    instead of a literal: the two originally hardcoded here (1 and 0) described
+    the fields as they stood before 2026-09-10, and the backtest field's has
+    since moved.
     """
-    assert _backspace_to_empty("1") == "", (
-        "the spinner-correction guard fired on a deletion and refilled the field"
-    )
-
-
-@_requires_node
-def test_backspacing_the_paper_trading_field_empty_leaves_it_empty():
-    """The same defect, one field over, and the reason it needs its own case.
-
-    The paper field's `min` is 0, so the refill lands on "0" rather than "1" --
-    a value that looks deliberate rather than broken. Asserting only the
-    backtest field would leave the paper field free to regress into a state that
-    reads as a real user choice of "no capital".
-    """
-    assert _backspace_to_empty("0") == "", (
-        "the spinner-correction guard fired on a deletion and refilled the field"
+    assert _backspace_to_empty(min_value) == "", (
+        f"{input_id}: the spinner-correction guard fired on a deletion "
+        "and refilled the field"
     )
 
 
@@ -186,7 +216,10 @@ def test_a_spinner_click_still_moves_by_a_full_step():
     assert result == "1100", "a spinner click must land on the configured step"
 
 
-def _type_and_commit(text: str, *, min_value: str = "1") -> dict:
+_DEFAULT_CASH_MIN = sorted(set(_SHIPPED_CASH_MINS.values()))[0]
+
+
+def _type_and_commit(text: str, *, min_value: str = _DEFAULT_CASH_MIN) -> dict:
     """Type `text` into a cleared field and blur it, as a user filling it in does."""
     return _run_node(
         f"""(() => {{
@@ -265,9 +298,9 @@ def test_correcting_an_invalid_value_clears_the_flag():
     """
     result = _run_node(
         """(() => {
-  const el = makeInput({ value: '1000', min: '1' });
+  const el = makeInput({ value: '1000', min: '0' });
   bindCashStepInput(el);
-  el.value = '0';
+  el.value = '-5';
   el._fire('input', { inputType: 'insertText' });
   el._fire('change');
   el.value = '500';
@@ -306,17 +339,6 @@ def test_every_bound_capital_input_has_somewhere_to_render_its_error():
 # ---------------------------------------------------------------------------
 # The form-submit path: the half none of the cases above touch.
 # ---------------------------------------------------------------------------
-
-
-def _cash_input_tags() -> dict[str, str]:
-    ids = re.findall(r"'([A-Za-z]+)'", fn_body("const CASH_STEP_INPUT_IDS ="))
-    assert len(ids) >= 4, "the bound-input list shrank; update this guard"
-    tags = {}
-    for input_id in ids:
-        match = re.search(rf'<input id="{input_id}"[^>]*>', APP_HTML)
-        assert match, f"{input_id} is bound in app.js but absent from app.html"
-        tags[input_id] = match.group(0)
-    return tags
 
 
 def test_the_spinner_increment_is_not_also_a_form_constraint():

--- a/dashboard/backend/tests/test_frontend_capital_input.py
+++ b/dashboard/backend/tests/test_frontend_capital_input.py
@@ -230,13 +230,18 @@ def test_a_small_typed_amount_is_not_rounded_away_to_the_minimum():
 
 @_requires_node
 def test_typing_below_the_minimum_is_flagged_rather_than_rewritten():
-    """Their second ask: "if smaller than 1, return a red error message".
+    """Their second ask: "if smaller than the minimum, return a red error message".
 
     The value is left on screen and the field marked invalid, so the message has
     something to render from and the user's own number is still there to fix.
+
+    The probe is ``-1`` against ``min="0"``, not ``0`` against ``min="1"``: both
+    shipped fields have carried ``min="0"`` since 2026-09-10 (see
+    tests/test_zero_backtest_capital.py), so a case built on a min of 1 would go
+    on passing against a synthetic element no field in the app resembles.
     """
-    result = _type_and_commit("0")
-    assert result["value"] == "0", "the typed value was overwritten instead of flagged"
+    result = _type_and_commit("-1", min_value="0")
+    assert result["value"] == "-1", "the typed value was overwritten instead of flagged"
     assert result["invalid"] == "true", "nothing marks the field invalid"
     assert result["error"], "no message for the inline error to render"
 
@@ -512,4 +517,59 @@ def test_every_caller_that_refills_a_capital_field_resets_it():
         assert "resetCashStepInput(" in body, (
             f"{opener} resets the form without clearing the capital field's "
             "error state, so the modal reopens red on a default value"
+        )
+
+
+def test_every_capital_field_accepts_zero():
+    """Both halves of the Allocated Capital card agree about zero.
+
+    They did not until 2026-09-10: the Paper Trading input shipped `min="0"`
+    and the Backtesting input beside it shipped `min="1"`, so a typed 0 was
+    accepted on the left and refused on the right with "Enter an amount between
+    $1 and $3,000". Two boxes in one card disagreeing about the same number
+    reads as the card being broken, which is how it was reported.
+
+    `min` is also what `snapCashStepValue` clamps to, so the floor was doing
+    double duty as the value the field refilled itself with -- see the module
+    docstring. The backend floor moved with it
+    (tests/test_zero_backtest_capital.py); this is the half a user can see.
+    """
+    for input_id, tag in _cash_input_tags().items():
+        assert 'min="0"' in tag, (
+            f"{input_id} does not accept $0. The two fields in the Allocated "
+            "Capital card must agree, and the backend floor is now 0"
+        )
+
+
+def test_the_editor_does_not_reimpose_a_dollar_floor_in_js():
+    """The `min` attribute is not the only gate -- getEditorState has its own.
+
+    Relaxing the markup and leaving `value < 1` in the validator would swap a
+    browser message for a thrown one: the field would accept the 0 and the save
+    would fail, which is a worse version of the same bug.
+    """
+    source = strip_comments(_AGENT_EDITOR_JS)
+    assert "value < 1" not in source, (
+        "getEditorState still rejects amounts below $1 in JS, so the relaxed "
+        "min attribute only moves where the refusal comes from"
+    )
+    assert "must be at least $1" not in source
+
+
+def test_both_backtest_capital_resolvers_honour_a_saved_zero():
+    """app.js renders the number; agent-editor.js refills the box with it.
+
+    They are separate implementations of one fallback chain, and both used
+    `value > 0` on the *saved* candidate. That made a $0 setting invisible in
+    the card and self-erasing in the editor -- reopening Configure showed the
+    fallback, and the next save wrote the fallback back. Fixing one and not the
+    other leaves the erasure intact, so this asserts the shape in both.
+    """
+    for label, source in (
+        ("app.js", strip_comments(APP_JS)),
+        ("agent-editor.js", strip_comments(_AGENT_EDITOR_JS)),
+    ):
+        assert "backtest_allocation != null" in source, (
+            f"{label} does not separate a saved backtest_allocation of 0 from a "
+            "NULL column, so a deliberate $0 falls through to the paper sleeve"
         )

--- a/dashboard/backend/tests/test_my_agents_card_ui.py
+++ b/dashboard/backend/tests/test_my_agents_card_ui.py
@@ -86,16 +86,16 @@ def test_card_backtest_capital_falls_back_to_the_sleeve():
     assert out.count("$2,000") == 2
 
 
-def test_zero_paper_sleeve_displays_as_zero_but_backtest_capital_does_not():
-    """The two capitals deliberately diverge at $0 -- this is not a bug.
+def test_an_unset_backtest_capital_does_not_mirror_a_zero_paper_sleeve():
+    """The two capitals diverge when the backtest one is UNSET -- by design.
 
-    `cash_allocation` is `ge=0` server-side: a $0 paper sleeve is a real,
-    legal state and must be shown honestly, not padded to a default. But
-    `backtest_allocation` is `ge=1` server-side -- a backtest cannot run on
-    $0 -- so `resolveBacktestCapital` treats a non-positive value as absent
-    and falls through to the $1,000 default. Rendering these two the same
-    way would either lie about a user's real (zero) money or hand a $0 into
-    an API call that would 422.
+    `cash_allocation` is `ge=0`: a $0 paper sleeve is a real, legal state and is
+    shown honestly rather than padded to a default. `backtest_allocation` is
+    `ge=0` too as of 2026-09-10, but this case is the NULL column -- "never
+    configured" -- which mirrors the paper sleeve only when that sleeve is
+    funded. A $0 sleeve is the ordinary state of someone who does not
+    paper-trade at all, and mirroring it would silently zero the backtests of
+    every such agent that never touched this field.
     """
     out = _run_node(
         _harness(
@@ -105,6 +105,26 @@ def test_zero_paper_sleeve_displays_as_zero_but_backtest_capital_does_not():
     )
     assert "$0" in out
     assert "$1,000" in out
+
+
+def test_a_saved_zero_backtest_capital_is_displayed_as_zero():
+    """The other half of the split above, and the one that used to be lost.
+
+    ``$0`` became a saveable backtest amount on 2026-09-10, but
+    ``resolveBacktestCapital``'s ``value > 0`` still read it as absent -- so the
+    card and the Run Backtest dialog rendered $1,000 (or the paper sleeve) over
+    a setting the owner had explicitly chosen, after a save that reported
+    success. Reopening Configure then wrote the displayed number back, which
+    made the setting undo itself by being looked at.
+    """
+    out = _run_node(
+        _harness(
+            "console.log(renderAgentAllocatedCapitalHero("
+            "{cash_allocation: 2000, backtest_allocation: 0}));"
+        )
+    )
+    assert "$0" in out, "a saved $0 backtest capital was replaced by a fallback"
+    assert "$1,000" not in out
 
 
 def test_run_paper_trading_button_is_disabled_and_explained():

--- a/dashboard/backend/tests/test_protocol_api.py
+++ b/dashboard/backend/tests/test_protocol_api.py
@@ -489,6 +489,57 @@ def test_reject_nonfinite_quantity(client):
     assert inf.status_code == 422, inf.text
 
 
+def test_accept_zero_initial_cash(client):
+    """$0 is a legal amount of simulated capital, on this surface too.
+
+    The protocol service carried its own ``requested <= 0`` refusal, separate
+    from the agents API's ``Field(ge=...)`` and from the dashboard route's.
+    Relaxing one and not the others is how the Configure card came to disagree
+    with itself in the first place -- see tests/test_zero_backtest_capital.py.
+    """
+    agent_id, key, _ = _new_agent(client)
+    version_id = _new_version(client, agent_id, key)
+
+    resp = client.post(
+        "/api/v1/runs",
+        json={
+            "agent_version_id": version_id,
+            "environment": {"type": "backtest", "environment_id": "us-equity-hourly-v1"},
+            "config": {
+                "start_date": "2026-04-15",
+                "end_date": "2026-04-16",
+                "symbols": ["AAPL", "MSFT"],
+                "initial_cash": 0,
+            },
+        },
+        headers={"X-API-Key": key},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def test_reject_negative_initial_cash(client):
+    """Zero opened up; negative did not."""
+    agent_id, key, _ = _new_agent(client)
+    version_id = _new_version(client, agent_id, key)
+
+    resp = client.post(
+        "/api/v1/runs",
+        json={
+            "agent_version_id": version_id,
+            "environment": {"type": "backtest", "environment_id": "us-equity-hourly-v1"},
+            "config": {
+                "start_date": "2026-04-15",
+                "end_date": "2026-04-16",
+                "symbols": ["AAPL", "MSFT"],
+                "initial_cash": -1,
+            },
+        },
+        headers={"X-API-Key": key},
+    )
+    assert resp.status_code == 400, resp.text
+    assert resp.json()["detail"]["error"]["code"] == "invalid_config"
+
+
 def test_reject_nondefault_initial_cash(client):
     """create_run rejects config.initial_cash above MAX_BACKTEST_INITIAL_CAPITAL."""
     agent_id, key, _ = _new_agent(client)
@@ -730,6 +781,61 @@ def test_full_run_to_completion_and_result(client):
 
     metrics = client.get(f"/api/v1/runs/{run_id}/metrics", headers={"X-API-Key": key}).json()
     assert "total_return" in metrics["metrics"]
+
+
+def test_full_zero_capital_run_completes_and_reports_a_zero_return(client):
+    """The $0 run, driven all the way through finalize -- not just accepted.
+
+    ``test_accept_zero_initial_cash`` proves create_run stopped refusing it;
+    that says nothing about whether the run can *end*. Finalize divides by
+    initial capital, and until 2026-09-10 the $1 floor was the only guard on
+    that division: accepting the 0 without ``fractional_return`` would have
+    swapped a readable 400 at create time for a ``ZeroDivisionError`` in the
+    finalize path, after the caller had already spent every step of the run.
+
+    A run with no cash fills nothing, so the honest report is a flat curve and
+    0.00% -- not ``inf``, and not a crash.
+    """
+    agent_id, key, _ = _new_agent(client)
+    version_id = _new_version(client, agent_id, key)
+
+    created = client.post(
+        "/api/v1/runs",
+        json={
+            "agent_version_id": version_id,
+            "environment": {"type": "backtest", "environment_id": "us-equity-hourly-v1"},
+            "config": {
+                "start_date": "2026-04-15",
+                "end_date": "2026-04-16",
+                "symbols": ["AAPL", "MSFT"],
+                "initial_cash": 0,
+            },
+        },
+        headers={"X-API-Key": key},
+    )
+    assert created.status_code == 200, created.text
+    run_id = created.json()["run_id"]
+
+    for _ in range(200):
+        body = _wait_for_step(client, run_id, key)
+        if body.get("status") == "completed":
+            break
+        resp = client.post(
+            f"/api/v1/runs/{run_id}/steps/{body['step_id']}/decision",
+            json={"idempotency_key": str(uuid.uuid4()), "orders": []},
+            headers={"X-API-Key": key},
+        )
+        assert resp.status_code == 200, resp.text
+    else:
+        raise AssertionError("$0 run did not complete")
+
+    status = client.get(f"/api/v1/runs/{run_id}/status", headers={"X-API-Key": key}).json()
+    assert status["status"] == "completed"
+
+    metrics = client.get(
+        f"/api/v1/runs/{run_id}/metrics", headers={"X-API-Key": key}
+    ).json()["metrics"]
+    assert metrics["total_return"] == 0
 
 
 def test_run_result_before_completion(client):

--- a/dashboard/backend/tests/test_zero_backtest_capital.py
+++ b/dashboard/backend/tests/test_zero_backtest_capital.py
@@ -1,0 +1,274 @@
+"""$0 is a legal amount of simulated backtest capital.
+
+The Configure screen's Allocated Capital card holds two fields, and until now
+they disagreed about zero: ``cash_allocation`` (the paper-trading sleeve)
+accepted ``$0`` at every layer, while ``backtest_allocation`` (simulated money)
+carried a ``$1`` floor at *seven* independent places -- the ``min`` attribute,
+the editor's own validator, two ``Field(ge=...)`` bounds, ``/backtest/run``'s
+explicit 422, the protocol run service's 400, and ``resolve_initial_capital``,
+which silently rewrote 0 to the $1,000 default rather than refusing it. Users
+read that split as a bug in the card, which is what it looks like: two boxes
+side by side, one takes 0 and the other will not say why it won't.
+
+**Why the floor was load-bearing, and what replaced it.** Return is computed as
+``(final_eq - initial_capital) / initial_capital`` at five sites (four in
+``engine.py``, one in ``external_run_service.py``), none of them guarded. The
+``$1`` floor was the only thing standing between a user's typed 0 and a
+``ZeroDivisionError`` partway through a run. Lifting the floor therefore had to
+come with ``fractional_return()``, which owns that arithmetic in one place --
+otherwise the 422 would simply have been traded for a 500.
+
+A $0 run is a real, if degenerate, backtest: no cash means no fills, so every
+step holds, the curve is flat at $0, and the honest return is 0.00%.
+"""
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from dashboard.backend.app import app
+from dashboard.backend.domain.backtesting.constants import (
+    INITIAL_CAPITAL,
+    MIN_BACKTEST_INITIAL_CAPITAL,
+    fractional_return,
+    resolve_initial_capital,
+)
+
+
+def _headers():
+    session = str(uuid.uuid4())
+    return {"X-Session-Id": session, "X-Browser-Id": session}
+
+
+# --------------------------------------------------------------------------
+# The constant and the two functions that read it
+# --------------------------------------------------------------------------
+
+
+def test_the_backtest_capital_floor_is_zero():
+    assert MIN_BACKTEST_INITIAL_CAPITAL == 0
+
+
+def test_zero_survives_resolution_instead_of_becoming_the_default():
+    """The one that made this a *silent* bug rather than a loud one.
+
+    ``if value <= 0: return INITIAL_CAPITAL`` meant a 0 that got past the API
+    came back as $1,000 -- the field would have accepted the number and the run
+    would have used a different one, with nothing anywhere saying so.
+    """
+    assert resolve_initial_capital(0) == 0.0
+    assert resolve_initial_capital("0") == 0.0
+    assert resolve_initial_capital(0.0) == 0.0
+
+
+@pytest.mark.parametrize("absent", [None, "", "abc", object()])
+def test_absent_or_unparseable_capital_still_falls_back_to_the_default(absent):
+    """Zero is a value; absent is not. Keeping them apart is the whole fix."""
+    assert resolve_initial_capital(absent) == float(INITIAL_CAPITAL)
+
+
+def test_negative_capital_is_still_treated_as_invalid():
+    """Nothing asked for negative money; it stays a fallback, not a balance."""
+    assert resolve_initial_capital(-1) == float(INITIAL_CAPITAL)
+    assert resolve_initial_capital(-3_000) == float(INITIAL_CAPITAL)
+
+
+def test_fractional_return_reports_zero_rather_than_dividing_by_zero():
+    assert fractional_return(0.0, 0.0) == 0.0
+    # A $0 run cannot produce equity, but a caller must not explode if it does.
+    assert fractional_return(5.0, 0.0) == 0.0
+
+
+def test_fractional_return_is_unchanged_for_every_funded_run():
+    assert fractional_return(1_100.0, 1_000.0) == pytest.approx(0.1)
+    assert fractional_return(900.0, 1_000.0) == pytest.approx(-0.1)
+    assert fractional_return(1_000.0, 1_000.0) == 0.0
+
+
+# --------------------------------------------------------------------------
+# The agents API: storing $0 on the agent
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    import dashboard.backend.domain.agents.repository as agent_store_module
+    import dashboard.backend.api.routers.agents as agents_api
+    import dashboard.backend.database as db_module
+
+    db_path = tmp_path / "test.db"
+    test_agents = agent_store_module.AgentStore(db_path=db_path)
+    test_db = db_module.BacktestDatabase(db_path=db_path)
+    monkeypatch.setattr(agent_store_module, "agent_store", test_agents)
+    monkeypatch.setattr(agents_api.agent_service, "agents", test_agents)
+    monkeypatch.setattr(agents_api.agent_service, "db", test_db)
+    monkeypatch.setattr(db_module, "db", test_db)
+    return TestClient(app)
+
+
+def test_create_accepts_zero_backtest_allocation(client):
+    resp = client.post(
+        "/api/v1/agents",
+        json={"name": "broke", "backtest_allocation": 0},
+        headers=_headers(),
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["agent"]["backtest_allocation"] == 0
+
+
+def test_patch_accepts_zero_backtest_allocation(client):
+    headers = _headers()
+    created = client.post(
+        "/api/v1/agents",
+        json={"name": "funded", "backtest_allocation": 2_000},
+        headers=headers,
+    ).json()["agent"]
+
+    resp = client.patch(
+        f"/api/v1/agents/{created['agent_id']}",
+        json={"backtest_allocation": 0},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["agent"]["backtest_allocation"] == 0
+
+
+def test_zero_reads_back_as_zero_and_not_as_unset(client):
+    """``0`` and ``None`` are different states and must survive as different.
+
+    A NULL column means "never configured" and falls back to the default; a
+    stored 0 means the owner chose 0. An ``or``-chain anywhere on this path
+    collapses them, and the collapse is invisible -- the run simply uses
+    $1,000.
+    """
+    headers = _headers()
+    zero = client.post(
+        "/api/v1/agents",
+        json={"name": "zero", "backtest_allocation": 0},
+        headers=headers,
+    ).json()["agent"]
+    unset = client.post(
+        "/api/v1/agents", json={"name": "unset"}, headers=headers
+    ).json()["agent"]
+
+    assert zero["backtest_allocation"] == 0
+    assert unset["backtest_allocation"] is None
+
+    reread = client.get(
+        f"/api/v1/agents/{zero['agent_id']}", headers=headers
+    ).json()
+    agent = reread.get("agent", reread)
+    assert agent["backtest_allocation"] == 0
+
+
+def test_negative_backtest_allocation_is_still_rejected(client):
+    resp = client.post(
+        "/api/v1/agents",
+        json={"name": "negative", "backtest_allocation": -1},
+        headers=_headers(),
+    )
+    assert resp.status_code == 422
+
+
+# --------------------------------------------------------------------------
+# The chart routes: a stored 0 must not be read as a missing value
+# --------------------------------------------------------------------------
+
+
+def test_a_stored_zero_scales_the_baselines_to_zero_not_to_a_thousand():
+    """``initial_equity or first_equity or 1_000`` reads zero as missing.
+
+    That chain was correct right up until zero became reachable. With a $0 run
+    it scaled DJIA and buy-and-hold to $1,000 and drew them a thousand times
+    above an agent curve sitting flat on the axis -- a chart that says the
+    agent was wiped out when in fact it was never funded.
+    """
+    from dashboard.backend.api.routers.backtests import _run_initial_capital
+
+    assert _run_initial_capital({"initial_equity": 0}, 0) == 0.0
+    assert _run_initial_capital({"initial_equity": 0.0}, 500.0) == 0.0
+
+
+def test_a_missing_stored_capital_still_falls_back():
+    from dashboard.backend.api.routers.backtests import _run_initial_capital
+
+    assert _run_initial_capital({}, 2_500.0) == 2_500.0
+    assert _run_initial_capital({"initial_equity": None}, 2_500.0) == 2_500.0
+    assert _run_initial_capital({}, None) == float(INITIAL_CAPITAL)
+
+
+def test_a_stored_nan_does_not_poison_every_scaled_point():
+    """NaN is a float and is not None, so it clears both of the other guards."""
+    from dashboard.backend.api.routers.backtests import _run_initial_capital
+
+    assert _run_initial_capital({"initial_equity": float("nan")}, 900.0) == 900.0
+    assert _run_initial_capital(
+        {"initial_equity": float("nan")}, float("nan")
+    ) == float(INITIAL_CAPITAL)
+
+
+# --------------------------------------------------------------------------
+# The engine arithmetic the floor used to be standing in front of
+# --------------------------------------------------------------------------
+
+
+def test_the_engine_computes_a_zero_capital_return_without_raising():
+    """Guards the actual call sites, not just the helper.
+
+    ``fractional_return`` passing its own unit tests proves nothing about
+    whether ``engine.py`` still divides directly -- this asserts the shipped
+    expression, so re-inlining the division fails here rather than in prod.
+    """
+    import inspect
+
+    from dashboard.backend.domain.backtesting import (
+        engine as engine_module,
+        external_run_service as ext_module,
+    )
+
+    for module in (engine_module, ext_module):
+        source = inspect.getsource(module)
+        assert "/ self.initial_capital" not in source, (
+            f"{module.__name__} divides by initial_capital directly; a $0 run "
+            "raises ZeroDivisionError. Use fractional_return()."
+        )
+        assert "fractional_return(" in source
+
+
+# --------------------------------------------------------------------------
+# The two route gates that carried their own hand-written "> 0"
+# --------------------------------------------------------------------------
+
+
+def test_backtest_run_rejects_negative_capital_and_names_the_floor():
+    """The refusal has to move with the constant, not restate a literal.
+
+    ``/backtest/run`` validated ``initial_capital <= 0`` inline, independently
+    of ``MIN_BACKTEST_INITIAL_CAPITAL``. A floor duplicated as a literal is a
+    floor that stops moving when the constant does -- which is how one field
+    ended up with seven of them disagreeing.
+    """
+    resp = TestClient(app).post(
+        "/backtest/run", json={"initial_capital": -1}, headers=_headers()
+    )
+    assert resp.status_code == 422
+    assert "negative" in resp.json()["detail"]
+    assert f"{MIN_BACKTEST_INITIAL_CAPITAL:g}" in resp.json()["detail"]
+
+
+def test_neither_route_gate_hardcodes_a_positive_floor_any_more():
+    import inspect
+
+    from dashboard.backend.api.routers import backtests as backtests_module
+    from dashboard.backend.domain.runs import service as runs_service
+
+    for module, field in (
+        (backtests_module, "initial_capital"),
+        (runs_service, "requested"),
+    ):
+        source = inspect.getsource(module)
+        assert f"{field} <= 0" not in source, (
+            f"{module.__name__} still refuses $0 with its own literal floor."
+        )
+        assert "MIN_BACKTEST_INITIAL_CAPITAL" in source

--- a/dashboard/backend/tests/test_zero_backtest_capital.py
+++ b/dashboard/backend/tests/test_zero_backtest_capital.py
@@ -272,3 +272,168 @@ def test_neither_route_gate_hardcodes_a_positive_floor_any_more():
             f"{module.__name__} still refuses $0 with its own literal floor."
         )
         assert "MIN_BACKTEST_INITIAL_CAPITAL" in source
+
+
+# --------------------------------------------------------------------------
+# The metrics the floor was also standing in front of
+#
+# ``fractional_return`` fixed the *return* division. Sharpe and max-drawdown
+# divide by the equity **series**, which is all zeros for an unfunded run --
+# the same zero denominator, two call sites over. Neither was touched, and
+# neither failure is visible locally: SQLite coerces NaN to NULL on write, so
+# the whole suite stays green while the Postgres run-history backend prod sets
+# (``AGENT_RUNS_DATABASE_URL``) round-trips the NaN intact.
+# --------------------------------------------------------------------------
+
+
+def test_sharpe_of_a_zero_capital_curve_is_zero_rather_than_nan():
+    """``np.std(returns) == 0`` is False for NaN, so the existing zero-volatility
+    early return does not catch this -- the guard has to precede the division.
+    """
+    from dashboard.backend.domain.backtesting.metrics import calculate_sharpe
+
+    sharpe = calculate_sharpe([{"equity": 0.0}] * 5)
+    assert sharpe == 0
+    assert sharpe == sharpe, "NaN reached the stored sharpe_ratio"
+
+
+def test_max_drawdown_of_a_zero_capital_curve_is_zero_without_warning():
+    """Its *result* was already right -- ``dd < max_dd`` is False for NaN, so
+    max_dd stays 0 by accident. The 0/0 still runs, and numpy prints a
+    RuntimeWarning into the stdout of every $0 backtest.
+    """
+    import warnings
+
+    from dashboard.backend.domain.backtesting.metrics import calculate_max_drawdown
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        assert calculate_max_drawdown([{"equity": 0.0}] * 5) == 0
+    assert not [w for w in caught if issubclass(w.category, RuntimeWarning)], (
+        "a $0 run prints a numpy divide warning into its own stdout"
+    )
+
+
+def test_no_metric_of_a_zero_capital_curve_is_unserialisable():
+    """The shape of the prod failure, expressed as the thing that actually breaks.
+
+    Starlette's ``JSONResponse`` encodes with ``allow_nan=False``. Routes that
+    return a plain dict rather than a ``response_model`` -- ``/runs/{id}/metrics``,
+    ``/result``, ``agents.py``'s builtin listing, the Discord route, v2's
+    leaderboard -- therefore answer **500** for any run carrying a NaN metric,
+    which is every $0 run once run history is on Postgres. An agent that
+    completes the run this PR makes legal cannot then read its own result.
+    """
+    import json
+
+    from dashboard.backend.domain.backtesting.metrics import (
+        calculate_max_drawdown,
+        calculate_sharpe,
+    )
+
+    curve = [{"equity": 0.0}] * 5
+    json.dumps(
+        {
+            "sharpe_ratio": float(calculate_sharpe(curve)),
+            "max_drawdown": float(calculate_max_drawdown(curve)),
+        },
+        allow_nan=False,
+    )
+
+
+def test_funded_curves_keep_their_existing_sharpe_and_drawdown():
+    """The guard must be a zero-denominator guard, not a flattener."""
+    from dashboard.backend.domain.backtesting.metrics import (
+        calculate_max_drawdown,
+        calculate_sharpe,
+    )
+
+    rising = [{"equity": v} for v in (1_000.0, 1_010.0, 1_030.0, 1_020.0)]
+    assert calculate_sharpe(rising) != 0
+    assert calculate_max_drawdown(rising) == pytest.approx(-10.0 / 1_030.0)
+
+
+# --------------------------------------------------------------------------
+# The benchmark curves: $0 x anything is still $0
+# --------------------------------------------------------------------------
+
+
+def test_index_baselines_are_skipped_rather_than_scaled_to_zero():
+    """``initial_capital * (value / base)`` is 0 for every point of a $0 run.
+
+    DJIA and Nasdaq-100 then draw as flat zero lines directly on top of the
+    agent's own flat zero line, which reads as "the benchmark data failed" --
+    while ``index_baselines_ok`` goes on reporting ``true``. Publishing nothing
+    is the honest render; there is no benchmark a $0 portfolio can be scaled to.
+
+    ``upstream_ok`` stays ``True``: ``False`` means *transient and retryable*,
+    which turns off plot caching (``_UncachedPlotPng``) and prints the degraded
+    -render note. Neither applies -- this window is permanently baseline-free,
+    exactly like the ``usable_window`` branch above it.
+    """
+    from datetime import datetime, timezone
+
+    from dashboard.backend import equity_plot
+
+    original = equity_plot.fetch_index_hourly
+
+    def _explode(*args, **kwargs):
+        raise AssertionError("Yahoo queried for a run no baseline can be scaled to")
+
+    equity_plot.fetch_index_hourly = _explode
+    try:
+        baselines, upstream_ok = equity_plot.market_index_baselines_with_status(
+            [datetime(2026, 4, 15, 14, 30, tzinfo=timezone.utc)],
+            "2026-04-15",
+            "2026-04-28",
+            0.0,
+        )
+    finally:
+        equity_plot.fetch_index_hourly = original
+
+    assert baselines == []
+    assert upstream_ok is True, "a $0 run is baseline-free, not degraded"
+
+
+def test_a_funded_run_still_asks_for_its_index_baselines():
+    """The cheapest way to pass the case above is to stop fetching entirely."""
+    from datetime import datetime, timezone
+
+    from dashboard.backend import equity_plot
+
+    asked = []
+    original = equity_plot.fetch_index_hourly
+
+    def _record(symbol, start, end):
+        asked.append(symbol)
+        return []
+
+    equity_plot.fetch_index_hourly = _record
+    try:
+        equity_plot.market_index_baselines_with_status(
+            [datetime(2026, 4, 15, 14, 30, tzinfo=timezone.utc)],
+            "2026-04-15",
+            "2026-04-28",
+            1_000.0,
+        )
+    finally:
+        equity_plot.fetch_index_hourly = original
+
+    assert asked, "a funded run stopped requesting index baselines"
+
+
+def test_the_engine_stores_no_baseline_run_for_a_zero_capital_backtest():
+    """The persisted twin of the chart bug, and the longer-lived one.
+
+    ``generate_baselines`` at $0 produces a flat zero history, which is then
+    written to ``agent_runs`` as a real row: a $0 run recorded the DJIA as
+    having returned 0.00% over its window. The chart is regenerated per
+    request; these rows are not.
+    """
+    from dashboard.backend.domain.backtesting.engine import HourlyBacktester
+
+    backtester = object.__new__(HourlyBacktester)
+    backtester.initial_capital = 0.0
+
+    assert backtester.run_buyhold_baseline() == (None, [])
+    assert backtester.run_djia_baseline() == (None, [])

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -1144,7 +1144,14 @@
                             </label>
                             <label class="agent-capital-field" for="agentEditorBacktestAllocation">
                                 <span class="agent-capital-label">Backtesting <span class="agent-capital-max">max $3,000</span></span>
-                                <input id="agentEditorBacktestAllocation" class="agent-capital-input" type="number" min="1" max="3000" step="any" data-cash-step="100" placeholder="1000" aria-label="Backtest Allocated Capital">
+                                <!-- min="0", matching the Paper Trading field above it. The two
+                                     halves of this card disagreed about zero until 2026-09-10:
+                                     this one was min="1" and refused a typed 0 with "Enter an
+                                     amount between $1 and $3,000", which reads as the card being
+                                     broken rather than as a rule. `min` is also what
+                                     snapCashStepValue clamps to, so the old 1 was what refilled
+                                     this field the instant it was cleared. -->
+                                <input id="agentEditorBacktestAllocation" class="agent-capital-input" type="number" min="0" max="3000" step="any" data-cash-step="100" placeholder="1000" aria-label="Backtest Allocated Capital">
                                 <span class="capital-input-error" data-cash-error-slot role="alert" hidden></span>
                                 <span class="agent-capital-note">Simulated only. Never spends real cash.</span>
                             </label>

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -1106,12 +1106,23 @@ function formatSignedReturnPct(frac) {
  * did, i.e. starting from its paper sleeve.
  */
 function resolveBacktestCapital(agent) {
-  const candidates = [agent?.backtest_allocation, agent?.cash_allocation];
-  for (const raw of candidates) {
-    const value = Number(raw);
-    if (Number.isFinite(value) && value > 0) {
-      return Math.min(Math.round(value), MAX_BACKTEST_ALLOCATED_CAPITAL);
-    }
+  // A SAVED 0 is an answer; only NULL falls through. `> 0` on this first
+  // candidate sent a deliberate $0 down the fallback chain and rendered it as
+  // the agent's paper sleeve, or $1,000 -- the card and the Run Backtest dialog
+  // then both displayed capital the owner had explicitly set to something else,
+  // with the save having reported success.
+  const saved = Number(agent?.backtest_allocation);
+  if (agent?.backtest_allocation != null && Number.isFinite(saved) && saved >= 0) {
+    return Math.min(Math.round(saved), MAX_BACKTEST_ALLOCATED_CAPITAL);
+  }
+  // The NULL case, unchanged: mirror the paper sleeve, but only a funded one.
+  // `> 0` is right *here* -- a $0 sleeve is the ordinary state of someone who
+  // does not paper-trade, and mirroring it would zero the backtests of every
+  // such agent that never set this field. See getEditorState in agent-editor.js,
+  // which makes the same split for the same reason.
+  const sleeve = Number(agent?.cash_allocation);
+  if (Number.isFinite(sleeve) && sleeve > 0) {
+    return Math.min(Math.round(sleeve), MAX_BACKTEST_ALLOCATED_CAPITAL);
   }
   return DEFAULT_AGENT_CASH_ALLOCATION;
 }

--- a/dashboard/frontend/js/agent-editor.js
+++ b/dashboard/frontend/js/agent-editor.js
@@ -837,17 +837,24 @@
     let backtest_allocation = null;
     if (backtestInput && backtestInput.value !== '') {
       const value = Number(backtestInput.value);
-      if (!Number.isFinite(value) || value < 1) {
-        throw new Error('Backtest Allocated Capital must be at least $1.');
+      // `< 0`, matching the Paper Trading branch above. $0 is a legal amount of
+      // simulated capital as of 2026-09-10 -- a run with no cash makes no
+      // trades and reports 0.00%, which is a real answer, not an error state.
+      if (!Number.isFinite(value) || value < 0) {
+        throw new Error('Backtest Allocated Capital must be zero or greater.');
       }
       if (value > 3000) {
         throw new Error('Backtest Allocated Capital cannot exceed $3,000.');
       }
       backtest_allocation = Math.round(value);
     } else {
-      // Non-positive counts as absent: cash_allocation is legally 0 (a $0 paper
-      // sleeve), but backtest capital is >= 1 server-side, so 0 must fall
-      // through to the default rather than becoming an unsaveable value.
+      // EMPTY, not zero. A typed 0 is saved verbatim by the branch above; this
+      // is the "never configured" case, which mirrors the paper sleeve the way
+      // the field's own hint promises ("Backtests start from this amount by
+      // default"). The `> 0` below is therefore about the *mirror*, not about
+      // what is saveable: a $0 paper sleeve is a common state for someone who
+      // does not paper-trade, and silently turning their unset backtest capital
+      // into $0 would change a run they never touched. Unset stays $1,000.
       backtest_allocation =
         Number.isFinite(Number(cash_allocation)) && Number(cash_allocation) > 0
           ? Math.min(Math.round(Number(cash_allocation)), 3000)
@@ -998,14 +1005,18 @@
     }
     const backtestInput = document.getElementById('agentEditorBacktestAllocation');
     if (backtestInput) {
-      // Non-positive counts as absent: cash_allocation is legally 0 (a $0 paper
-      // sleeve), but backtest capital is >= 1 server-side, so 0 must fall
-      // through to the default rather than becoming an unsaveable value.
-      const candidates = [agent.backtest_allocation, agent.cash_allocation];
-      let resolved = 1000;
-      for (const raw of candidates) {
-        const value = Number(raw);
-        if (Number.isFinite(value) && value > 0) { resolved = value; break; }
+      // Mirrors resolveBacktestCapital in app.js -- a saved 0 is an answer and
+      // only NULL falls through to the paper sleeve. With `> 0` on the first
+      // candidate, reopening Configure on a $0 agent showed 1000 in the box,
+      // and the next save wrote that back: the setting undid itself by being
+      // looked at.
+      const saved = Number(agent.backtest_allocation);
+      let resolved;
+      if (agent.backtest_allocation != null && Number.isFinite(saved) && saved >= 0) {
+        resolved = saved;
+      } else {
+        const sleeve = Number(agent.cash_allocation);
+        resolved = Number.isFinite(sleeve) && sleeve > 0 ? sleeve : 1000;
       }
       backtestInput.value = String(Math.min(Math.round(resolved), 3000));
       resetCapitalInput(backtestInput);

--- a/docs/api/agent-environment-protocol-v1.md
+++ b/docs/api/agent-environment-protocol-v1.md
@@ -82,9 +82,15 @@ GET /api/v1/environments/{environment_id}
 ```
 
 The current universe is the DJIA 30 with a default initial cash of `1000`.
-Callers may override it via `config.initial_cash` on `POST /api/v1/runs`, up to
-a `10000` cap — a request above the cap gets a 400 `invalid_config` error, not
-a silent clamp.
+Callers may override it via `config.initial_cash` on `POST /api/v1/runs`, within
+`0` to `3000` — a request outside that range gets a 400 `invalid_config` error,
+not a silent clamp. The error body names the bound it broke
+(`min_initial_cash` / `max_initial_cash` in `details`).
+
+`0` is a legal amount, not a rejected one. A zero-capital run is created and
+stepped like any other; the agent simply has nothing to spend, so every order is
+refused for insufficient cash, the equity curve stays flat at `0`, and the run
+finalises with a `total_return` of `0`.
 
 ---
 

--- a/docs/source/lab/getting_started.rst
+++ b/docs/source/lab/getting_started.rst
@@ -77,7 +77,15 @@ but they are different kinds of money and have their own limits:
    setting rather than a per-run choice, so the **Run Backtest** dialog shows it
    read-only. Leave the field blank and it follows the agent's Paper Trading
    Allocated Capital. A backtest never spends real portfolio cash and never
-   changes it. Minimum **$1**, maximum **$10,000**.
+   changes it. Minimum **$0**, maximum **$3,000** — the same ceiling as the
+   Paper Trading field above, so neither capital can outgrow one agent's share
+   of the portfolio.
+
+   **$0 is a real amount, and blank is not $0.** Type ``0`` and the backtest
+   runs like any other: the agent simply has nothing to trade, so every order
+   is refused for insufficient cash, the equity curve stays flat at $0, and the
+   return is reported as ``0.00%``. Leaving the field *empty* means something
+   different — "not configured" — and falls back as described above.
 
 Paper trading is not switched on yet, so the first of those two currently has
 nothing to spend. **Run Paper Trading** sits beside **Run Backtest** on every
@@ -90,7 +98,10 @@ The reservation is real in the meantime: Paper Trading Allocated Capital leaves
 **My Portfolio** the moment you set it and reduces the cash available to your
 other agents. You can drop it to **$0** on an agent you only plan to backtest —
 give that agent its own **Backtesting** amount first, though, or its backtests
-fall back to $1,000 along with it.
+fall back to $1,000 rather than to $0. That asymmetry is deliberate: an *empty*
+Backtesting field mirrors the Paper Trading sleeve only while that sleeve is
+funded, so nobody who simply does not paper-trade gets their backtests silently
+zeroed. A typed ``0`` is always honoured.
 
 Start from a template
 ---------------------

--- a/docs/superpowers/notes/2026-09-10-user-facing-docs-backlog.md
+++ b/docs/superpowers/notes/2026-09-10-user-facing-docs-backlog.md
@@ -1,0 +1,144 @@
+# User-facing docs backlog — opened 2026-09-10
+
+Running list of **hosted / user-facing** documentation that the shipped code has
+outrun. Nothing here is edited piecemeal: the whole list lands in one pass, on
+one branch, when it is signed off. Add to it as work merges; do not fix items
+individually.
+
+Scope is `docs/source/lab/*.rst` (the Sphinx manual) and `README.md`. Agent-facing
+notes (`docs/superpowers/`, `docs/architecture/`) are out of scope — they are
+maintained inline with the code that changes them.
+
+Every entry below was re-verified against source on 2026-09-10, on `main` at
+`f5f803c3`. Where a suspected item turned out to be correct it is recorded under
+**Checked, not stale** rather than deleted, so the same false lead is not chased
+twice.
+
+---
+
+## 1 + 1b. Wrong capital numbers - LANDED 2026-09-10 (zero-capital PR)
+
+Both entries are **fixed and out of this backlog**. They were the only items the
+zero-capital change itself made wrong, so they shipped on that branch rather than
+waiting for the batch - a batch that landed the ceiling fix alone would have left
+a freshly-false floor behind it.
+
+- `docs/source/lab/getting_started.rst` - "Minimum **$1**, maximum **$10,000**"
+  is now "Minimum **$0**, maximum **$3,000**", with the ceiling tied to the Paper
+  Trading cap it matches (`MAX_AGENT_CASH_ALLOCATION`) and a paragraph separating
+  a typed `0` (honoured; a real, flat, 0.00% run) from an *empty* field ("not
+  configured"; mirrors the paper sleeve, floor $1,000). The `$0`-sleeve paragraph
+  further down now states that asymmetry as the deliberate choice it is.
+- `docs/api/agent-environment-protocol-v1.md` - the `10000` cap is now the real
+  `0`-`3000` range, plus a paragraph saying `0` is legal rather than rejected and
+  what a zero-capital run actually does.
+
+The `$10,000` red herring is worth remembering for the rest of this batch: it is
+a real number in the product (`DEFAULT_PORTFOLIO_EQUITY`, the account-level
+budget) sitting two paragraphs away, which is almost certainly how it got here.
+
+## 2. Undocumented surface: Credits & Billing
+
+**Files:** nowhere. `grep -ri credits docs/source/lab/` returns one unrelated hit
+("runs are credited to your agents" in `accounts.rst:9`).
+
+**Shipped and user-visible:** a whole top-level page — `#creditsView`
+(`app.html:1892`), reachable from the account menu ("Credits & Billing",
+`app.html:263`) and from the `credits` nav route (`app.html:32,114`). It carries
+three tabs — **API Keys**, **Credits**, **Activity** (`app.html:1908-1910`) — a
+**Test Mode** badge, and Stripe-test-card purchase.
+
+A signed-out visitor gets a "Sign in to manage Credits" empty state
+(`app.html:1913`), so this is an account-gated feature that `accounts.rst`
+should introduce and a new page should cover.
+
+**Must state plainly:** purchased Credits **buy nothing yet**. They land in
+`credit_ledger_entries`, while the metered path spends `user_entitlements.credits`,
+and no code path connects the two — pinned by
+`test_balance_does_not_claim_credits_are_spendable`. Documentation that implies a
+purchased balance is spendable would contradict a test that exists specifically to
+stop that claim.
+
+## 3. Undocumented surface: BYOK vs Platform Credits
+
+**Files:** nowhere.
+
+**Shipped:** a billing-mode choice on the run path — `data-billing-mode="byok"`
+and `data-billing-mode="platform_credits"` (`app.html:438,444`), with the
+"Use ATL Credits" button at `app.html:447`. The Credits page's own footnote
+states the rule: *"BYOK runs use your provider account and do not deduct ATL
+Credits"* (`app.html:2068`).
+
+This is the first thing a cost-conscious user needs to understand and it exists
+only as one line of footnote text inside the app. It belongs in
+`getting_started.rst` (the run-a-backtest flow) and in the new Credits page.
+
+## 4. Incomplete: the Asset Universe is now a builder, not a picker
+
+**File:** `docs/source/lab/getting_started.rst:9`
+**Says:** "In the dialog set the **Period** and **Asset Universe**, then click
+**Run Backtest**."
+
+**Actual:** the Asset Universe control is a two-tab component (`app.html:377-415`)
+— **Built-in** vs **Custom**, where Custom is a chip-based universe builder
+("Add companies to create your custom universe", `app.html:415`), plus a
+collapsible roster preview (`#backtestUniversePreview`, `:395`). There is also a
+separate registered **A-share universe** panel (`#ifindAshareUniverse`, `:362`)
+with its own selector.
+
+Shipped across #441/#442/#443/#446. One sentence describing a dropdown no longer
+covers it.
+
+## 5. Stale: the Leaderboard is two boards now
+
+**File:** `docs/source/lab/operating_modes.rst:13-14`
+**Says:** one board — "Standardized comparison of agents against buy-and-hold and
+index baselines over a fixed window."
+
+**Actual:** since #352 the dashboard serves the **Competition Leaderboard** (the
+fixed historical window this sentence describes) *and* the **Live Trading
+Leaderboard**, which renders a **Season 0 preview** — real Competition curves under
+season chrome, with a banner saying nothing has advanced, because the season
+engine does not exist yet.
+
+The existing sentence is not wrong about the Competition board; it is silent about
+the second one, which is the one a visitor sees under a "Live" label and will
+misread as live results. The H6 sentence that follows it is still accurate.
+
+**Careful:** do not write copy implying either board takes user entries. Neither
+does — every row is built from the curated roster in
+`dashboard/config/leaderboard.json`, and `api/routers/leaderboard.py` exposes no
+submission route.
+
+---
+
+## Checked, not stale
+
+- **`agentic-trading-lab.vercel.app` as the "Live app" URL**
+  (`overview.rst:6`, `getting_started.rst:7`). Verified working: Vercel serves the
+  static frontend and **proxies the API to Render** — `dashboard/frontend/vercel.json`
+  rewrites `/api`, `/paper`, `/backtest`, `/runs`, `/config`, `/admin`, `/ticker`,
+  `/health` and `/compare` to `https://agentictrading.onrender.com`, and its CSP
+  allowlists that origin in `connect-src`. Both `/` and `/app` return 200 on both
+  hosts. The Vercel URL is correct user-facing guidance; leave it.
+
+- **"charts the agent against buy-and-hold and DJIA"** (`getting_started.rst:11-13`)
+  — still matches the benchmark comparison shipped in #415.
+
+- **Agent Supermarket naming** — `marketplace.rst`, `getting_started.rst` and
+  `live_trading.rst` were all renamed on 2026-08-27 alongside #409. Current.
+
+- **PR #447's own changes** (capital-field guard, chart height floor, board
+  palette) — cosmetic and behavioural-guard only; they change no documented number
+  or flow. Item 1 above predates #447 and is unrelated to it.
+
+---
+
+## Landing the batch
+
+One branch, one PR, `docs:` prefix. Items 2 and 3 likely want a new
+`docs/source/lab/credits.rst` added to the `lab/index.rst` toctree rather than
+being wedged into `accounts.rst`. Items 1, 4 and 5 are edits in place.
+
+Sphinx deps are optional and live in `requirements-sphinx.txt` — install those
+before building to check the toctree.


### PR DESCRIPTION
The Allocated Capital card's two fields disagreed: **Paper Trading** accepted `$0`, **Backtesting** returned 422 (`ge: 1.0`). Reproduced against the live API before any edit.

### Why it wasn't a one-character `min` fix

The `$1` floor was load-bearing — the only guard on five unguarded `(final_eq - initial_capital) / initial_capital` sites. Dropping it alone trades a readable 422 for a `ZeroDivisionError` at finalize, *after* the caller has spent every step. `fractional_return()` now owns that arithmetic.

Making zero reachable exposed four latent falsy-zero collapses, correct only while zero was impossible:
- two `initial_equity or … or 1_000` chains → benchmark curves drawn at `$1,000` over a flat-zero agent
- `resolveBacktestCapital` (`app.js` + `agent-editor.js`) read a saved `0` as absent → Configure re-showed `$1,000` and the next save wrote it back; the setting undid itself by being looked at

### Deliberately unchanged

An **empty** Backtesting field still defaults to `$1,000` even at a `$0` paper sleeve. A `$0` sleeve is the normal state of anyone who doesn't paper-trade; mirroring it would silently zero their backtests. A typed `0` is honoured; unset is not zero.

`dashboard/scripts/backtest_engine.py` has two more unguarded divisions, unreachable (`initial_capital=100000` hardcoded in its only constructor). Flagged, not fixed.

### Verification

- Full backend suite: 4374 passed, 121 skipped, 0 failed
- A `$0` protocol run driven end-to-end through finalize → completes, `total_return == 0`
- Every new guard mutation-checked (fails on reverted code, passes on the fix)

### Docs

`getting_started.rst` and the v1 protocol doc had **both** numbers wrong (`$1` floor, `$10,000` ceiling vs the real `$3,000`); corrected, with the typed-`0`-vs-blank distinction stated. Remaining user-facing doc debt stays in the backlog note included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdJi4sUdBcci22kudVZiKm