### PR TITLE
chore(deps): bump pyarrow to 23.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ numba==0.61.2
 openai==1.101.0
 pandas==2.3.2
 pandas-ta==0.4.71b0
-pyarrow==21.0.0
+pyarrow==23.0.1
 platformdirs==4.3.7
 propcache==0.4.1
 pycparser==3.0


### PR DESCRIPTION
Closes Dependabot #86 (GHSA-rgxp-2hwp-jwgg / CVE-2026-25087). One line in `requirements.txt`: `pyarrow==21.0.0` → `23.0.1`.

**This was not an exploitable pin.** The advisory's own text says the trigger — `RecordBatchFileReader::PreBufferMetadata`, off by default — "is not exposed in language bindings (Python, Ruby, C GLib), so these bindings are not vulnerable." Arrow C++ ships inside the pyarrow wheel, which is why Dependabot flags it. Treat this as alert hygiene, not a live fix.

**Verification.** The repo's only pyarrow surface is pandas' parquet engine in `infrastructure/market_data/equity_metadata.py` (column projection + an `in` predicate pushdown). Read the same fixture under both versions: identical rows, columns, dtypes and SHA-256 digest. `pip install --dry-run -r requirements.txt` resolves clean on Python 3.13 with no conflicts.

**Gap worth knowing:** no test round-trips a real parquet file — `test_equity_metadata.py` feeds DataFrames straight in — so the suite stays green under any pyarrow version. The version evidence above is out-of-band, not something CI re-checks.

Split out of #451 deliberately: a two-major runtime-dep jump should be revertible on its own, not bundled into a UX change that auto-deploys prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WTxkF1MJZDcz7WYidPNeuv