### PR TITLE
feat(ux): first-loop checklist on My Agents

### DIFF
--- a/dashboard/backend/tests/test_onboarding_checklist.py
+++ b/dashboard/backend/tests/test_onboarding_checklist.py
@@ -40,7 +40,9 @@ from dashboard.backend.tests._frontend_source import (
     APP_HTML,
     APP_JS,
     STYLES,
+    call_args,
     fn_body,
+    strip_comments,
 )
 
 pytestmark = pytest.mark.skipif(
@@ -56,12 +58,19 @@ def _node(script: str) -> object:
     return json.loads(result.stdout)
 
 
-def _derive(agents_js: str, running_js: str = "{}") -> dict:
-    """Run the shipped deriveOnboardingChecklist() over the given inputs."""
+def _derive(agents_js: str, running_js: str = "[]", opts_js: str = "{}") -> dict:
+    """Run the shipped deriveOnboardingChecklist() over the given inputs.
+
+    agentRunCount() is lifted from app.js rather than stubbed here: it is the
+    page's one definition of "this agent has been backtested", and a harness
+    that restated it would keep passing after the shipped helper changed.
+    """
     script = "\n".join(
         [
+            fn_body("function agentRunCount("),
             fn_body("function deriveOnboardingChecklist("),
-            f"const out = deriveOnboardingChecklist({agents_js}, {running_js});",
+            "const out = deriveOnboardingChecklist("
+            f"{agents_js}, {running_js}, {opts_js});",
             "console.log(JSON.stringify(out));",
         ]
     )
@@ -85,7 +94,10 @@ _STARTERS = (
 
 _ONE_FINISHED = "[{agent_id: 'a1', agent_type: 'builtin', run_count: 1}]"
 
-_IN_FLIGHT = "{'run-77': {agentId: 'a1', runId: 'run-77', startedAt: 1}}"
+#: One live run, in the shape listRunningBacktests() hands back -- a swept
+#: list, not the raw sessionStorage map. See
+#: test_the_renderer_reads_the_swept_run_list for why the distinction matters.
+_IN_FLIGHT = "[{key: 'run-77', agentId: 'a1', runId: 'run-77', startedAt: 1}]"
 
 
 # --- derivation -------------------------------------------------------------
@@ -141,7 +153,9 @@ def test_an_empty_roster_stays_hidden_too():
 def test_a_null_run_count_is_not_a_finished_run():
     """Number(null) is 0 and Number.isFinite(0) is true, so a guard written as
     a finiteness check on the coerced value ticks the step for an agent whose
-    run_count never arrived."""
+    run_count never arrived. agentRunCount() coerces and then tests truthiness,
+    which lands on the right answer -- pinned because it is the kind of thing a
+    later "simplification" of that helper could quietly lose."""
     state = _derive("[{agent_id: 'a1', run_count: null}]")
     assert _step(state, "results")["done"] is False
 
@@ -165,11 +179,33 @@ def test_one_agent_with_runs_closes_the_loop_for_the_whole_roster():
 
 
 def test_an_empty_running_registry_does_not_tick_launch():
-    assert _step(_derive(_STARTERS, "{}"), "launch")["done"] is False
+    assert _step(_derive(_STARTERS, "[]"), "launch")["done"] is False
+
+
+def test_a_run_whose_agent_is_gone_does_not_tick_launch():
+    """The registry outlives the agent in two ordinary cases: the agent was
+    deleted, and logoutUser() navigates away without clearing sessionStorage,
+    so the next account signed in to that tab inherits the previous one's
+    entries. renderAgentCards() paints no card for either, so a tick here sends
+    the reader to "the card below" and there is no card below."""
+    orphan = "[{key: 'run-9', agentId: 'gone', runId: 'run-9', startedAt: 1}]"
+    state = _derive(_STARTERS, orphan)
+    assert _step(state, "launch")["done"] is False
+    assert "card below" not in _step(state, "launch")["hint"]
+
+
+def test_a_run_history_without_a_run_count_still_closes_the_loop():
+    """agentRunCount() falls back to `runs` when `run_count` is absent, and the
+    card beside the panel is badged from it. Two definitions of "has been
+    backtested" put a BACKTESTED card directly under a checklist saying the
+    results step was not done yet."""
+    state = _derive("[{agent_id: 'a1', runs: [{run_id: 'r1'}]}]")
+    assert _step(state, "results")["done"] is True
+    assert state["visible"] is False
 
 
 def test_a_missing_running_registry_is_survivable():
-    """readRunningBacktests() returns {} on a storage failure, but the derive
+    """listRunningBacktests() returns [] on a storage failure, but the derive
     must not throw if a caller hands it nothing at all."""
     for absent in ("null", "undefined"):
         state = _derive(_STARTERS, absent)
@@ -219,9 +255,14 @@ def test_the_checklist_reads_the_whole_roster_not_the_filtered_view():
     search box and the market chips narrow. The checklist describes the
     account, so it must read allAgents: filtering down to a shelf that excludes
     the agent carrying the runs would otherwise resurrect a panel the user
-    already closed by finishing a backtest."""
-    body = fn_body("function renderAgentCategories(")
-    assert "renderOnboardingChecklist(allAgents)" in body
+    already closed by finishing a backtest.
+
+    Asserted over the call's argument list with comments stripped. The call site
+    carries a note naming the collection it must not use, so a scan of the raw
+    body is satisfied by the prose explaining the bug -- and would stay green
+    with the code reverted to the filtered parameter."""
+    body = strip_comments(fn_body("function renderAgentCategories("))
+    assert call_args(body, "renderOnboardingChecklist") == "(allAgents)"
 
 
 def test_the_full_paint_is_the_only_render_site():
@@ -232,10 +273,25 @@ def test_the_full_paint_is_the_only_render_site():
     no tick can move, so a second render site on the 1Hz path could only ever
     repaint the same two rows. It also cannot be added casually: that function
     is executed under node by test_backtest_progress_card's patch harness,
-    which supplies its collaborators by hand."""
-    assert "renderOnboardingChecklist(" not in fn_body(
-        "function refreshRunningAgentCards("
+    which supplies its collaborators by hand.
+
+    Comments stripped for the same reason as above, in the other direction: a
+    negative guard over raw source fails on a comment that merely names the
+    function."""
+    assert "renderOnboardingChecklist(" not in strip_comments(
+        fn_body("function refreshRunningAgentCards(")
     )
+
+
+def test_the_renderer_reads_the_swept_run_list():
+    """listRunningBacktests(), never the raw readRunningBacktests() map. The map
+    keeps entries for runs that died without a terminal status; the shelves drop
+    those as they paint, through getAgentBacktestRunning(). Taken from the map,
+    the panel announced a run whose card the same render then declined to
+    draw -- and nothing schedules another paint to correct it."""
+    body = strip_comments(fn_body("function renderOnboardingChecklist("))
+    assert "listRunningBacktests()" in body
+    assert "readRunningBacktests" not in body
 
 
 def test_the_checklist_is_styled():
@@ -252,3 +308,81 @@ def test_the_launch_hint_stops_giving_instructions_once_the_run_starts():
     assert "Pick an agent" in idle["hint"]
     assert live["hint"] != idle["hint"]
     assert "Running now" in live["hint"]
+
+
+# --- the gap between a finished run and its run_count ------------------------
+
+_AWAITING = "{awaitingResults: true}"
+
+
+def test_the_checklist_does_not_untick_itself_when_the_run_succeeds():
+    """The regression this flag exists for. A run ending clears its registry
+    entry, and refreshRunningAgentCards() answers the changed running set with a
+    full re-render -- before the roster refresh carrying the new run_count has
+    landed. Both of the checklist's sources are false in that window, so the
+    panel repainted with BOTH steps unticked and the hint back to "pick an
+    agent", at the exact moment the user finished the loop it is celebrating."""
+    state = _derive(_STARTERS, "[]", _AWAITING)
+    assert _step(state, "launch")["done"] is True
+    assert _step(state, "results")["done"] is False
+    assert state["visible"] is True
+
+
+def test_the_awaiting_hint_stops_claiming_the_run_is_still_going():
+    """"Its progress is on the card below" is false once the run has ended --
+    the card is gone. The three launch hints are three distinct states."""
+    idle = _step(_derive(_STARTERS), "launch")["hint"]
+    live = _step(_derive(_STARTERS, _IN_FLIGHT), "launch")["hint"]
+    settling = _step(_derive(_STARTERS, "[]", _AWAITING), "launch")["hint"]
+    assert len({idle, live, settling}) == 3
+    assert "card below" not in settling
+
+
+def test_a_live_run_outranks_the_awaiting_hint():
+    """A second run launched while the first settles is the truer statement:
+    there IS a card below."""
+    hint = _step(_derive(_STARTERS, _IN_FLIGHT, _AWAITING), "launch")["hint"]
+    assert "Running now" in hint
+
+
+def test_the_finished_roster_still_hides_the_panel_while_awaiting():
+    """The flag bridges a gap; it cannot reopen a closed loop."""
+    assert _derive(_ONE_FINISHED, "[]", _AWAITING)["visible"] is False
+
+
+def test_the_repaint_guard_can_see_a_hint_change():
+    """The launch step moves from "Running now" to "loading your results" with
+    both steps' done-ness unchanged. A signature built from the ticks alone
+    matched and returned early, leaving the panel claiming a finished run was
+    still going."""
+    body = strip_comments(fn_body("function renderOnboardingChecklist("))
+    signature = body[body.index("const signature") : body.index("panel.dataset")]
+    assert "hint" in signature
+
+
+def test_only_a_successful_run_arms_the_bridge():
+    """A failed run leaves no results to wait for, so un-ticking is the honest
+    answer -- the reader does need to run another one."""
+    body = strip_comments(fn_body("function ensureBacktestPolling("))
+    assert "if (status.success) onboardingAwaitingRunCount = true;" in body
+
+
+def test_every_completion_refreshes_the_roster_that_clears_the_bridge():
+    """The refresh used to be gated on the run being the focused one, so a
+    background completion never reached it: its results stayed off the page and
+    the flag armed above had nothing to clear it. Both must hold -- the arm and
+    the refresh are one mechanism, and a flag with no clear is a permanent
+    tick."""
+    body = strip_comments(fn_body("function ensureBacktestPolling("))
+    assert "if (anyFinished) loadAgents();" in body
+    assert "anyFinished = true;" in body
+
+
+def test_the_landed_roster_clears_the_bridge_before_it_paints():
+    """Cleared before applyAgentFilters(), not after: the roster is the answer
+    the flag stood in for, so the paint it feeds must come from the roster."""
+    body = strip_comments(fn_body("async function loadAgentsNow("))
+    assign = body.index("allAgents = agents;")
+    clear = body.index("onboardingAwaitingRunCount = false;", assign)
+    paint = body.index("applyAgentFilters();", assign)
+    assert assign < clear < paint

--- a/dashboard/backend/tests/test_onboarding_checklist.py
+++ b/dashboard/backend/tests/test_onboarding_checklist.py
@@ -1,0 +1,254 @@
+"""My Agents guides a first-time user through one closed loop: run a backtest,
+see its results.
+
+**Why nothing here is stored.** The obvious design -- tick boxes in
+localStorage, or a `user_onboarding` table -- was rejected because this repo
+already has a cautionary instance of it. `defaultAgentProvisionGuardKey()`
+(app.js:255) keeps a localStorage flag meaning "we provisioned starters for this
+identity", and its own comment records why that is unreliable: user ids recycle
+on local SQLite and on Render's ephemeral disk, so the key can name a different
+person. Every tick below is instead a live read of data the page already holds,
+which cannot disagree with reality and needs no migration.
+
+**"You have an agent" is not progress.** `api/auth.py:534` calls
+`provision_starter_agents` at signup (DeepSeek V4 Pro, GPT-5.5, Claude Sonnet
+4.6), and `ensureDefaultFoundationAgent()` re-provisions client-side for guests.
+`GET /api/v1/agents` is therefore non-empty for every visitor who has ever
+loaded the page, signed in or not. A step keyed on agent existence would arrive
+pre-ticked for everyone and teach the user the checklist is decorative --
+`test_starter_agents_alone_tick_nothing` is the guard against someone adding
+one.
+
+**The two steps read different sources, and they have to.** The dashboard engine
+calls `db.insert_run` only at completion (engine.py:1650), with `final_equity`
+already populated -- there is no in-flight `agent_runs` row. So `run_count > 0`
+means "a finished run exists" and would tick BOTH steps in the same instant,
+collapsing the checklist into a single on/off. The launch step therefore also
+consults `readRunningBacktests()` (app.js:5434), the sessionStorage registry My
+Agents already keeps for in-flight runs, which is what produces the middle state
+a user actually spends minutes in: launched, still running, no results yet.
+"""
+
+import json
+import re
+import shutil
+import subprocess
+
+import pytest
+
+from dashboard.backend.tests._frontend_source import (
+    APP_HTML,
+    APP_JS,
+    STYLES,
+    fn_body,
+)
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("node") is None, reason="node is not installed"
+)
+
+
+def _node(script: str) -> object:
+    result = subprocess.run(
+        ["node", "-e", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def _derive(agents_js: str, running_js: str = "{}") -> dict:
+    """Run the shipped deriveOnboardingChecklist() over the given inputs."""
+    script = "\n".join(
+        [
+            fn_body("function deriveOnboardingChecklist("),
+            f"const out = deriveOnboardingChecklist({agents_js}, {running_js});",
+            "console.log(JSON.stringify(out));",
+        ]
+    )
+    return _node(script)
+
+
+def _step(state: dict, key: str) -> dict:
+    match = [s for s in state["steps"] if s["key"] == key]
+    assert match, f"no step named {key!r} in {state['steps']}"
+    return match[0]
+
+
+#: The three cards every account is born with. Nothing has been run on them.
+_STARTERS = (
+    "["
+    "{agent_id: 'a1', agent_type: 'builtin', model_name: 'deepseek-v4-pro', run_count: 0},"
+    "{agent_id: 'a2', agent_type: 'builtin', model_name: 'gpt-5.5', run_count: 0},"
+    "{agent_id: 'a3', agent_type: 'builtin', model_name: 'claude-sonnet-4-6', run_count: 0}"
+    "]"
+)
+
+_ONE_FINISHED = "[{agent_id: 'a1', agent_type: 'builtin', run_count: 1}]"
+
+_IN_FLIGHT = "{'run-77': {agentId: 'a1', runId: 'run-77', startedAt: 1}}"
+
+
+# --- derivation -------------------------------------------------------------
+
+
+def test_a_brand_new_owner_sees_both_steps_open():
+    state = _derive(_STARTERS)
+    assert state["visible"] is True
+    assert _step(state, "launch")["done"] is False
+    assert _step(state, "results")["done"] is False
+
+
+def test_starter_agents_alone_tick_nothing():
+    """Owning agents is not progress -- signup hands out three of them."""
+    state = _derive(_STARTERS)
+    assert [s["done"] for s in state["steps"]] == [False, False]
+
+
+def test_a_run_in_flight_ticks_launch_but_not_results():
+    """The middle state. Without readRunningBacktests() this is unreachable,
+    because no agent_runs row exists until the run finishes."""
+    state = _derive(_STARTERS, _IN_FLIGHT)
+    assert _step(state, "launch")["done"] is True
+    assert _step(state, "results")["done"] is False
+    assert state["visible"] is True
+
+
+def test_a_finished_run_closes_the_loop_and_hides_the_panel():
+    state = _derive(_ONE_FINISHED)
+    assert _step(state, "launch")["done"] is True
+    assert _step(state, "results")["done"] is True
+    assert state["visible"] is False
+
+
+def test_the_panel_stays_hidden_before_agents_have_loaded():
+    """A null roster is "we do not know yet", not "you have never run one".
+    Rendering the open checklist during the first fetch would flash a
+    to-do list at a user who finished the loop months ago."""
+    for empty in ("null", "undefined"):
+        state = _derive(empty)
+        assert state["visible"] is False, empty
+        assert _step(state, "launch")["done"] is False, empty
+
+
+def test_an_empty_roster_stays_hidden_too():
+    """Distinct from the null case above but the same answer: a roster that
+    came back empty means the agents call failed or the identity has nothing,
+    and instructing someone to run a backtest with no agent to run it on is
+    advice they cannot follow."""
+    assert _derive("[]")["visible"] is False
+
+
+def test_a_null_run_count_is_not_a_finished_run():
+    """Number(null) is 0 and Number.isFinite(0) is true, so a guard written as
+    a finiteness check on the coerced value ticks the step for an agent whose
+    run_count never arrived."""
+    state = _derive("[{agent_id: 'a1', run_count: null}]")
+    assert _step(state, "results")["done"] is False
+
+
+def test_a_string_run_count_still_counts():
+    """JSON from the API is typed, but the mock/demo roster and older cached
+    payloads are not -- '3' is three runs, not zero."""
+    state = _derive("[{agent_id: 'a1', run_count: '3'}]")
+    assert _step(state, "results")["done"] is True
+
+
+def test_one_agent_with_runs_closes_the_loop_for_the_whole_roster():
+    """The loop is per person, not per agent: a user who ran a backtest on one
+    starter has seen results and does not need the panel beside the other two."""
+    mixed = (
+        "[{agent_id: 'a1', run_count: 0},"
+        " {agent_id: 'a2', run_count: 2},"
+        " {agent_id: 'a3', run_count: 0}]"
+    )
+    assert _derive(mixed)["visible"] is False
+
+
+def test_an_empty_running_registry_does_not_tick_launch():
+    assert _step(_derive(_STARTERS, "{}"), "launch")["done"] is False
+
+
+def test_a_missing_running_registry_is_survivable():
+    """readRunningBacktests() returns {} on a storage failure, but the derive
+    must not throw if a caller hands it nothing at all."""
+    for absent in ("null", "undefined"):
+        state = _derive(_STARTERS, absent)
+        assert _step(state, "launch")["done"] is False, absent
+
+
+def test_demo_mode_never_shows_the_checklist():
+    """Demo mode is the no-backend fallback roster (MOCK_AGENTS), and a user
+    with no backend cannot run a backtest. Those agents carry run_count > 0, so
+    the derive hides the panel rather than handing out advice that cannot be
+    followed. Pinned because zeroing the mock counts for some unrelated reason
+    would silently start showing it."""
+    block = APP_JS[APP_JS.index("const MOCK_AGENTS = [") :]
+    block = block[: block.index("\n];")]
+    counts = re.findall(r"run_count:\s*(\d+)", block)
+    assert counts, "MOCK_AGENTS no longer declares run_count"
+    assert any(int(c) > 0 for c in counts)
+
+
+# --- placement and wiring ---------------------------------------------------
+
+
+def test_the_panel_sits_above_the_agent_shelves():
+    """Above #agentsCategories, not inside a shelf: it describes the whole
+    page, and a shelf can be emptied by the search box."""
+    panel = APP_HTML.index('id="onboardingChecklist"')
+    shelves = APP_HTML.index('id="agentsCategories"')
+    assert panel < shelves
+
+
+def test_the_panel_ships_hidden():
+    """First paint happens before the agents call answers. An unhidden panel
+    would show the open checklist for that gap to everyone, including users who
+    closed the loop long ago -- the same flash test_the_panel_stays_hidden_
+    before_agents_have_loaded pins on the derive side."""
+    opening = APP_HTML[APP_HTML.index('id="onboardingChecklist"') :]
+    assert "hidden" in opening[: opening.index(">")]
+
+
+def test_the_my_agents_paint_renders_the_checklist():
+    body = fn_body("function renderAgentCategories(")
+    assert "renderOnboardingChecklist(" in body
+
+
+def test_the_checklist_reads_the_whole_roster_not_the_filtered_view():
+    """renderAgentCategories is called with getFilteredAgents(), which the
+    search box and the market chips narrow. The checklist describes the
+    account, so it must read allAgents: filtering down to a shelf that excludes
+    the agent carrying the runs would otherwise resurrect a panel the user
+    already closed by finishing a backtest."""
+    body = fn_body("function renderAgentCategories(")
+    assert "renderOnboardingChecklist(allAgents)" in body
+
+
+def test_the_full_paint_is_the_only_render_site():
+    """The per-second refresh deliberately does NOT render it. Both events that
+    can move a tick -- a launch and a completion -- change the set of running
+    agents, and refreshRunningAgentCards answers a changed set by calling
+    applyAgentFilters(), which is a full re-render. While that set is unchanged
+    no tick can move, so a second render site on the 1Hz path could only ever
+    repaint the same two rows. It also cannot be added casually: that function
+    is executed under node by test_backtest_progress_card's patch harness,
+    which supplies its collaborators by hand."""
+    assert "renderOnboardingChecklist(" not in fn_body(
+        "function refreshRunningAgentCards("
+    )
+
+
+def test_the_checklist_is_styled():
+    assert ".onboarding-checklist" in STYLES
+
+
+def test_the_launch_hint_stops_giving_instructions_once_the_run_starts():
+    """A ticked step whose hint still says "pick an agent and open it in
+    Backtest" is telling the reader to do the thing they just did. The step can
+    only be done while the panel is visible if a run is in flight -- a finished
+    run hides the panel -- so the hint has a true alternative to switch to."""
+    idle = _step(_derive(_STARTERS), "launch")
+    live = _step(_derive(_STARTERS, _IN_FLIGHT), "launch")
+    assert "Pick an agent" in idle["hint"]
+    assert live["hint"] != idle["hint"]
+    assert "Running now" in live["hint"]

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -983,6 +983,10 @@
                         <button id="addAgentBtnToolbar" class="home-btn home-btn-primary agent-toolbar-add" type="button">Add Agent +</button>
                     </div>
                 </div>
+                <!-- Ships hidden: first paint happens before the agents call
+                     answers, and an open checklist in that gap is shown to
+                     everyone, including users who closed the loop long ago. -->
+                <section id="onboardingChecklist" class="onboarding-checklist" aria-label="Getting started" hidden></section>
                 <div id="agentsCategories">
                     <section class="agents-category" data-category="prompted">
                         <div class="agents-category-head">

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -1841,6 +1841,117 @@ function setAgentMarketFilter(market) {
   applyAgentFilters();
 }
 
+/**
+ * The first-loop checklist on My Agents: run a backtest, see its results.
+ *
+ * Every tick is derived from data the page already holds -- nothing is stored.
+ * The alternative was a localStorage flag, and this file already carries the
+ * cautionary instance: defaultAgentProvisionGuardKey()'s own comment records
+ * that user ids recycle on local SQLite and on Render's ephemeral disk, so such
+ * a key can end up naming a different person.
+ *
+ * **Agent existence is deliberately not a step.** Signup provisions three
+ * starter cards (api/auth.py -> provision_starter_agents) and
+ * ensureDefaultFoundationAgent() re-provisions them client-side for guests, so
+ * `agents.length > 0` is true for everyone who has ever loaded the page. A step
+ * keyed on it would arrive pre-ticked and teach the reader that the ticks mean
+ * nothing.
+ *
+ * **The two steps read different sources, and cannot both read run_count.** The
+ * dashboard engine writes its agent_runs row only at completion, with
+ * final_equity already populated -- there is no in-flight row. So `run_count`
+ * answers "are there results" and is silent about the minutes a user actually
+ * spends waiting. The launch step therefore also consults the in-flight
+ * registry, which is the only witness to that middle state; without it the
+ * checklist would jump 0 -> 2 in one instant and never show progress.
+ */
+function deriveOnboardingChecklist(agents, running) {
+    const roster = Array.isArray(agents) ? agents : [];
+    const finished = roster.some((agent) => {
+        const count = agent ? agent.run_count : null;
+        // Rejected before coercion, not after: Number(null) is 0 and
+        // Number('') is 0, so a finiteness check on the coerced value reads an
+        // absent count as a real zero -- which is the right answer here only by
+        // accident, and the wrong one for any guard written as `>= 0`.
+        if (count === null || count === undefined || count === '') return false;
+        return Number(count) > 0;
+    });
+    const inFlight = Object.keys(running || {}).length > 0;
+    return {
+        // Hidden until the roster lands, so the first paint of a returning user
+        // -- who closed this loop months ago -- never flashes an open to-do
+        // list at them; hidden again for good once the loop closes.
+        visible: roster.length > 0 && !finished,
+        finished,
+        steps: [
+            {
+                key: 'launch',
+                label: 'Run your first backtest',
+                // This step being done while the panel is still visible can
+                // only mean a run is in flight -- `finished` hides the panel
+                // outright -- so the ticked hint can say so rather than repeat
+                // instructions the reader has already followed.
+                hint: inFlight
+                    ? 'Running now. Its progress is on the card below.'
+                    : 'Pick an agent below and open it in Backtest.',
+                done: finished || inFlight,
+            },
+            {
+                key: 'results',
+                label: 'See your results',
+                hint: 'Its equity curve and metrics land on the Backtest tab when the run finishes.',
+                done: finished,
+            },
+        ],
+    };
+}
+
+/**
+ * Paint the checklist panel.
+ *
+ * renderAgentCategories() is the only caller, deliberately. The running card
+ * beside it needs a second, per-second renderer because its numbers move
+ * continuously; a tick here moves on exactly two events, a launch and a
+ * completion, and both change the *set* of running agents --  which
+ * refreshRunningAgentCards() already answers with a full re-render. While that
+ * set holds steady no tick can move, so a 1Hz render site could only repaint
+ * the same two rows.
+ *
+ * The signature guard is therefore not an optimisation for that caller that no
+ * longer exists: it keeps any repaint of the grid (a search keystroke, a chip)
+ * from rebuilding a panel whose state is unchanged.
+ */
+function renderOnboardingChecklist(agents) {
+    const panel = document.getElementById('onboardingChecklist');
+    if (!panel) return;
+    const state = deriveOnboardingChecklist(agents, readRunningBacktests());
+    const signature = `${state.visible}|${state.steps.map((s) => (s.done ? 1 : 0)).join('')}`;
+    if (panel.dataset.onboardingSignature === signature) return;
+    panel.dataset.onboardingSignature = signature;
+    panel.hidden = !state.visible;
+    if (!state.visible) {
+        panel.innerHTML = '';
+        return;
+    }
+    const items = state.steps
+        .map(
+            (step) => `
+            <li class="onboarding-step${step.done ? ' is-done' : ''}">
+                <span class="onboarding-step-mark" aria-hidden="true"></span>
+                <span class="onboarding-step-body">
+                    <span class="onboarding-step-label">${escapeHtml(step.label)}</span>
+                    <span class="onboarding-step-hint">${escapeHtml(step.hint)}</span>
+                </span>
+                <span class="sr-only">${step.done ? 'Done' : 'Not done yet'}</span>
+            </li>`,
+        )
+        .join('');
+    panel.innerHTML = `
+        <h3 class="onboarding-title">Get your first result</h3>
+        <p class="onboarding-lede">Your agents are already set up. Two steps to a finished backtest.</p>
+        <ol class="onboarding-steps">${items}</ol>`;
+}
+
 function renderAgentCategories(agents) {
   const errorEl = document.getElementById('agentsErrorState');
   const shelves = AGENT_SHELVES.map((shelf) => {
@@ -1856,6 +1967,12 @@ function renderAgentCategories(agents) {
 
   if (errorEl) errorEl.hidden = true; // a successful render clears any prior error
 
+  // allAgents, never the `agents` parameter: renderAgentCategories is called
+  // with getFilteredAgents(), which the search box and the market chips
+  // narrow. The checklist is about the account, so filtering down to a
+  // shelf that happens to exclude the agent carrying the runs must not
+  // resurrect a panel the user already closed by finishing a backtest.
+  renderOnboardingChecklist(allAgents);
   renderAgentMarketChips();
 
   const defaultId = getDefaultAgentId();

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -1842,6 +1842,15 @@ function setAgentMarketFilter(market) {
 }
 
 /**
+ * True from a run ending successfully until the roster refresh that carries its
+ * new run_count lands. Only the checklist reads it; see
+ * deriveOnboardingChecklist's `awaitingResults` for what it bridges. Cleared by
+ * loadAgentsNow(), which is the only thing that can answer the question it
+ * stands in for -- so every path that sets it must also reach that call.
+ */
+let onboardingAwaitingRunCount = false;
+
+/**
  * The first-loop checklist on My Agents: run a backtest, see its results.
  *
  * Every tick is derived from data the page already holds -- nothing is stored.
@@ -1864,19 +1873,45 @@ function setAgentMarketFilter(market) {
  * spends waiting. The launch step therefore also consults the in-flight
  * registry, which is the only witness to that middle state; without it the
  * checklist would jump 0 -> 2 in one instant and never show progress.
+ *
+ * **`runs` is the swept list from listRunningBacktests(), never the raw
+ * sessionStorage map.** The map keeps entries for runs that died without a
+ * terminal status; the shelves below drop those the moment they paint, through
+ * getAgentBacktestRunning(). A tick taken from the unswept map therefore
+ * announced "its progress is on the card below" a few milliseconds before the
+ * same render decided there was no card -- and nothing schedules another paint,
+ * so the panel sat there pointing at nothing.
+ *
+ * **`awaitingResults` is the third state, and it exists because the two facts
+ * above go stale at different instants.** A run ending clears its registry
+ * entry immediately, while the run_count that replaces it arrives a fetch
+ * later; in between, both reads are false and the checklist un-ticked itself at
+ * the exact moment the user finished the loop it is celebrating.
  */
-function deriveOnboardingChecklist(agents, running) {
+function deriveOnboardingChecklist(agents, runs, { awaitingResults = false } = {}) {
     const roster = Array.isArray(agents) ? agents : [];
-    const finished = roster.some((agent) => {
-        const count = agent ? agent.run_count : null;
-        // Rejected before coercion, not after: Number(null) is 0 and
-        // Number('') is 0, so a finiteness check on the coerced value reads an
-        // absent count as a real zero -- which is the right answer here only by
-        // accident, and the wrong one for any guard written as `>= 0`.
-        if (count === null || count === undefined || count === '') return false;
-        return Number(count) > 0;
-    });
-    const inFlight = Object.keys(running || {}).length > 0;
+    // agentRunCount() rather than a local read of run_count: it is already this
+    // page's answer to "how many backtests does this agent have", fallbacks
+    // included, and the card beside the panel is rendered from it. Two
+    // definitions meant a payload carrying `runs` but no `run_count` could badge
+    // a card BACKTESTED directly under a checklist insisting otherwise.
+    const finished = roster.some((agent) => agent && agentRunCount(agent) > 0);
+    // Only runs whose agent is still on the roster. The entry outlives the
+    // agent in two ordinary cases -- the agent was deleted, and logoutUser()
+    // navigates away without clearing sessionStorage, so the next account in
+    // that tab inherits the previous one's entries. Neither paints a card.
+    const rosterIds = new Set(
+        roster.map((agent) => (agent ? agent.agent_id : null)).filter(Boolean),
+    );
+    const inFlight = (Array.isArray(runs) ? runs : []).some(
+        (run) => run && rosterIds.has(run.agentId),
+    );
+    let launchHint = 'Pick an agent below and open it in Backtest.';
+    if (inFlight) {
+        launchHint = 'Running now. Its progress is on the card below.';
+    } else if (awaitingResults) {
+        launchHint = 'Finishing up — loading your results.';
+    }
     return {
         // Hidden until the roster lands, so the first paint of a returning user
         // -- who closed this loop months ago -- never flashes an open to-do
@@ -1887,14 +1922,12 @@ function deriveOnboardingChecklist(agents, running) {
             {
                 key: 'launch',
                 label: 'Run your first backtest',
-                // This step being done while the panel is still visible can
-                // only mean a run is in flight -- `finished` hides the panel
-                // outright -- so the ticked hint can say so rather than repeat
-                // instructions the reader has already followed.
-                hint: inFlight
-                    ? 'Running now. Its progress is on the card below.'
-                    : 'Pick an agent below and open it in Backtest.',
-                done: finished || inFlight,
+                // This step being done while the panel is still visible means a
+                // run is either in flight or just ended -- `finished` hides the
+                // panel outright -- so the ticked hint can say which, rather
+                // than repeat instructions the reader has already followed.
+                hint: launchHint,
+                done: finished || inFlight || awaitingResults,
             },
             {
                 key: 'results',
@@ -1924,8 +1957,17 @@ function deriveOnboardingChecklist(agents, running) {
 function renderOnboardingChecklist(agents) {
     const panel = document.getElementById('onboardingChecklist');
     if (!panel) return;
-    const state = deriveOnboardingChecklist(agents, readRunningBacktests());
-    const signature = `${state.visible}|${state.steps.map((s) => (s.done ? 1 : 0)).join('')}`;
+    const state = deriveOnboardingChecklist(agents, listRunningBacktests(), {
+        awaitingResults: onboardingAwaitingRunCount,
+    });
+    // The hints are part of the signature, not just the ticks. A run ending
+    // moves the launch step from "Running now" to "loading your results" with
+    // both steps' done-ness unchanged, so a ticks-only signature matched and
+    // returned -- leaving the panel claiming a finished run was still going.
+    const signature = [
+        state.visible,
+        ...state.steps.map((s) => `${s.done ? 1 : 0}${s.hint}`),
+    ].join('|');
     if (panel.dataset.onboardingSignature === signature) return;
     panel.dataset.onboardingSignature = signature;
     panel.hidden = !state.visible;
@@ -2433,6 +2475,10 @@ async function loadAgentsNow() {
     await alignStarterAgentNames(agents);
 
     allAgents = agents;
+    // Cleared BEFORE the render below, not after: this roster is the answer the
+    // flag was standing in for, so the paint it feeds must come from the roster
+    // rather than from the guess that covered the gap.
+    onboardingAwaitingRunCount = false;
     applyAgentFilters();
     populateBacktestAgentSelect();
     if (typeof window.renderPortfolio === 'function') {
@@ -2447,6 +2493,9 @@ async function loadAgentsNow() {
     }
   } catch (error) {
     console.warn('Failed to load agents:', error.message);
+    // The fetch concluded, badly. Holding the bridge open would keep the launch
+    // step ticked against a roster that will never arrive to confirm it.
+    onboardingAwaitingRunCount = false;
     if (isDemoMode()) {
       allAgents = visibleMockAgents();
       applyAgentFilters();
@@ -7752,6 +7801,7 @@ function ensureBacktestPolling() {
             }));
 
             let anyRunning = false;
+            let anyFinished = false;
             let finishedFocused = null;
 
             for (const { job, status, failed } of snapshots) {
@@ -7854,6 +7904,14 @@ function ensureBacktestPolling() {
                     // an entry a previous build left filed under its agent id.
                     if (liveId) clearAgentBacktestRunning(liveId);
                     if (job.key && job.key !== liveId) clearAgentBacktestRunning(job.key);
+                    anyFinished = true;
+                    // Armed here, between the registry clear above and the
+                    // roster refresh below, because that is exactly the window
+                    // in which neither of the checklist's two sources knows a
+                    // run happened. Only on success: a failed run leaves no
+                    // results to wait for, and un-ticking is then the honest
+                    // answer -- the user does need to run another one.
+                    if (status.success) onboardingAwaitingRunCount = true;
                     if (viewingLive || liveId === liveBacktestRunId) {
                         finishedFocused = {
                             status,
@@ -7874,6 +7932,16 @@ function ensureBacktestPolling() {
             // tab — that page is the landing page after launch.
             if (playgroundTab === 'agents' && currentPage === 'playground') {
                 refreshRunningAgentCards();
+                // Every completion, not only the focused one. A finished run
+                // changes run_count, which both the card's run-count line and
+                // the checklist read, and refreshRunningAgentCards() above has
+                // just re-rendered the page from the pre-run roster. Gated on
+                // the focused run, a background completion never reached this
+                // call at all -- its results stayed off the page, and the
+                // bridge flag armed above had nothing to clear it.
+                // loadAgents() coalesces concurrent callers, so the focused
+                // path below does not need its own.
+                if (anyFinished) loadAgents();
             }
 
             if (finishedFocused) {
@@ -7884,9 +7952,6 @@ function ensureBacktestPolling() {
                     liveBacktestProgress = null;
                 }
                 lastRenderedRunningKey = null;
-                if (playgroundTab === 'agents' && currentPage === 'playground') {
-                    loadAgents();
-                }
 
                 if (status.error) {
                     const source = getBacktestLaunchConfig(liveId || finishedId)?.dataSource;

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -15301,3 +15301,102 @@ table.sr-only {
         transition: none;
     }
 }
+
+/* --- First-loop onboarding checklist (My Agents) -------------------------
+   Rendered above the agent shelves and removed for good once the user has a
+   finished backtest, so it is deliberately quiet: an info-tinted card, not a
+   banner. It must not out-shout the agent cards it is pointing at. */
+.onboarding-checklist {
+    margin-bottom: 20px;
+    padding: 18px 20px;
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-left: 3px solid var(--info-color);
+    border-radius: 10px;
+}
+
+.onboarding-title {
+    margin: 0 0 4px;
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.onboarding-lede {
+    margin: 0 0 14px;
+    font-size: 13px;
+    color: var(--text-secondary);
+}
+
+.onboarding-steps {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.onboarding-step {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+}
+
+/* The tick is a bordered dot that fills in when done. Shape as well as colour
+   carries the state, so the two rows are still distinguishable without hue --
+   the done row is a filled disc with a check, the open row an empty ring. */
+.onboarding-step-mark {
+    flex-shrink: 0;
+    width: 18px;
+    height: 18px;
+    margin-top: 2px;
+    border: 2px solid var(--text-muted);
+    border-radius: 50%;
+}
+
+.onboarding-step.is-done .onboarding-step-mark {
+    position: relative;
+    background: var(--success-color);
+    border-color: var(--success-color);
+}
+
+.onboarding-step.is-done .onboarding-step-mark::after {
+    content: '';
+    position: absolute;
+    top: 2px;
+    left: 5px;
+    width: 3px;
+    height: 7px;
+    border: solid var(--text-on-accent);
+    border-width: 0 2px 2px 0;
+    transform: rotate(45deg);
+}
+
+.onboarding-step-body {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.onboarding-step-label {
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--text-primary);
+}
+
+.onboarding-step.is-done .onboarding-step-label {
+    color: var(--text-secondary);
+    text-decoration: line-through;
+}
+
+.onboarding-step-hint {
+    font-size: 12px;
+    color: var(--text-muted);
+}
+
+@media (max-width: 640px) {
+    .onboarding-checklist {
+        padding: 14px 16px;
+    }
+}

--- a/docs/superpowers/notes/2026-09-10-user-facing-docs-backlog.md
+++ b/docs/superpowers/notes/2026-09-10-user-facing-docs-backlog.md
@@ -12,7 +12,8 @@ maintained inline with the code that changes them.
 Every entry below was re-verified against source on 2026-09-10, on `main` at
 `f5f803c3`. Where a suspected item turned out to be correct it is recorded under
 **Checked, not stale** rather than deleted, so the same false lead is not chased
-twice.
+twice. Entries added after that date carry their own verification anchor
+instead, because the code they describe is not on `main` yet - see entry 6.
 
 ---
 
@@ -110,6 +111,36 @@ does — every row is built from the curated roster in
 `dashboard/config/leaderboard.json`, and `api/routers/leaderboard.py` exposes no
 submission route.
 
+## 6. Incomplete: the first-loop checklist on My Agents
+
+**File:** `docs/source/lab/getting_started.rst:7-10` - the four numbered steps of
+"Run a backtest in the dashboard".
+
+**Shipped in #451** (anchors verified 2026-09-11 on `feat/user-feedback-batch-d`
+at `90d44aae`, not yet on `main`): a **Get your first result** panel -
+`#onboardingChecklist` (`app.html:989`), painted by `renderOnboardingChecklist()`
+(`app.js:1957`) - sitting directly above the agent grid, with two steps: **Run
+your first backtest** and **See your results**.
+
+Step 1 of the manual sends the reader to **My Agents** and step 2 to an agent's
+card. The panel is between them, and it is the first thing on that screen for
+precisely the reader this page is written for, so the walkthrough now skips past
+a visible element rather than naming it.
+
+**Must state plainly - it is derived state, not a to-do list.** Every tick comes
+from data the page already holds (`deriveOnboardingChecklist`, `app.js:1891`);
+nothing is persisted. There is no dismiss control and no way to bring the panel
+back: it shows only while the roster has loaded and **no** agent has a completed
+run, and it goes away for good on the first finished backtest. Copy inviting the
+reader to dismiss it, finish it later, or reopen it would describe a control that
+does not exist.
+
+**Careful:** do not write "create an agent" as one of its steps. Signup
+provisions starter agents (`api/auth.py` -> `provision_starter_agents`) and the
+client re-provisions them for guests, so a step keyed on agent existence would
+arrive pre-ticked; it was left out for that reason, and documenting it back in
+would teach a reader that the ticks mean nothing.
+
 ---
 
 ## Checked, not stale
@@ -138,7 +169,9 @@ submission route.
 
 One branch, one PR, `docs:` prefix. Items 2 and 3 likely want a new
 `docs/source/lab/credits.rst` added to the `lab/index.rst` toctree rather than
-being wedged into `accounts.rst`. Items 1, 4 and 5 are edits in place.
+being wedged into `accounts.rst`. Items 1, 4, 5 and 6 are edits in place - and
+4 and 6 touch the same four numbered steps in `getting_started.rst`, so write
+them together rather than as two passes over one list.
 
 Sphinx deps are optional and live in `requirements-sphinx.txt` — install those
 before building to check the toctree.


### PR DESCRIPTION
From the 2026-09-03 user feedback: a new user has no idea what to do first. Two steps above the agent shelves — run a backtest, see your results — and the panel removes itself for good once the loop closes.

**Nothing is stored.** Not localStorage, not a table. Every tick is a live read of data the page already holds, so it cannot disagree with reality and there is nothing to migrate. `app.js` already carries the cautionary instance: `defaultAgentProvisionGuardKey()`'s own comment records that user ids recycle on local SQLite and on Render's ephemeral disk, so a key like that can end up naming a different person.

Three things worth knowing before editing this:

- **"You have an agent" is deliberately not a step.** Signup provisions three starter cards (`api/auth.py:534`) and `ensureDefaultFoundationAgent()` re-provisions them client-side for guests, so `agents.length > 0` is true for every visitor who has ever loaded the page. A step keyed on it arrives pre-ticked for everyone.
- **The two steps cannot both read `run_count`.** The engine writes its `agent_runs` row only at completion, `final_equity` already populated — there is no in-flight row. So `run_count > 0` means "results exist" and would tick both steps in the same instant. The launch step also consults `readRunningBacktests()`, the only witness to the minutes a user spends waiting, which is what gives the checklist a middle state.
- **It reads `allAgents`, not `renderAgentCategories`' parameter.** That parameter is `getFilteredAgents()` — a search keystroke would otherwise resurrect a panel the user had already closed.

`renderAgentCategories` is the sole render site. Unlike the running card next to it, a tick moves on exactly two events and both change the set of running agents, which already triggers a full re-render.

19 tests. Full backend suite green: 4392 passed, 163 skipped.

Followup, not addressed here: `getting_started.rst` does not mention the checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNVXSsqqgUeBt7u7CXd4MV