### PR TITLE
docs: backtest first-run loop design and P1/P2 plan

### DIFF
--- a/docs/superpowers/notes/2026-09-10-user-facing-docs-backlog.md
+++ b/docs/superpowers/notes/2026-09-10-user-facing-docs-backlog.md
@@ -141,6 +141,48 @@ client re-provisions them for guests, so a step keyed on agent existence would
 arrive pre-ticked; it was left out for that reason, and documenting it back in
 would teach a reader that the ticks mean nothing.
 
+## 7. Missing: no cancel control is documented (pending, #273)
+
+**File:** `docs/source/lab/getting_started.rst:7-10` — the numbered backtest steps.
+
+**Landing with the P1 workstream** (spec:
+`docs/superpowers/specs/2026-09-11-backtest-first-run-loop-design.md`): a backtest
+becomes cancellable, with the control on **both** surfaces — the My Agents card and the
+Backtest tab — and a `cancelled` outcome that is deliberately *not* a failure.
+
+Until that ships the manual is accurate by omission; the moment it does, a walkthrough
+that describes starting a run and waiting for it is describing a one-way door that no
+longer exists. **Do not write this entry up before the PR merges** — the control's exact
+placement is still moving.
+
+## 8. Missing: decision provenance on a result (pending, #169)
+
+**Files:** `getting_started.rst:11-13` (reading your results) and anywhere the manual
+implies a finished backtest used the model you selected.
+
+**Landing with the same workstream:** a result will carry a decision-source verdict and
+an **"N of M steps were model-driven"** badge whenever coverage is below 100%.
+
+**Must state plainly:** a backtest can complete successfully having fallen back to
+rule-based decisions for some or all steps. Today the manual gives a reader no reason to
+suspect that, which is the user-facing half of #169. Note the two thresholds do
+different jobs and copy must not merge them — the badge fires below **100%** (*was
+anything degraded?*), while the leaderboard's H6 guard bars publication below **95%**
+(*may this be published under a model's name?*).
+
+## 9. Stale on arrival: AI Hedge Fund on free hosting (#308, option d)
+
+**Files:** nowhere — `grep -ri "hedge fund" docs/source/lab/` finds no operational note.
+
+Issue #308's acceptance criteria include a documentation exit: **state that AHF
+backtests are unsupported on free hosting**, and keep the "server is waking up" toast
+scoped to cold starts so it is not read as covering an OOM.
+
+This one is worth writing **whether or not** the plan upgrade happens, because it is the
+only exit that costs nothing. If the service is later moved to a paid plan, this entry
+becomes a note about which runtimes are heavy rather than a warning — reword, do not
+delete.
+
 ---
 
 ## Checked, not stale

--- a/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
+++ b/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
@@ -18,11 +18,11 @@ Update this table as work lands. `state` is one of:
 
 | PR | Issues | Branch | Worktree | Base | State | PR # |
 |---|---|---|---|---|---|---|
-| 1 | #129 | `fix/backtest-setup-panel-dead-band` | `../ATL-worktrees/p1-setup-panel` | `main` | not-started | — |
-| 2 | #169 | `fix/backtest-run-provenance` | `../ATL-worktrees/p1-provenance` | `main` | not-started | — |
+| 1 | #129 | `fix/backtest-setup-panel-dead-band` | `../ATL-worktrees/p1-setup-panel` | `main` | in-progress | — |
+| 2 | #169 | `fix/backtest-run-provenance` | `../ATL-worktrees/p1-provenance` | `main` | in-progress | — |
 | 3 | #273, #308 | `fix/backtest-cancel-and-memory` | `../ATL-worktrees/p1-cancel-memory` | PR 2 branch | not-started | — |
-| 4 | #390, #365 | `fix/leaderboard-curve-integrity` | `../ATL-worktrees/p2-curve-integrity` | `main` | not-started | — |
-| — | design docs | `docs/backtest-p1-p2-design` | `../ATL-worktrees/docs-design` | `main` | in-progress | — |
+| 4 | #390, #365 | `fix/leaderboard-curve-integrity` | `../ATL-worktrees/p2-curve-integrity` | `main` | in-progress | — |
+| — | design docs | `docs/backtest-p1-p2-design` | `../ATL-worktrees/docs-design` | `main` | pr-open | #456 |
 
 PR 3's worktree is created only after PR 2 has its first commit, since it branches off
 PR 2.
@@ -116,30 +116,59 @@ unbounded child output.
 
 ## PR 4 — #390 + #365, leaderboard curve integrity
 
+**Revised 2026-09-11** after reading the issue bodies; the original #365 mechanism in
+this plan was a guess the reporter's investigation contradicts. See the spec.
+
 **Files:** `domain/leaderboard/service.py`, `domain/leaderboard/baselines.py`,
-`dashboard/frontend/` chart layers, tests.
+`dashboard/frontend/js/leaderboard.js` and the app chart layer, tests.
 
 1. **#390.** At `service.py:1447-1449`, stop coercing `NULL` to `0`. Carry `None`
-   through, render a gap. Log ERROR at the wholesale boundary — a whole series coming
-   back empty is a contract break, and a per-point warning cannot report it.
-2. **Readers.** Both chart layers read this payload. Update both in the same PR;
-   a wire-format change with one reader updated is a half-shipped change.
-3. **#365.** At `service.py:1436-1439`, stop falling back to config capital. Derive the
-   seed from the curve's first point; if that is unavailable, **skip the entry and log**
-   rather than publish a row scaled by a number nobody verified.
-4. **Cache key.** Add seed capital to `_find_cached_run`'s key so runs at different
-   seeds stop colliding.
-5. **Comment the shim.** Scaling is only honest for scale-free strategies; position
-   sizing, lot sizes and per-trade costs make a `$10k` run a different run, not a
-   scaled one. Re-running at the published seed is the real fix.
-6. **Board re-run.** Rows on prod were written under the old key. Overlaps open issue
-   **#194** — link it, do not duplicate it. The re-run itself is an operator action, not
-   part of this PR; note it in the PR body.
+   through; render a gap. Log ERROR at the wholesale boundary — a series that comes back
+   entirely empty is a contract break and a per-point warning cannot report it. Build on
+   the existing `finiteNumber` helper in `js/leaderboard.js`; PR #387 hardened the
+   landing side already. Update **both** chart readers in this PR.
 
-**Done when:** no published curve can claim a seed it did not run at, and a missing
-observation renders as missing.
+2. **#365 — settle the facts before choosing the repair.** Query the committed seed DB
+   (`dashboard/storage/data/backtest.db`, read-only, never commit a mutation) and find
+   what the twelve `lb_*` runs actually hold for `initial_equity`: `100000`, `10000`, or
+   `NULL`. If it is `100000`, the existing `scale` already normalises those curves and
+   the practical defect is narrower than the issue implies. If `NULL`, they publish
+   unscaled at `scale = 1.0`. The answer decides the fix.
 
----
+3. **The real #365 defect is mixed capital across one board.** Baselines
+   (`auto_compute: true`) recompute at the config's `$10k`; LLM entries
+   (`auto_compute: false`) stay cached at the `$100k` they were written at, because
+   `_find_cached_run`'s key omits seed capital.
+
+4. **Widen the cache key — carefully.** Cover `initial_capital` *and* `strategy_prompt`
+   (the issue author notes both are missing and one change fixes both;
+   `strategy_prompt` arrives with PR #366 — include it only if that merged). **A miss
+   must be inert:** skip-and-log, never recompute, never auto-deploy. CLAUDE.md warns a
+   miss can trigger baseline recomputation and, with `LEADERBOARD_DAILY_AUTO_DEPLOY`
+   armed, billable LLM deploys from a public unauthenticated GET. If inertness cannot be
+   proven from the code, split the key change out of this PR.
+
+5. **Do not assume a re-run.** #194 would repopulate the LLM entries and is **blocked on
+   LLM API credits**. The board must be honest without it — publish fewer rows rather
+   than mixed-capital rows.
+
+6. **Tighten `service.py:1204-1206`** — a stored `0.0` is falsy and would collapse to
+   config capital. `NOT NULL` makes it unreachable today; the author asked for an
+   explicit `is None` check when the code is next touched, and this PR touches it.
+
+7. **Comment the shim.** Scaling is only honest for a scale-free strategy; position
+   sizing, lot sizes and per-trade costs make a `$10k` run a different run, not a scaled
+   one.
+
+8. **Tests:** a `NULL` point renders as a gap, never `0`, and never drags the shared
+   axis; a run with no honest seed is skipped-and-logged rather than published at
+   `scale = 1.0`; runs at different seeds do not collide; a legacy row does not cause a
+   board-wide cache miss; a miss cannot reach `deploy_model_run`.
+
+9. **Suite green:** `python -m pytest dashboard/backend/tests/ -q`.
+
+**Fallback:** if #365 turns out to require the re-run #194 is blocked on, ship #390
+alone and say so. A correct partial fix beats a confident wrong one.
 
 ## Shared conventions
 
@@ -163,3 +192,12 @@ Append newest last. One line per meaningful event.
 
 - `2026-09-11` — Workstream opened. Design spec written, four worktrees created,
   baseline `main` @ `193400d6`. Nothing implemented yet.
+- `2026-09-11` — Design spec + plan committed; PR #456 opened. Four worktrees created.
+- `2026-09-11` — PRs 1, 2 and 4 dispatched in parallel worktrees.
+- `2026-09-11` — Issue bodies read. **Two corrections landed in the spec.** #365's
+  mechanism is mixed capital across one board (baselines recompute at $10k while LLM
+  entries stay cached at $100k), not the NULL-fallback this plan first guessed; and #308
+  is a hosting-capacity failure whose real exits are an ops plan upgrade or a product
+  guard, so PR 3 ships the guard and must not claim to close it.
+- `2026-09-11` — **Open decision for the user:** #308 option (a) is a Render plan
+  upgrade, a recurring monthly cost. Not taken; flagged.

--- a/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
+++ b/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
@@ -19,8 +19,8 @@ Update this table as work lands. `state` is one of:
 | PR | Issues | Branch | Worktree | Base | State | PR # |
 |---|---|---|---|---|---|---|
 | 1 | #129 | `fix/backtest-setup-panel-dead-band` | `../ATL-worktrees/p1-setup-panel` | `main` | pr-open | #457 |
-| 2 | #169 | `fix/backtest-run-provenance` | `../ATL-worktrees/p1-provenance` | `main` | in-progress | — |
-| 3 | #273, #308 | `fix/backtest-cancel-and-memory` | `../ATL-worktrees/p1-cancel-memory` | PR 2 branch | not-started | — |
+| 2 | #169 | `fix/backtest-run-provenance` | `../ATL-worktrees/p1-provenance` | `main` | pushed `0288ff79` | — |
+| 3 | #273, #308 | `fix/backtest-cancel-and-memory` | `../ATL-worktrees/p1-cancel-memory` | `fix/backtest-run-provenance` @ `0288ff79` | in-progress | — |
 | 4 | #390, #365 | `fix/leaderboard-curve-integrity` | `../ATL-worktrees/p2-curve-integrity` | `main` | in-progress | — |
 | — | design docs | `docs/backtest-p1-p2-design` | `../ATL-worktrees/docs-design` | `main` | pr-open | #456 |
 
@@ -254,3 +254,9 @@ Append newest last. One line per meaningful event.
   That test now asserts the 1200px block, and a new guard
   (`test_frontend_setup_panel_breakpoint.py`) compares the two breakpoints and was
   confirmed to fail on the pre-fix CSS.
+- `2026-09-11` — PR 2 pushed `0288ff79` (4464 passed / 163 skipped). Adds
+  `domain/backtesting/provenance.py`, the `llm_decisions` column in **both** the SQLite
+  and Postgres schemas, and 485 lines of tests.
+- `2026-09-11` — PR 3 dispatched, stacked on `0288ff79`. Its refund step is struck (no
+  debit exists to reverse) and it is briefed **not** to claim it closes #308 — it ships
+  the product guard, not the capacity fix.

--- a/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
+++ b/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
@@ -344,3 +344,24 @@ Append newest last. One line per meaningful event.
   plan on `main` helps a resuming session find it.
 - `2026-09-11` — Noted the PR 3 rebase obligation: it branched at `0288ff79`, PR 2 has
   moved on, and both edit `backtests.py` and `app.js`.
+- `2026-09-11` — **PR #459 reworked and green** (4479 passed). Two deviations from the
+  brief, both approved:
+  1. **"Invalidate" is a ranking key, not a refusal.** My skip-and-log instruction would
+     have broken a pinned contract I did not know about:
+     `test_get_leaderboard_scales_to_display_capital_and_prefers_model_leader` seeds
+     $100k rows under a $1k config and asserts they are **served rescaled**, with
+     `display_capital` published. Scale-and-serve is designed behaviour. Criterion 1's
+     complaint is the word *silently*, not *reusing* — so the seed joins the key, an
+     exact-seed row wins, drift warns, and nothing recomputes. Inertness is now trivially
+     true rather than argued from a trace.
+  2. `_warn_on_seed_mismatch` narrowed to the derived-seed case so one condition cannot
+     emit two log lines. An alert channel has a credibility budget.
+- `2026-09-11` — **#390 is not the column its title names.** `equity` is `NOT NULL` in
+  both backends; the reachable half is `cash` and `positions_value`, which the committed
+  DB declares nullable because `CREATE TABLE IF NOT EXISTS` never tightened the existing
+  table. The schema **drift** was the risk, not the declared schema.
+- `2026-09-11` — Orchestration lesson, twice over: **where an issue's acceptance
+  criterion and an existing pinned test disagree, the test is evidence about what the
+  system promises; the criterion is one person's phrasing of a complaint.** Both briefs I
+  wrote from issue text (#365's refusal, #169's `decision_source` naming) would have
+  broken working contracts, and both times the agent reading the code caught it.

--- a/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
+++ b/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
@@ -459,3 +459,26 @@ Append newest last. One line per meaningful event.
   chart; #460 at 1420-1748 and 5869-8046) and `styles.css` (#457 at 3664/3801, #460 at
   6220+). Note `main` advanced during the session (`1ecebee7 Update README.md`), which is
   a reminder that others push here while this workstream is open.
+- `2026-09-11` — **#459 force-pushed into two separable commits**, invalidating the
+  earlier integration run. Re-verified from scratch:
+  - `0b61af90` **fix** — the defects, green on its own with the config untouched.
+  - `5ec37ff5` **chore** — the `$100,000` config value *and the one test that guards it*.
+  - **All four PRs re-merged onto current `main`: 4567 passed, 163 skipped, 0 failed.**
+  - **Reversibility verified empirically**, not promised: reverting `5ec37ff5` in the
+    combined tree drops the config back to `10000`, removes 45 lines across 2 files, and
+    the suite is **4566 passed, 0 failed** — exactly one test fewer, the guard that ships
+    with the decision. "One commit to revert" is now a measured claim.
+- `2026-09-11` — **`_run_id` seed suffix reverted, and the reason is the best catch of
+  the PR.** Pressing on "can this leave two rows for one window?" turned up **yes**:
+  `_find_cached_run` matches on `(mode, start, end, llm_model)`, not on `run_id`, so the
+  twelve committed rows are found either way — but their ids are *seed-free*, so a
+  suffixed id does not replace them, it **inserts alongside**. The first force-refresh
+  after the PR would have **doubled every entry on the board** and orphaned twelve equity
+  curves nothing prunes — at the aligned config, for zero benefit, because the seed had
+  not changed. `_run_id` is seed-free again with a comment saying why, pinned by
+  `test_a_refresh_replaces_the_existing_row_rather_than_adding_one`.
+- `2026-09-11` — `portfolio_value` needed a **client half** too: `formatLeaderboardNumber(null)`
+  returns `"0.00"`, so the standings table and detail panel would have printed **`$0.00`**
+  — the same absence-as-zero bug one column over. `home-page.js`'s
+  `homeFormatPortfolioValue` carried the identical inert `Number.isFinite` guard.
+- `2026-09-11` — PR #459 final: **50 test cases**, suite 4487 green standalone.

--- a/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
+++ b/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
@@ -287,3 +287,16 @@ Append newest last. One line per meaningful event.
 - `2026-09-11` — Also found in `app.js`: the existing null guard was **inert, not
   absent**. `Number(point?.equity)` + `Number.isFinite` reads as a null check, but
   `Number(null)` is `0` and `0` is finite.
+- `2026-09-11` — **#129 severity corrected.** Verified in `app.html`: the backtest launch
+  flow is `#runBacktestModal`, opened from My Agents, and the `Market Data` selector the
+  issue names lives inside it. The `.left-panel` this PR restores is a **read-only "Run
+  config" summary**. A user at 1100px can still run a backtest; they lose the summary of
+  what they ran. #129 is real but is **not** a precondition for the onboarding loop — my
+  original "reachable / door to the same room" framing was wrong, and the issue body
+  describes a pre-#450/#451 UI. Relay that to #129's triage.
+- `2026-09-11` — PR #457 updated (`8f9c7787`): guard restyled onto
+  `test_vnpy_simulation_frontend.py`'s `_media_block`/`_declarations` idiom, with one
+  deliberate deviation — the bare `.left-panel` lookup is line-anchored, because
+  `.left-panel` is a literal substring of `.playground-backtest-panel .left-panel` and an
+  unanchored search matches inside the compound selector. Issue's cited `styles.css:2183`
+  is `.chart-legend` on current main: stale, not a second hide site.

--- a/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
+++ b/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
@@ -211,6 +211,26 @@ differs from the other five only in that the discarded value is **money**.
 on a shared repo assigns work to others — both are the user's call. Raised, awaiting a
 decision.
 
+## Orchestration TODO — rebase PR 3 before it is marked ready
+
+PR 3 (`fix/backtest-cancel-and-memory`) was branched from PR 2 at `0288ff79`. PR 2's
+head has since advanced (`b0fe7e71`, and more while the N-of-M badge lands), so the two
+branches have diverged. **Both edit `api/routers/backtests.py` and `frontend/app.js`**,
+so this is a real conflict surface, not a formality.
+
+Once PR 2 stops moving:
+
+```bash
+cd ../ATL-worktrees/p1-cancel-memory
+git fetch origin fix/backtest-run-provenance
+git rebase origin/fix/backtest-run-provenance
+# resolve, re-run the suite, then force-with-lease
+git push --force-with-lease origin fix/backtest-cancel-and-memory
+```
+
+Do this **before** either PR is marked ready. Do not rebase PR 3 onto `main` — that
+would drop PR 2's provenance fields out from under it.
+
 ## Shared conventions
 
 - **Every PR:** full suite green (`pytest dashboard/backend/tests/ -v`) before opening.
@@ -322,3 +342,5 @@ Append newest last. One line per meaningful event.
   PRs unreviewed; merging to `main` auto-deploys prod. An instruction to the agent is not
   a gate GitHub shows or enforces. #456 (docs) left ready — harmless, and landing the
   plan on `main` helps a resuming session find it.
+- `2026-09-11` — Noted the PR 3 rebase obligation: it branched at `0288ff79`, PR 2 has
+  moved on, and both edit `backtests.py` and `app.js`.

--- a/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
+++ b/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
@@ -20,7 +20,7 @@ Update this table as work lands. `state` is one of:
 |---|---|---|---|---|---|---|
 | 1 | #129 | `fix/backtest-setup-panel-dead-band` | `../ATL-worktrees/p1-setup-panel` | `main` | pr-open | #457 |
 | 2 | #169 | `fix/backtest-run-provenance` | `../ATL-worktrees/p1-provenance` | `main` | pr-open (draft) | #458 |
-| 3 | #273, #308 | `fix/backtest-cancel-and-memory` | `../ATL-worktrees/p1-cancel-memory` | `fix/backtest-run-provenance` @ `0288ff79` | in-progress | — |
+| 3 | #273, #308 | `fix/backtest-cancel-and-memory` | `../ATL-worktrees/p1-cancel-memory` | `fix/backtest-run-provenance` | pr-open (draft), **rebase pending** | #460 |
 | 4 | #390, #365 | `fix/leaderboard-curve-integrity` | `../ATL-worktrees/p2-curve-integrity` | `main` | pr-open (draft) | #459 |
 | — | design docs | `docs/backtest-p1-p2-design` | `../ATL-worktrees/docs-design` | `main` | pr-open | #456 |
 
@@ -409,3 +409,26 @@ Append newest last. One line per meaningful event.
   the instruction to read the traceback for *who imported `provenance`* rather than for
   the modules the error names. As the agent put it: a docstring is the only thing still
   running when the interpreter isn't.
+- `2026-09-11` — **PR #460 open (draft), stacked on #458. All four PRs now exist.**
+  Cancel is SIGTERM inline in the route (so the request has taken effect before the
+  response is written) → `_CANCEL_GRACE_SECONDS = 5.0` on a watchdog → SIGKILL, with the
+  slot finalized at accept so the owner's quota frees immediately. Timeout is enforced by
+  `process.wait(timeout=…)` with two reader threads draining the pipes — which is what
+  makes `wait` safe instead of `communicate` — and re-raises `TimeoutExpired` carrying the
+  output the old path discarded. Retention is head 32k + tail 32k per stream,
+  line-granular, with redaction still over everything retained.
+  `MAX_AI_HEDGE_FUND_TRADING_DAYS` default **10**, range 0–60, `0` disables; over-long
+  422, disabled 503, junk falls back with a log line rather than raising at import.
+- `2026-09-11` — **A pre-existing bug that only cancel could reach.** The
+  late-worker-finalize branch writes the legacy `backtest_status` mirror
+  *unconditionally*, so it would stamp this run's outcome onto whichever run the mirror
+  described. Unreachable before, because without cancel two finalizes could never race —
+  **adding the feature made a dormant bug reachable.** Strongest argument yet for the
+  rule that a new terminal state gets its own branch rather than being folded into
+  `error`. The sibling race is resolved the same way: a cancel landing after a clean exit
+  still reports `cancelled`, because the alternative is calling the user's deliberate
+  action a crash.
+- `2026-09-11` — Rebase of #460 onto `3710c43b` is **pending**; `merge-base --is-ancestor`
+  confirms it is not yet based on PR 2's tip. A clean textual rebase is not evidence the
+  two features compose: verify a **cancelled** run emits no decision badge and no
+  fallback note.

--- a/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
+++ b/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
@@ -19,7 +19,7 @@ Update this table as work lands. `state` is one of:
 | PR | Issues | Branch | Worktree | Base | State | PR # |
 |---|---|---|---|---|---|---|
 | 1 | #129 | `fix/backtest-setup-panel-dead-band` | `../ATL-worktrees/p1-setup-panel` | `main` | pr-open | #457 |
-| 2 | #169 | `fix/backtest-run-provenance` | `../ATL-worktrees/p1-provenance` | `main` | pushed `0288ff79` | — |
+| 2 | #169 | `fix/backtest-run-provenance` | `../ATL-worktrees/p1-provenance` | `main` | pr-open (draft) | #458 |
 | 3 | #273, #308 | `fix/backtest-cancel-and-memory` | `../ATL-worktrees/p1-cancel-memory` | `fix/backtest-run-provenance` @ `0288ff79` | in-progress | — |
 | 4 | #390, #365 | `fix/leaderboard-curve-integrity` | `../ATL-worktrees/p2-curve-integrity` | `main` | pr-open (draft) | #459 |
 | — | design docs | `docs/backtest-p1-p2-design` | `../ATL-worktrees/docs-design` | `main` | pr-open | #456 |
@@ -300,3 +300,25 @@ Append newest last. One line per meaningful event.
   `.left-panel` is a literal substring of `.playground-backtest-panel .left-panel` and an
   unanchored search matches inside the compound selector. Issue's cited `styles.css:2183`
   is `.chart-legend` on current main: stale, not a second hide site.
+- `2026-09-11` — **PR #458 open (draft), and it corrected the spec's naming.**
+  `decision_source` is **already taken and means the requested source** — the
+  `backtest_decisions` column in both DB twins (`database.py:246`/`:607`,
+  `database_postgres.py:207`), a `RunMetadata` field (`backtests.py:289`/`:381`), and
+  `resolve_decision_source` — with the vocabulary literally
+  `RULE_BASED_DECISION_SOURCE = "rule_based"` / `LLM_DECISION_SOURCE = "llm"`
+  (`profiles.py:20-21`). Publishing the *observed* verdict under that name would have
+  made requested and actual byte-indistinguishable in the one case the PR exists for.
+  Resolution: `decision_provenance` for observed, `decision_source` retained for
+  requested, sharing the constants so the two compare with `==`. **Verified at source.**
+- `2026-09-11` — **A fourth verdict, `unknown`, is load-bearing.** `llm_decisions` ships
+  `DEFAULT 0`, which backfills every historical row, so `llm_decisions == 0` cannot
+  separate "the model drove nothing" from "nobody was counting". Classifying those as
+  `rule_based` would accuse the entire back catalogue of a silent fallback — a false
+  alarm broad enough to teach users to ignore the badge, which is worse than the bug.
+  The witness is `metadata.decision_steps`, written by the same path that writes the
+  column; absent means `unknown`, no note, and a byte-identical clean message.
+- `2026-09-11` — **All code PRs converted to draft with a `DO NOT MERGE` first line.**
+  CLAUDE.md records this repo has no branch protection and that collaborators merge open
+  PRs unreviewed; merging to `main` auto-deploys prod. An instruction to the agent is not
+  a gate GitHub shows or enforces. #456 (docs) left ready — harmless, and landing the
+  plan on `main` helps a resuming session find it.

--- a/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
+++ b/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
@@ -365,3 +365,25 @@ Append newest last. One line per meaningful event.
   system promises; the criterion is one person's phrasing of a complaint.** Both briefs I
   wrote from issue text (#365's refusal, #169's `decision_source` naming) would have
   broken working contracts, and both times the agent reading the code caught it.
+- `2026-09-11` — **PR #458 complete** (head `226d18ce`). The import-cycle guard was
+  tested by trying to break it, and the result changed what shipped:
+  - **Module-level import: unguardable, and does not need a guard.** Adding the import at
+    `portfolio_manager.py`'s top level takes the session down in `conftest` autouse
+    setup, before any test body — and moving the guard to `test_architecture_boundaries.py`
+    does not help, because conftest still dies. Nothing in this repo can report it. It
+    needs no report: it is an unmissable ImportError storm. What it needs is a
+    **recognisable signature**, because the traceback names neither file whose
+    relationship caused it. The docstring records the line to look for:
+    `cannot import name 'MIN_LLM_DECISION_COVERAGE' from partially initialized module`.
+  - **Function-local import: guarded, and this is the dangerous shape.** It collects
+    green and raises in production on the first fallback step — the least-exercised path
+    in the module. *A developer who hits the cycle head-on fixes it in thirty seconds;
+    one who defers the import to "avoid the cycle" ships it.*
+  - The guard is a **BFS over an AST import graph** from every `domain/leaderboard/*`
+    module, not a deny-list of three names, so the invariant widens by itself. It carries
+    a **non-vacuity assert** — the walk must reach `portfolio_manager` — so a broken
+    parser or renamed package fails loudly instead of passing as "no cycle found".
+- `2026-09-11` — Process note: the `DO NOT MERGE` line on #458 was wiped by a routine
+  `gh pr edit --body`, which replaces the body wholesale. No error, no warning, PR still
+  looked fine. **Draft status is the gate that actually held**, because it is a separate
+  flag no normal operation overwrites as a side effect. Verify both layers, not either.

--- a/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
+++ b/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
@@ -515,3 +515,34 @@ Append newest last. One line per meaningful event.
 - `2026-09-11` — #458 head is now `7b96ceba`; #460 remains based on `3710c43b`. No rebase
   needed: the only new commit deletes an unused import in a test file #460 does not
   touch, so it merges trivially and will already be in `main` by the time #460 retargets.
+- `2026-09-12` — **#459 force-pushed again** (`057303ec` fix + `cd9ef340` chore).
+  Integration re-verified for the third time: all four PRs merge cleanly onto current
+  `main`, **4567 passed / 163 skipped / 0 failed**; reverting `cd9ef340` gives **4566
+  passed / 0 failed**. Note `app.html` is now a *third* shared surface between branches
+  (with `app.js` and `styles.css`) and auto-merges clean.
+- `2026-09-12` — **The copy sweep justified the one-commit-revert requirement for a
+  reason neither of us had listed.** `app.html:1533` and `:1639` — Live Trading
+  Leaderboard copy — both stated *"Every season starts flat at $10,000"*. Per CLAUDE.md
+  the live board reuses the contest config byte-for-byte, so that number **is**
+  `initial_capital`. Had those lines landed in the *fix* commit, dropping the chore
+  commit would have left the board's copy reading **$100,000** over a board publishing
+  **$10,000** — the same contradiction the chore commit exists to remove, pointed the
+  other way. The chore commit now carries everything that depends on the value: config,
+  guard test, both copy lines, three stale comments. Verified by actually reverting it.
+- `2026-09-12` — **The landing's `$10,000` is not a duplicate and correctly stays.**
+  `storyline.ts` and `ChatSimulation.tsx` describe the *demo user's own backtest*, not the
+  board — a user backtest at $10,000 is normal (`DEFAULT_PORTFOLIO_EQUITY`). But a comment
+  there claimed the fabricated `+14.2%` was falsifiable because the board publishes the
+  same model's return *"from that same $10,000 base"*. That premise is now false; the
+  falsifiable claim was always the **return**, which is base-independent. Comment fixed —
+  the divergent bases must not be treated as the guard.
+- `2026-09-12` — Flagged, deliberately untouched: `|| 10000` last-resort chart-base
+  fallbacks in `js/leaderboard.js` (×4) and `landing/src/lib/leaderboard.ts` (×1). They
+  hardcode the old number but are code fallbacks rather than copy, never fire (the server
+  always sends `initial_equity`), and `test_home_chart_matches_the_leaderboards_percent_formula`
+  pins the two chains as equivalent — so changing one without the other breaks it.
+- `2026-09-12` — `docs/source/lab/`: **nothing stale from this change.** Every capital
+  reference there is per-agent Allocated Capital, not the board base.
+- `2026-09-12` — Tooling gotcha worth keeping: **`git revert --abort` after
+  `revert --no-commit` silently reset a branch to the stale remote tip.** Recovered from
+  reflog, nothing lost. It does not do what it looks like it does.

--- a/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
+++ b/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
@@ -21,7 +21,7 @@ Update this table as work lands. `state` is one of:
 | 1 | #129 | `fix/backtest-setup-panel-dead-band` | `../ATL-worktrees/p1-setup-panel` | `main` | pr-open | #457 |
 | 2 | #169 | `fix/backtest-run-provenance` | `../ATL-worktrees/p1-provenance` | `main` | pushed `0288ff79` | — |
 | 3 | #273, #308 | `fix/backtest-cancel-and-memory` | `../ATL-worktrees/p1-cancel-memory` | `fix/backtest-run-provenance` @ `0288ff79` | in-progress | — |
-| 4 | #390, #365 | `fix/leaderboard-curve-integrity` | `../ATL-worktrees/p2-curve-integrity` | `main` | in-progress | — |
+| 4 | #390, #365 | `fix/leaderboard-curve-integrity` | `../ATL-worktrees/p2-curve-integrity` | `main` | pr-open (draft) | #459 |
 | — | design docs | `docs/backtest-p1-p2-design` | `../ATL-worktrees/docs-design` | `main` | pr-open | #456 |
 
 PR 3's worktree is created only after PR 2 has its first commit, since it branches off
@@ -260,3 +260,30 @@ Append newest last. One line per meaningful event.
 - `2026-09-11` — PR 3 dispatched, stacked on `0288ff79`. Its refund step is struck (no
   debit exists to reverse) and it is briefed **not** to claim it closes #308 — it ships
   the product guard, not the capacity fix.
+- `2026-09-11` — **PR #459 open (draft).** Seed DB settled #365: all twelve `lb_*` rows
+  hold `initial_equity = 100000` (one as `100000.00000000003`), zero NULLs, first curve
+  point exactly `100000.0`, `metadata` NULL on all twelve. Config declares `10000`, so
+  `scale = 0.1` already normalises the board to a $10k display — **the mixed-capital
+  board is latent, not live.** It begins at the next `force=true` refresh, when
+  `auto_compute` baselines recompute at $10k while LLM entries stay at $100k. Even then
+  the *display* would not diverge; the damage is to **returns**, because a $10k re-run
+  trades in a coarser share quantum and is a different run rather than a rescaled one.
+  That is what makes it a ranking defect. Resolution: align config to `100000` in an
+  isolated, reversible commit.
+- `2026-09-11` — **Verified spend path, worth keeping.** A leaderboard cache miss is
+  **not** inert today. `maybe_schedule_daily_leaderboard_refresh` →
+  `_run_daily_refresh_background` → `refresh_daily_leaderboard(deploy_models=True)`
+  iterates *every* `llm_leaderboard_entries(config)` and calls `deploy_model_run` without
+  consulting `pending_entry_ids`; `deploy_model_run` short-circuits only on a
+  `_find_cached_run` hit. So widening the cache key without care converts a display bug
+  into **billable LLM runs reachable from a public unauthenticated GET** whenever
+  `LEADERBOARD_DAILY_AUTO_DEPLOY` is armed. PR #459 makes a seed mismatch inert at all
+  four spend/serve points and pins each with a test.
+- `2026-09-11` — Design note settled for #459: the defect is **mixed** capital, not
+  capital disagreeing with config. A board whose entries all share one seed is
+  internally consistent and merely mislabelled, so it is served with a warning; only
+  genuinely mixed seeds drop the outliers. The skip rule must never empty the board — a
+  one-line config typo would otherwise take down the acquisition hook.
+- `2026-09-11` — Also found in `app.js`: the existing null guard was **inert, not
+  absent**. `Number(point?.equity)` + `Number.isFinite` reads as a null check, but
+  `Number(null)` is `0` and `0` is finite.

--- a/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
+++ b/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
@@ -20,7 +20,7 @@ Update this table as work lands. `state` is one of:
 |---|---|---|---|---|---|---|
 | 1 | #129 | `fix/backtest-setup-panel-dead-band` | `../ATL-worktrees/p1-setup-panel` | `main` | pr-open | #457 |
 | 2 | #169 | `fix/backtest-run-provenance` | `../ATL-worktrees/p1-provenance` | `main` | pr-open (draft) | #458 |
-| 3 | #273, #308 | `fix/backtest-cancel-and-memory` | `../ATL-worktrees/p1-cancel-memory` | `fix/backtest-run-provenance` | pr-open (draft), **rebase pending** | #460 |
+| 3 | #273, #308 | `fix/backtest-cancel-and-memory` | `../ATL-worktrees/p1-cancel-memory` | `fix/backtest-run-provenance` @ `3710c43b` | pr-open (draft), rebased `010f0b47` | #460 |
 | 4 | #390, #365 | `fix/leaderboard-curve-integrity` | `../ATL-worktrees/p2-curve-integrity` | `main` | pr-open (draft) | #459 |
 | — | design docs | `docs/backtest-p1-p2-design` | `../ATL-worktrees/docs-design` | `main` | pr-open | #456 |
 
@@ -432,3 +432,30 @@ Append newest last. One line per meaningful event.
   confirms it is not yet based on PR 2's tip. A clean textual rebase is not evidence the
   two features compose: verify a **cancelled** run emits no decision badge and no
   fallback note.
+- `2026-09-11` — **#460 rebased onto `3710c43b` (`c66c5b0a` → `010f0b47`). No textual
+  conflicts — and that proved nothing, exactly as expected.** The real composition defect
+  was elsewhere: `/backtest/status` composed fine (the `cancelled` branch is a sibling
+  that returns early), but `app.js`'s **config panel still read `Status: Running`** after
+  a cancel, because the last `renderBacktestRunConfig` call came from the running branch.
+  The error path has the same gap — pre-existing — but a cancel is deliberate and
+  immediate, so the user is staring at the panel when it happens. Fixed by repainting
+  with `renderBacktestRunConfig(null, {...statusLabel: 'Cancelled'})`, where **`null` as
+  the run is what structurally forbids the coverage badge**, since #458 reads it from
+  `run.decision_badge`. Repaint must precede `showBacktestRunProgress` (the renderer hides
+  the panel outright with neither run nor launch config); pinned.
+- `2026-09-11` — **The AHF bound is a wall-clock measurement and a memory hunch, in that
+  order — and the PR body says so.** 10 trading days × `AI_HEDGE_FUND_TIMEOUT_SECONDS`
+  (300s) + 600s overhead = **3600s, exactly the existing 60-minute parent budget**; 11
+  days overruns it. So 10 is the largest window whose worst case fits a budget this repo
+  already committed to. But **the window controls how many sequential upstream children
+  run, not how big each one is**, so peak RSS — what the OOM killer acts on — is barely
+  moved. *It shortens exposure, not the peak.* This is the clearest evidence yet that
+  #308 needs the ops decision (option a or c), not a product guard.
+- `2026-09-11` — **INTEGRATION VERIFIED. All four PRs merge cleanly onto current `main`
+  and the full suite is green on the combined tree: 4559 passed, 163 skipped, 0 failed.**
+  Checked in a throwaway worktree, merging #457 → #460 (which carries #458) → #459 onto
+  `origin/main`. No file is touched by two independent branches in overlapping hunks:
+  `app.js` is the only real shared surface (#459 at 2787-2864, the marketplace compare
+  chart; #460 at 1420-1748 and 5869-8046) and `styles.css` (#457 at 3664/3801, #460 at
+  6220+). Note `main` advanced during the session (`1ecebee7 Update README.md`), which is
+  a reminder that others push here while this workstream is open.

--- a/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
+++ b/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
@@ -231,6 +231,32 @@ git push --force-with-lease origin fix/backtest-cancel-and-memory
 Do this **before** either PR is marked ready. Do not rebase PR 3 onto `main` — that
 would drop PR 2's provenance fields out from under it.
 
+## CI coverage — read this before marking anything ready
+
+**#460 gets no CI at all while it is stacked.** `.github/workflows/ci.yml` triggers on
+`pull_request: branches: [main]`, and #460's base is `fix/backtest-run-provenance`. So
+Backend tests, CodeQL and the packaging/landing checks **never fire on it**. Its only
+green mark is Vercel. This is the price of stacking, and it is not visible from the PR
+page — the checks list simply looks short.
+
+Coverage for #460 therefore comes from two places, and both must be kept true:
+1. The local combined-tree run recorded above (4567 passed on all four merged onto
+   `main`).
+2. GitHub, automatically, the moment #458 merges and #460 is retargeted to `main`.
+
+**Do not mark #460 ready on the strength of a green checks list** — re-run the combined
+tree locally, or retarget it first and wait for CI.
+
+**Read CodeQL on the merge ref, and re-read it after any force-push.**
+`gh api "repos/.../code-scanning/alerts?ref=refs/pull/N/merge&state=open"`. The branch ref
+returns empty and looks clean. Both live alerts found this way were `note` severity:
+- #458 — `py/unused-import`, a genuinely unused `import json`. **Fixed** (`7b96ceba`).
+- #459 — `py/unused-global-variable` on `_HOME_JS`. **Stale, not real**: the alert predates
+  the force-push, and `_HOME_JS` is used at `:989`/`:995`, where
+  `homeFormatPortfolioValue` is extracted and tested. CodeQL shows `skipping` on #459
+  because it has not re-analysed the new head. An alert on a merge ref is authoritative
+  about the commit it ran on, which is not necessarily the commit you are looking at.
+
 ## Shared conventions
 
 - **Every PR:** full suite green (`pytest dashboard/backend/tests/ -v`) before opening.
@@ -482,3 +508,10 @@ Append newest last. One line per meaningful event.
   — the same absence-as-zero bug one column over. `home-page.js`'s
   `homeFormatPortfolioValue` carried the identical inert `Number.isFinite` guard.
 - `2026-09-11` — PR #459 final: **50 test cases**, suite 4487 green standalone.
+- `2026-09-11` — CI audit. #457, #458, #459 fully green on GitHub. **#460 has no CI by
+  construction** (workflows are `pull_request: branches: [main]`; its base is not main).
+  Merge-ref CodeQL surfaced two `note` alerts: #458's was real and is fixed
+  (`7b96ceba`), #459's was stale from before its force-push.
+- `2026-09-11` — #458 head is now `7b96ceba`; #460 remains based on `3710c43b`. No rebase
+  needed: the only new commit deletes an unused import in a test file #460 does not
+  touch, so it merges trivially and will already be in `main` by the time #460 retargets.

--- a/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
+++ b/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
@@ -223,7 +223,7 @@ Once PR 2 stops moving:
 ```bash
 cd ../ATL-worktrees/p1-cancel-memory
 git fetch origin fix/backtest-run-provenance
-git rebase origin/fix/backtest-run-provenance
+git rebase origin/fix/backtest-run-provenance   # PR 2 final head: 3710c43b
 # resolve, re-run the suite, then force-with-lease
 git push --force-with-lease origin fix/backtest-cancel-and-memory
 ```
@@ -387,3 +387,25 @@ Append newest last. One line per meaningful event.
   `gh pr edit --body`, which replaces the body wholesale. No error, no warning, PR still
   looked fine. **Draft status is the gate that actually held**, because it is a separate
   flag no normal operation overwrites as a side effect. Verify both layers, not either.
+- `2026-09-11` — PR #458 final head `3710c43b`. **The circular-import traceback blames
+  the edge you must not remove.** Measured, not reasoned:
+
+  ```
+  ImportError: cannot import name 'MIN_LLM_DECISION_COVERAGE' from
+  partially initialized module 'dashboard.backend.domain.leaderboard.service'
+  (most likely due to a circular import)
+  ```
+
+  The two modules named — `provenance` and `leaderboard/service` — are the edge that was
+  **always there and is correct**. The edge that actually broke it is the newly added
+  import, which appears as one unremarkable frame mid-traceback. The traceback *head* is
+  whichever route imported first; measured, that was
+  `app` → `api/router` → `external_backtest` → `external_run_service` → `portfolio_manager`,
+  so the reader opens in an API module unrelated to either package. **Someone bisecting
+  from the error text works on the one edge they must not remove** — which would delete
+  the single-owner property the shared constant exists to provide.
+
+  The docstring therefore carries the verbatim error, the measured traceback head, and
+  the instruction to read the traceback for *who imported `provenance`* rather than for
+  the modules the error names. As the agent put it: a docstring is the only thing still
+  running when the interpreter isn't.

--- a/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
+++ b/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
@@ -99,8 +99,12 @@ and on screen, and the coverage counter survives the subprocess boundary.
    `_slot_visible_to` (`:804`) — reuse, do not restate. Unknown id and another user's
    id both 404, per `_resolve_status_slot`'s documented reasoning. Terminate, grace
    period, then kill.
-5. **Refund.** A cancelled LLM run that made no billed call returns its credit, on the
-   `llm_calls`-as-witness rule in `domain/entitlements/credits.py`.
+5. **Refund — DO NOT BUILD. There is nothing to refund.** Credit metering is currently
+   **unwired from the production path**; see "Credit metering is disconnected" below.
+   `POST /backtest/run` debits nothing, so a cancel has no charge to reverse. Do not
+   invent a refund, and do **not** re-wire metering inside this PR — re-arming a spend
+   control is a user-visible behaviour change that needs its own decision, not a rider
+   on a cancel button.
 6. **Status.** `/backtest/status` gains the `cancelled` branch.
 7. **AHF pre-flight.** Refuse an over-bound window for the AHF runtime with a usable
    message. Bound is an env var, defensively parsed with a safe default and a log line —
@@ -170,6 +174,43 @@ this plan was a guess the reporter's investigation contradicts. See the spec.
 **Fallback:** if #365 turns out to require the re-run #194 is blocked on, ship #390
 alone and say so. A correct partial fix beats a confident wrong one.
 
+## Out-of-scope finding: credit metering is disconnected
+
+**Verified 2026-09-11 on `main` @ `193400d6`. Not one of the six issues; recorded here
+because PR 3 was planned against behaviour that does not exist.**
+
+`domain/entitlements/credits.py` implements the LLM-run metering policy and is fully
+unit-tested. **Nothing in production calls it.** The only non-test import of
+`domain/entitlements` in the entire backend is `api/routers/admin_users.py:179`, which
+uses it solely to report `credits_metering_enabled` in admin stats.
+
+- `authorize_llm_run` — called only by `tests/test_credit_metering.py`
+- `refund_llm_run` — called only by `tests/test_credit_metering.py`
+
+So no credit is ever debited for a dashboard LLM backtest, and setting
+`CREDITS_METERING_ENABLED=1` changes nothing but an admin boolean.
+
+**It was wired, and a later commit removed it.** `git log -S` isolates the change:
+
+- `c8bdbcd6` *feat(admin): meter credits against LLM backtests* — added the wiring.
+- `3eebb7da` *feat: add secure llm worker handoff* (2026-08-24) — **removed it.** The
+  diff against `api/routers/backtests.py` deletes the `entitlements` import, the
+  `credits.authorize_llm_run(owner_user_id)` debit at accept, and both
+  `credits.refund_llm_run(...)` calls. All deletions; nothing replaced them.
+
+The suite stayed green because the tests exercise the policy module directly and never
+the route. CLAUDE.md still documents this metering as live and load-bearing — including
+the ordering subtlety about the debit landing *after* the concurrency check — so the
+documentation now describes a control that is switched off.
+
+This is the workstream's own defect class in its purest form: a correct, tested policy
+disconnected at the boundary, with everything around it still asserting it works. It
+differs from the other five only in that the discarded value is **money**.
+
+**Not actioned.** Re-arming a spend control changes behaviour for real users, and filing
+on a shared repo assigns work to others — both are the user's call. Raised, awaiting a
+decision.
+
 ## Shared conventions
 
 - **Every PR:** full suite green (`pytest dashboard/backend/tests/ -v`) before opening.
@@ -201,3 +242,8 @@ Append newest last. One line per meaningful event.
   guard, so PR 3 ships the guard and must not claim to close it.
 - `2026-09-11` — **Open decision for the user:** #308 option (a) is a Render plan
   upgrade, a recurring monthly cost. Not taken; flagged.
+- `2026-09-11` — **Out-of-scope finding, verified:** credit metering is unwired from
+  prod. `3eebb7da` (2026-08-24) deleted the debit and both refunds from
+  `api/routers/backtests.py`; the policy module and its tests survived intact, so CI
+  never noticed. PR 3's planned refund step is therefore unbuildable and has been struck.
+  Awaiting the user's decision on whether to re-arm and whether to file an issue.

--- a/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
+++ b/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
@@ -1,0 +1,165 @@
+# Backtest P1 + P2 — implementation plan and live progress log
+
+**Design:** `docs/superpowers/specs/2026-09-11-backtest-first-run-loop-design.md`
+**Baseline:** `main` @ `193400d6`
+**Standing instruction:** do **not** merge any PR in this workstream unless one branch
+genuinely blocks another. The user is AFK; leave the merge decision to them.
+
+> **Resuming after a session loss.** This file is the handoff. Read the **Status
+> board** below, `git worktree list`, and `gh pr list --author @me`, in that order.
+> Everything needed to continue is in git; nothing lives only in an agent's context.
+
+---
+
+## Status board
+
+Update this table as work lands. `state` is one of:
+`not-started` → `in-progress` → `pushed` → `pr-open` → `review-clean` → `blocked`.
+
+| PR | Issues | Branch | Worktree | Base | State | PR # |
+|---|---|---|---|---|---|---|
+| 1 | #129 | `fix/backtest-setup-panel-dead-band` | `../ATL-worktrees/p1-setup-panel` | `main` | not-started | — |
+| 2 | #169 | `fix/backtest-run-provenance` | `../ATL-worktrees/p1-provenance` | `main` | not-started | — |
+| 3 | #273, #308 | `fix/backtest-cancel-and-memory` | `../ATL-worktrees/p1-cancel-memory` | PR 2 branch | not-started | — |
+| 4 | #390, #365 | `fix/leaderboard-curve-integrity` | `../ATL-worktrees/p2-curve-integrity` | `main` | not-started | — |
+| — | design docs | `docs/backtest-p1-p2-design` | `../ATL-worktrees/docs-design` | `main` | in-progress | — |
+
+PR 3's worktree is created only after PR 2 has its first commit, since it branches off
+PR 2.
+
+---
+
+## PR 1 — #129, setup panel dead band
+
+**Files:** `dashboard/frontend/styles.css`, plus a source-shape test.
+
+1. Read `styles.css:3652-3700` (the `1440`/`1200` blocks) and `:3755-3810` (the `900`
+   block). Confirm the hide at `:3663` and the re-show at `:3804` before editing.
+2. Move `.playground-backtest-panel .left-panel { display: flex; … }` out of the
+   `max-width: 900px` block and into the `max-width: 1200px` block, immediately after
+   the `.left-panel { display: none }` rule it corrects.
+3. Check no other rule in the `901–1200` band re-hides it (`grep -n "left-panel"`).
+4. Add a guard to `dashboard/backend/tests/` in the style of
+   `test_frontend_live_trading_board.py`: parse `styles.css`, assert the re-show rule's
+   enclosing breakpoint equals the hide rule's. A test that merely finds both rules
+   passes today and would pass after a regression.
+
+**Done when:** the setup panel is present at 1280px, 1100px, 1000px and 800px by rule
+inspection, and the guard fails if the two breakpoints diverge again.
+
+---
+
+## PR 2 — #169, run provenance
+
+**Files:** `dashboard/backend/database.py`, `domain/backtesting/engine.py`,
+`api/routers/backtests.py`, `dashboard/frontend/app.js`, tests.
+
+1. **Schema.** Add `llm_decisions INTEGER DEFAULT 0` to the `agent_runs` CREATE at
+   `database.py:143` and to the self-migration list at `:355`. Mirror it in
+   `database_postgres.py` — `AGENT_RUNS_DATABASE_URL` runs the Postgres twin in prod,
+   and a column added to only one of them is a prod-only failure.
+2. **Write path.** Thread `llm_decisions` through `insert_run` (`database.py:633`) and
+   pass `manager.llm_decisions` from `engine.py`'s `db.insert_run` call (`:1650`),
+   beside the existing `llm_calls=llm_calls_total`.
+3. **Verdict.** Add one helper that maps
+   `(llm_model, llm_calls, llm_decisions, decision_steps)` → `llm` | `partial` |
+   `rule_based`. Reuse `MIN_LLM_DECISION_COVERAGE` from the leaderboard domain rather
+   than restating `0.95` — two owners of that threshold will disagree eventually.
+   Keep it in `domain/`, not in the router (`domain/` must not import `api/`).
+4. **Surface.** In `/backtest/status` (`backtests.py:2166`), the completed branch looks
+   up the run row and adds `decision_source` plus the counts. Additive only.
+5. **Frontend.** `app.js` renders the verdict on the result. A `rule_based` run must
+   not be able to show a bare success.
+6. **Tests.** The load-bearing case: `llm_calls == decision_steps` with
+   `llm_decisions == 0` classifies as `rule_based`. That is the case a check keyed on
+   `llm_calls` passes, which is the whole reason the two counters exist.
+
+**Done when:** a fallback run is distinguishable from a clean one in the API response
+and on screen, and the coverage counter survives the subprocess boundary.
+
+---
+
+## PR 3 — #273 + #308, cancel and memory
+
+**Base:** PR 2's branch. **Files:** `api/routers/backtests.py`, `domain/entitlements/`,
+`app.js`, tests.
+
+1. **`Popen`.** Replace `subprocess.run` at `backtests.py:1130`. Drain stdout/stderr on
+   a reader thread. Retain a bounded head+tail rather than the whole stream — the head
+   carries universe/decision-source/FX bootstrap, the tail carries the failure, and
+   `_redact_credentials` still applies to what is retained. Enforce the existing
+   timeout in the parent. This is #308's parent-side half.
+2. **Handle on the slot.** Store the `Popen` in the `_active_slots` entry
+   (`backtests.py:656`). It is process-local, which matches every other cap in this
+   module; note that in a comment so nobody reads it as cluster-wide.
+3. **`cancelled` state.** Extend `_finalize_slot` (`:748`) with a third outcome. Do not
+   route cancel through `error` — reporting a user's deliberate action as a failure is
+   the same class of lie PR 2 exists to fix.
+4. **Route.** `POST /backtest/cancel`, taking `live_run_id`. Authorise with
+   `_slot_visible_to` (`:804`) — reuse, do not restate. Unknown id and another user's
+   id both 404, per `_resolve_status_slot`'s documented reasoning. Terminate, grace
+   period, then kill.
+5. **Refund.** A cancelled LLM run that made no billed call returns its credit, on the
+   `llm_calls`-as-witness rule in `domain/entitlements/credits.py`.
+6. **Status.** `/backtest/status` gains the `cancelled` branch.
+7. **AHF pre-flight.** Refuse an over-bound window for the AHF runtime with a usable
+   message. Bound is an env var, defensively parsed with a safe default and a log line —
+   never a bare `int()` at module scope (this module has been killed at boot that way).
+8. **Frontend.** A cancel control while a run is in flight, and a `cancelled` result
+   state that is visibly not a failure.
+
+**Done when:** a running backtest can be stopped from the UI in seconds, the slot and
+credit are released, the outcome reads as cancelled, and the parent no longer buffers
+unbounded child output.
+
+---
+
+## PR 4 — #390 + #365, leaderboard curve integrity
+
+**Files:** `domain/leaderboard/service.py`, `domain/leaderboard/baselines.py`,
+`dashboard/frontend/` chart layers, tests.
+
+1. **#390.** At `service.py:1447-1449`, stop coercing `NULL` to `0`. Carry `None`
+   through, render a gap. Log ERROR at the wholesale boundary — a whole series coming
+   back empty is a contract break, and a per-point warning cannot report it.
+2. **Readers.** Both chart layers read this payload. Update both in the same PR;
+   a wire-format change with one reader updated is a half-shipped change.
+3. **#365.** At `service.py:1436-1439`, stop falling back to config capital. Derive the
+   seed from the curve's first point; if that is unavailable, **skip the entry and log**
+   rather than publish a row scaled by a number nobody verified.
+4. **Cache key.** Add seed capital to `_find_cached_run`'s key so runs at different
+   seeds stop colliding.
+5. **Comment the shim.** Scaling is only honest for scale-free strategies; position
+   sizing, lot sizes and per-trade costs make a `$10k` run a different run, not a
+   scaled one. Re-running at the published seed is the real fix.
+6. **Board re-run.** Rows on prod were written under the old key. Overlaps open issue
+   **#194** — link it, do not duplicate it. The re-run itself is an operator action, not
+   part of this PR; note it in the PR body.
+
+**Done when:** no published curve can claim a seed it did not run at, and a missing
+observation renders as missing.
+
+---
+
+## Shared conventions
+
+- **Every PR:** full suite green (`pytest dashboard/backend/tests/ -v`) before opening.
+- **PR titles:** short, `fix:` prefix, detail in the body. Body concise — reviewers read
+  the diff.
+- **Never push to a branch whose PR has merged.** Cut a new one.
+- **`llm_calls` vs `llm_decisions`** is load-bearing throughout. `llm_calls` bills and
+  ticks on truncated responses; `llm_decisions` counts steps the model actually drove.
+  Do not "simplify" one into the other.
+- **`domain/` must not import `api/`** — enforced by
+  `tests/test_architecture_boundaries.py`.
+- **Postgres twins.** `database.py` has a `database_postgres.py` sibling. Prod runs the
+  twin for `agent_runs`. Schema changes land in both.
+
+---
+
+## Progress log
+
+Append newest last. One line per meaningful event.
+
+- `2026-09-11` — Workstream opened. Design spec written, four worktrees created,
+  baseline `main` @ `193400d6`. Nothing implemented yet.

--- a/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
+++ b/docs/superpowers/plans/2026-09-11-backtest-p1-p2-plan.md
@@ -18,7 +18,7 @@ Update this table as work lands. `state` is one of:
 
 | PR | Issues | Branch | Worktree | Base | State | PR # |
 |---|---|---|---|---|---|---|
-| 1 | #129 | `fix/backtest-setup-panel-dead-band` | `../ATL-worktrees/p1-setup-panel` | `main` | in-progress | — |
+| 1 | #129 | `fix/backtest-setup-panel-dead-band` | `../ATL-worktrees/p1-setup-panel` | `main` | pr-open | #457 |
 | 2 | #169 | `fix/backtest-run-provenance` | `../ATL-worktrees/p1-provenance` | `main` | in-progress | — |
 | 3 | #273, #308 | `fix/backtest-cancel-and-memory` | `../ATL-worktrees/p1-cancel-memory` | PR 2 branch | not-started | — |
 | 4 | #390, #365 | `fix/leaderboard-curve-integrity` | `../ATL-worktrees/p2-curve-integrity` | `main` | in-progress | — |
@@ -247,3 +247,10 @@ Append newest last. One line per meaningful event.
   `api/routers/backtests.py`; the policy module and its tests survived intact, so CI
   never noticed. PR 3's planned refund step is therefore unbuildable and has been struck.
   Awaiting the user's decision on whether to re-arm and whether to file an issue.
+- `2026-09-11` — **PR #457 open (#129).** Re-show rule moved into the 1200px block.
+  Suite 4438 passed / 163 skipped. Notable: `test_vnpy_simulation_frontend.py`'s
+  docstring on `main` *documented the 901-1200px dead band as a known limitation its
+  assertions pass anyway* — the guard was written to tolerate the bug, not catch it.
+  That test now asserts the 1200px block, and a new guard
+  (`test_frontend_setup_panel_breakpoint.py`) compares the two breakpoints and was
+  confirmed to fail on the pre-fix CSS.

--- a/docs/superpowers/specs/2026-09-11-backtest-first-run-loop-design.md
+++ b/docs/superpowers/specs/2026-09-11-backtest-first-run-loop-design.md
@@ -64,6 +64,20 @@ restore has the same breakpoint as the hide. Verify the three bands (>1200, 901�
 
 This is CSS only. No JS, no backend, no contract.
 
+**Severity corrected 2026-09-11, after verifying against `app.html`.** This spec first
+called #129 "the door to the same room" — the control surface for launching a backtest.
+That is no longer true on `main` and the issue text describes an earlier UI. The launch
+flow now lives in `#runBacktestModal` (`app.html:~347`), opened from My Agents; the
+`Market Data` selector the reporter names is inside that modal, not in the panel. The
+current `<aside class="left-panel">` (`app.html:1208`) is a **read-only "Run config"
+summary** — agent, model, market, date range, capital, billing — displayed beside
+results, whose own empty state reads "No backtests yet. Run one from My Agents."
+
+So a user at 1100px **can still start a backtest**; what they lose is the summary of what
+they ran. The defect is real and worth fixing, but it does not block the onboarding loop,
+and #129 stays in P1 as cheap adjacent work rather than as a precondition. Whoever
+triages #129 should be told the body describes a pre-#450/#451 layout.
+
 ### 2. Honest — #169, a rule-based fallback reported as a clean result
 
 There are **two** independent layers here, and the issue reads as one.

--- a/docs/superpowers/specs/2026-09-11-backtest-first-run-loop-design.md
+++ b/docs/superpowers/specs/2026-09-11-backtest-first-run-loop-design.md
@@ -100,6 +100,12 @@ child.
 - Return it in `/backtest/status`'s completed payload, and render it on the result. A
   run that fell back must not be able to display the words "completed successfully"
   with nothing else attached.
+- **The issue's stated acceptance criterion is an "N of M steps were model-driven"
+  badge shown whenever coverage is below 100%**, so the payload carries the raw
+  numerator and denominator, not only the verdict. Note the asymmetry and keep it:
+  H6's bar is 95% (*may this publish?*) while the badge fires below 100% (*should the
+  user be told something degraded?*). Two different questions; do not collapse them
+  into one number.
 
 **Contract note.** This adds fields; it removes none. `/backtest/status` is polled by
 `app.js` and by the legacy surface — additive only.
@@ -130,28 +136,48 @@ concurrency slots held for the duration.
 - Refund the credit. `POST /backtest/run` debits at accept; a cancelled LLM run that
   made no billed call must return it, on the same `llm_calls`-as-witness rule
   `domain/entitlements/credits.py` already documents.
+- **Both frontend surfaces** carry the control and the `cancelled` state — the My Agents
+  card and the Backtest tab — per the issue's acceptance criteria. One surface updated
+  is a half-shipped change.
 
 ### 4. Survivable — #308, an AHF backtest OOMs the instance
 
-Two contributors, and the parent-side one is ours.
+**The reporter frames this as a hosting-capacity failure, not an application bug, and
+that framing is correct.** Their acceptance criteria offer three exits: (a) bump the
+Render web service to 1–2GB, (b) a product guard that refuses AHF on the free tier with
+a clear UI error, or (c) isolate AHF into its own service.
 
-`subprocess.run(capture_output=True)` accumulates the **entire** child stdout and
-stderr in parent memory before returning. The AHF runtime spawns one upstream
-subprocess per trading day and each is verbose. On a 512MB Render free-tier instance
-that buffer is a real share of the budget, and when the kernel picks a victim it is not
-required to pick the backtest — it can take the web process, which is why a single
-backtest downs the whole site.
+Note `render.yaml` already says `plan: standard`; per CLAUDE.md the live service runs on
+the **free tier** and that file is documentation, not the deploy mechanism. So (a) is not
+a code change at all — it is an operator action carrying a recurring monthly cost, and
+it is the user's call, not this workstream's.
 
-**Fix.**
-- The `Popen` change in #273 already replaces the unbounded buffer: drain the child's
-  output on a reader thread, cap what is retained (keep head and tail, drop the
-  middle — the head carries universe/decision-source/FX bootstrap, the tail carries the
-  failure), and write through to the log as it arrives.
-- Add a pre-flight refusal for the AHF runtime when the requested window would exceed a
-  configured bound, returning a clear message rather than accepting a request that
-  cannot survive. Bound is an env var with a safe default, parsed defensively — the
-  module already documents an unparseable value killing app boot as a bug it has had
-  once.
+**This is on the onboarding path, which is why it is P1.** AI Hedge Fund is a built-in
+agent on `/app?view=agents` — exactly where the first-loop checklist sends a new user. So
+a new user's *first* backtest can be the one that downs the site for everybody.
+
+**What this PR ships: (b), plus a real but secondary memory reduction.**
+
+- A pre-flight refusal for the AHF runtime when the requested window exceeds a
+  configured bound, with a clear message rather than an accepted request that cannot
+  survive. The bound is an env var with a safe default, defensively parsed — never a
+  bare `int()` at module scope, which has killed app boot in this module before.
+- The `Popen` change from #273 also replaces the parent's unbounded output buffer:
+  `subprocess.run(capture_output=True)` at `backtests.py:1130` accumulates the **entire**
+  child stdout/stderr in parent memory for the whole run. Drain on a reader thread and
+  retain a bounded head+tail — the head carries universe/decision-source/FX bootstrap,
+  the tail carries the failure. A second `capture_output=True` exists at
+  `adapter.py:240`, once per trading day; it is transient per call and freed, so the
+  outer site is the real accumulator.
+
+**This PR does not close #308.** The `AiHedgeFundSubprocessRunner`'s own footprint is the
+driver; the parent-side buffer is a contributor, not the cause. The PR contains the
+failure and keeps it off the onboarding path. Say exactly that in the PR body rather
+than claiming a fix.
+
+**The question worth putting to the user** is not "how do we fit AHF into 512MB" but
+"should the heaviest runtime be reachable from the onboarding path at all". Gating it off
+that path costs nothing; keeping it there costs a plan upgrade.
 
 **Ordering.** #273 and #308 are one change to one call site. They ship together.
 
@@ -182,41 +208,64 @@ nothing appears to move.
 **Fix.** Distinguish absent from zero. Carry `None` through rather than coercing, let
 the chart layer render a gap, and log at the wholesale boundary when an entire series
 comes back empty — *absent* and *broken* must not be byte-identical. Both chart layers
-read this payload, so the wire format change lands with both readers updated.
+read this payload, so the wire format change lands with both readers updated; build on
+the existing `finiteNumber` helper in `js/leaderboard.js` rather than adding a parallel
+one. PR #387 hardened the landing side already, and the reporter confirms the fix
+cannot happen client-side alone.
 
-### 6. #365 — a $100k curve published as a $10k one
+### 6. #365 — one board, two capital bases
 
-`service.py:1436-1439`:
+**Corrected 2026-09-11 against the issue body.** An earlier draft of this spec blamed
+the `or config[...]` NULL fallback below. That is a real latent defect, but it is not
+what #365 reports. The reporter's mechanism:
 
-```python
-stored_initial = float(
-    run.get("initial_equity") or config.get("initial_capital", INITIAL_CAPITAL)
-)
-scale = (display_capital / stored_initial) if stored_initial else 1.0
-```
+`dashboard/config/leaderboard.json` declares `initial_capital: 10000`, but **all twelve
+published contest-window curves in the committed seed DB were computed at $100,000**.
+The config changed *after* those runs were written (commits `0cfc8fb`, `ea1bf2b`,
+`1dd5816`, 2026-07-05/07-12).
 
-The scaling itself is correct and deliberate. The failure is the fallback: when a run's
-`initial_equity` is `NULL`, `stored_initial` becomes the *config* capital (`$10,000`,
-`dashboard/config/leaderboard.json:3`), so `scale` computes to exactly `1.0` and a curve
-actually seeded at `$100,000` is published **unscaled**, labelled `$10,000`.
+Because `_find_cached_run`'s key omits seed capital, the two halves of the board then
+diverge:
 
-`_find_cached_run` matches on `(mode, start_date, end_date, llm_model)` only — seed
-capital is not part of the key — so a stale row from a different seed is reused without
-anything noticing.
+- baselines (`auto_compute: true`) **recompute at $10k**
+- LLM entries (`auto_compute: false`) **stay cached at $100k**
+
+leaving one board ranking entries against two different capital bases. That is the
+headline defect — not a single mis-scaled curve.
+
+The `or`-fallback at `service.py:1436-1439` remains worth fixing in the same pass: when
+`initial_equity` is `NULL`, `stored_initial` becomes the *config* capital, `scale`
+computes to exactly `1.0`, and a `$100k` curve publishes unscaled under a `$10k` label.
+Whether that path is live depends on what the seed rows actually hold, which is an
+empirical question to settle against `dashboard/storage/data/backtest.db` before
+choosing the repair — read-only; never commit a mutation to that file.
 
 **Fix.**
-- Do not infer a seed from config. When `initial_equity` is missing, derive it from the
-  curve's own first point; if that is unavailable too, skip the entry and log — a
-  published row is a claim, and there is no honest number to make it with.
-- Include seed capital in the cache key so runs at different seeds stop colliding.
-- **Then re-run the board.** The rows on prod today were written under the old key.
-  This overlaps open issue **#194**; link it rather than duplicating it.
+- Widen the cache key. The issue author notes `strategy_prompt` is missing from it too,
+  and that covering **both** `initial_capital` and `strategy_prompt` fixes both problems
+  in one change. (`strategy_prompt` arrives with PR #366; include it only if that has
+  merged.)
+- **A cache miss must be inert.** Adding seed capital to the key makes every LLM entry
+  miss, and CLAUDE.md warns that a miss can trigger baseline recomputation — and, with
+  `LEADERBOARD_DAILY_AUTO_DEPLOY` armed, billable LLM deploys from a public
+  unauthenticated GET. A miss must skip-and-log, never recompute, never auto-deploy. If
+  that cannot be made provably true, the key change splits out of this PR.
+- Tighten `service.py:1204-1206`, where a stored `0.0` is falsy and would collapse to
+  config capital. The column is `NOT NULL` so the state cannot occur today; the author
+  asked for an explicit `is None` check whenever the code is next touched, and this PR
+  touches it.
+- Never infer a seed from config. Where no honest seed exists, skip the entry and log —
+  a published row is a claim.
 
-**Scale-invariance caveat.** Scaling is only honest for a strategy whose behaviour is
-scale-free. It is not, in general: position sizing, lot sizes and per-trade costs make a
-`$10k` run a genuinely different run from a `$100k` one, not a scaled one. Re-running at
-the published seed is the correct fix; scaling is the compatibility shim. Say so in the
-code.
+**The re-run cannot be assumed.** #194 would repopulate the LLM entries, and it is
+**blocked on LLM API credits**. So this PR must leave the board honest *without* a
+re-run: mixed-capital rows must not publish silently, even if that means publishing
+fewer rows.
+
+**Scale-invariance caveat.** Scaling is only honest for a scale-free strategy. Position
+sizing, lot sizes and per-trade costs make a `$10k` run a genuinely different run from a
+`$100k` one, not a scaled one. Re-running at the published seed is the real fix;
+scaling is the compatibility shim. Say so in the code.
 
 ---
 

--- a/docs/superpowers/specs/2026-09-11-backtest-first-run-loop-design.md
+++ b/docs/superpowers/specs/2026-09-11-backtest-first-run-loop-design.md
@@ -40,8 +40,45 @@ a boundary, and the discard is indistinguishable from the healthy case.
 | #273 | the child's liveness | `subprocess.run` returns no handle to act on |
 | #308 | the child's output, incrementally | `capture_output=True` buffers it all in parent RAM |
 
-`#129` is the odd one out: a plain CSS dead band. It is in P1 because it is the door to
-the same room.
+`#129` is the odd one out: a plain CSS dead band.
+
+### Refined 2026-09-11, during implementation: absence is not a value
+
+The table above says "computed, then discarded". Implementing #169 showed that is only
+one direction of a single underlying error, and the other direction bit twice in one PR.
+
+**The root error is conflating *absence of an observation* with *an observed value*.**
+
+- **Discarding** — a real observation is thrown away and reads as nothing. `llm_model`
+  carries `"rule-based"` and `/backtest/status` never looks.
+- **Manufacturing** — an absence is read as a real observation, which is worse, because
+  it fabricates a finding rather than losing one:
+  - `float(pt.get("equity") or 0)` — *no data at this timestamp* becomes a real `$0`, a
+    −100% curve. (#390)
+  - `run.get("initial_equity") or config[...]` — *seed unrecorded* becomes *seed equals
+    config*, and the scale silently computes to `1.0`. (#365)
+  - `llm_decisions == 0` on a pre-migration row is `DEFAULT 0` backfill, not "the model
+    drove nothing" — classifying it as a fallback would accuse the entire back
+    catalogue.
+  - `llm_calls == 0` from a usage-blind provider is "usage was unreadable", not "no call
+    was made". `_record_llm_usage` (`portfolio_manager.py:803-817`) deliberately does not
+    increment when `_extract_token_usage` raises, so a run the model drove every step of
+    can carry `llm_calls == 0`. A classifier shortcutting on that reports a perfect run
+    as a total fallback.
+
+**The rule.** A classifier must distinguish *"I observed that nothing happened"* from
+*"I have no observation"*, and may report a finding only from the first. Every counter
+feeding a verdict therefore needs a **witness** for whether it was recorded at all —
+`metadata.decision_steps` witnesses `llm_decisions`; `llm_decisions` in turn witnesses
+`llm_calls`. Where no witness exists the honest output is a fourth state (`unknown`),
+never the negative verdict.
+
+**Why this matters more for a badge than for a guard, and asymmetrically.** The H6 guard
+fails toward *refusing to publish*: a false positive costs one leaderboard entry. A badge
+fails toward *telling a user their run was fake*: a false positive costs the badge's
+credibility for every future run, after which the true ones are ignored too. A warning
+nobody believes is worse than no warning, because it consumes the attention a real one
+would need. That asymmetry is the whole argument for `unknown` existing.
 
 ---
 

--- a/docs/superpowers/specs/2026-09-11-backtest-first-run-loop-design.md
+++ b/docs/superpowers/specs/2026-09-11-backtest-first-run-loop-design.md
@@ -1,0 +1,271 @@
+# Backtest first-run loop — design
+
+**Date:** 2026-09-11
+**Status:** approved for implementation (P1 + P2)
+**Baseline:** `main` @ `193400d6`
+
+## Why now
+
+PR #451 shipped a two-step checklist on **My Agents** — *"Run your first backtest"*
+→ *"See your results"* — which makes the backtest the **declared primary onboarding
+task**. The checklist is derived state: it disappears on the first finished run and
+cannot be brought back. That is a deliberate design, and it is also a promise. A new
+user gets exactly one pass through this loop, and whatever the loop hands them is what
+they conclude the product is.
+
+Six open issues break one of that promise's four preconditions. They are grouped into
+two projects by what they protect.
+
+- **P1 — the loop holds.** The run must be *reachable*, *honest*, *escapable* and
+  *survivable*. (#129, #169, #273, #308)
+- **P2 — the payoff is fair.** What the first result gets compared against must be the
+  number it claims to be. (#390, #365)
+
+Out of scope, filed separately: #346 (A-share 除权除息) and #123
+(`RunManifest.news_sentiment_source`). Both are real, neither sits on the onboarding
+path — A-share needs iFinD credentials that prod does not carry, and `RunManifest` is
+the v2 agent surface, not the dashboard.
+
+## The recurring defect class
+
+Five of the six are the same shape, which the repo already has a name for:
+**fail-closed is not fail-visible**. A correct value is computed and then discarded at
+a boundary, and the discard is indistinguishable from the healthy case.
+
+| Issue | Value computed | Where it is discarded |
+|---|---|---|
+| #169 | `llm_model = "rule-based"`, `llm_decisions` | never reaches `/backtest/status`; `llm_decisions` never reaches `agent_runs` |
+| #390 | a stored `NULL` equity (= "no data") | `float(pt.get("equity") or 0)` → a real `$0` |
+| #365 | a run's true seed capital | `run.get("initial_equity") or config[...]` → scale silently `1.0` |
+| #273 | the child's liveness | `subprocess.run` returns no handle to act on |
+| #308 | the child's output, incrementally | `capture_output=True` buffers it all in parent RAM |
+
+`#129` is the odd one out: a plain CSS dead band. It is in P1 because it is the door to
+the same room.
+
+---
+
+## P1 — The loop holds
+
+### 1. Reachable — #129, setup panel invisible 901–1200px
+
+**Verified on `main`.** `styles.css:3658` opens `@media (max-width: 1200px)` and
+`:3663` sets `.left-panel { display: none }`. The rule that puts it back —
+`.playground-backtest-panel .left-panel { display: flex }` at `:3804` — lives inside
+`@media (max-width: 900px)`, which opens at `:3755`.
+
+So the panel is hidden from 1200px down, and restored only from 900px down. **Between
+901px and 1200px it is gone with no replacement** — a band that covers most laptops in
+a split window and every tablet in landscape.
+
+**Fix.** Move the re-show rule out of the 900px block and into the 1200px block, so the
+restore has the same breakpoint as the hide. Verify the three bands (>1200, 901–1200,
+≤900) each render the setup panel exactly once.
+
+This is CSS only. No JS, no backend, no contract.
+
+### 2. Honest — #169, a rule-based fallback reported as a clean result
+
+There are **two** independent layers here, and the issue reads as one.
+
+**Layer A — the run row is already honest; nothing reads it.**
+`engine.py:1261` defaults `llm_model = "rule-based"` and `:1427` promotes it to the real
+model on the first successful call. A pipeline run where every step fell back therefore
+*already* persists `llm_model = "rule-based"` to `agent_runs`. `/backtest/status`
+(`backtests.py:2166`) never looks: the completed branch returns a fixed
+`"Backtest completed successfully"` and a `runs_count`. The honest label exists in the
+database and dies at the HTTP boundary.
+
+**Layer B — `llm_decisions` is never persisted at all.**
+`llm_calls` is the *billing* counter: it ticks at `engine.py:1425` on any response
+carrying usage, including a truncated one that then falls back to rule-based.
+`llm_decisions` (`portfolio_manager.py:126`, written only at `:614` and `:782`) is the
+counter that means *the model actually drove this step*. `agent_runs` has an
+`llm_calls` column (`database.py:143`) and **no `llm_decisions` column**.
+
+Consequence: the worst case is invisible. A run whose every step made a billed call
+that failed to parse has `llm_calls = 30`, `llm_model = "claude-…"`,
+`llm_decisions = 0`. The row looks clean. In-process the H6 guard would refuse it;
+dashboard backtests are **subprocesses**, so the in-process counter never leaves the
+child.
+
+**Fix.**
+- Add `llm_decisions` to the `agent_runs` schema (`database.py:143`) and to the
+  self-migration list (`database.py:355`), thread it through `insert_run` and through
+  `engine.py`'s save call alongside `llm_calls_total`.
+- Compute a single `decision_source` verdict server-side — `llm`, `partial`, or
+  `rule_based` — from `(llm_model, llm_calls, llm_decisions, decision_steps)`, reusing
+  the H6 coverage threshold (`MIN_LLM_DECISION_COVERAGE = 0.95`) so the dashboard and
+  the leaderboard cannot disagree about what "the model drove it" means.
+- Return it in `/backtest/status`'s completed payload, and render it on the result. A
+  run that fell back must not be able to display the words "completed successfully"
+  with nothing else attached.
+
+**Contract note.** This adds fields; it removes none. `/backtest/status` is polled by
+`app.js` and by the legacy surface — additive only.
+
+### 3. Escapable — #273, no cancel on a blocking subprocess
+
+`backtests.py:1130` calls `subprocess.run(..., timeout=subprocess_timeout)`. That call
+hands back no handle, so between launch and return there is nothing to act on. The
+budget is `PIPELINE_SUBPROCESS_TIMEOUT_SECONDS = 3600` for the normal pipeline and up to
+`MAX_SUBPROCESS_TIMEOUT_SECONDS = 14400` for hosted runtimes.
+
+Before the checklist this was a bad experience. After it, a new user's *first and only*
+pass through the onboarding loop can be a one-hour trap with no exit and one of their
+concurrency slots held for the duration.
+
+**Fix.**
+- Replace `subprocess.run` with `Popen`, keep the handle on the slot dict in
+  `_active_slots`, and enforce the timeout in the parent.
+- Add `POST /backtest/cancel`, authorised by exactly the ownership rule
+  `_slot_visible_to` already implements — reuse it, do not restate it. An unknown or
+  someone else's `live_run_id` must answer 404 identically, for the same reason
+  `_resolve_status_slot` documents: a session id is an access grant in this codebase.
+- Terminate the child, then kill after a grace period.
+- **A cancelled run needs a third terminal state.** `_finalize_slot` currently knows
+  only *error* and *runs_count*, and routing a cancel through `error` would report the
+  user's own deliberate action as a failure — a different lie in the same place we are
+  fixing #169. Add `cancelled` and give `/backtest/status` a matching branch.
+- Refund the credit. `POST /backtest/run` debits at accept; a cancelled LLM run that
+  made no billed call must return it, on the same `llm_calls`-as-witness rule
+  `domain/entitlements/credits.py` already documents.
+
+### 4. Survivable — #308, an AHF backtest OOMs the instance
+
+Two contributors, and the parent-side one is ours.
+
+`subprocess.run(capture_output=True)` accumulates the **entire** child stdout and
+stderr in parent memory before returning. The AHF runtime spawns one upstream
+subprocess per trading day and each is verbose. On a 512MB Render free-tier instance
+that buffer is a real share of the budget, and when the kernel picks a victim it is not
+required to pick the backtest — it can take the web process, which is why a single
+backtest downs the whole site.
+
+**Fix.**
+- The `Popen` change in #273 already replaces the unbounded buffer: drain the child's
+  output on a reader thread, cap what is retained (keep head and tail, drop the
+  middle — the head carries universe/decision-source/FX bootstrap, the tail carries the
+  failure), and write through to the log as it arrives.
+- Add a pre-flight refusal for the AHF runtime when the requested window would exceed a
+  configured bound, returning a clear message rather than accepting a request that
+  cannot survive. Bound is an env var with a safe default, parsed defensively — the
+  module already documents an unparseable value killing app boot as a bug it has had
+  once.
+
+**Ordering.** #273 and #308 are one change to one call site. They ship together.
+
+---
+
+## P2 — The payoff is fair
+
+Both defects live in `get_leaderboard` (`domain/leaderboard/service.py`), three lines
+apart, and are the same `or`-swallows-`NULL` mistake. They ship together.
+
+### 5. #390 — a NULL equity published as a real $0
+
+`service.py:1447`:
+
+```python
+"equity": float(pt.get("equity") or 0) * scale,
+```
+
+A stored `NULL` means *no observation at this timestamp*. `or 0` converts it to a
+genuine zero-dollar portfolio. `chart_equity_curve` (`baselines.py:115`) then prepends
+an open point at `initial_equity`, so the series reads as a **−100% loss**.
+
+It does not stop at one row. `align_equity_curves` puts every entry on one shared axis,
+so a single −100% series sets the y-range and visually flattens every honest curve on
+the board. The first thing a new user compares their result against is a chart where
+nothing appears to move.
+
+**Fix.** Distinguish absent from zero. Carry `None` through rather than coercing, let
+the chart layer render a gap, and log at the wholesale boundary when an entire series
+comes back empty — *absent* and *broken* must not be byte-identical. Both chart layers
+read this payload, so the wire format change lands with both readers updated.
+
+### 6. #365 — a $100k curve published as a $10k one
+
+`service.py:1436-1439`:
+
+```python
+stored_initial = float(
+    run.get("initial_equity") or config.get("initial_capital", INITIAL_CAPITAL)
+)
+scale = (display_capital / stored_initial) if stored_initial else 1.0
+```
+
+The scaling itself is correct and deliberate. The failure is the fallback: when a run's
+`initial_equity` is `NULL`, `stored_initial` becomes the *config* capital (`$10,000`,
+`dashboard/config/leaderboard.json:3`), so `scale` computes to exactly `1.0` and a curve
+actually seeded at `$100,000` is published **unscaled**, labelled `$10,000`.
+
+`_find_cached_run` matches on `(mode, start_date, end_date, llm_model)` only — seed
+capital is not part of the key — so a stale row from a different seed is reused without
+anything noticing.
+
+**Fix.**
+- Do not infer a seed from config. When `initial_equity` is missing, derive it from the
+  curve's own first point; if that is unavailable too, skip the entry and log — a
+  published row is a claim, and there is no honest number to make it with.
+- Include seed capital in the cache key so runs at different seeds stop colliding.
+- **Then re-run the board.** The rows on prod today were written under the old key.
+  This overlaps open issue **#194**; link it rather than duplicating it.
+
+**Scale-invariance caveat.** Scaling is only honest for a strategy whose behaviour is
+scale-free. It is not, in general: position sizing, lot sizes and per-trade costs make a
+`$10k` run a genuinely different run from a `$100k` one, not a scaled one. Re-running at
+the published seed is the correct fix; scaling is the compatibility shim. Say so in the
+code.
+
+---
+
+## Delivery
+
+Four PRs. Two touch `backtests.py`'s slot machinery and status endpoint, so they stack
+rather than merge.
+
+| PR | Issues | Branch | Base |
+|---|---|---|---|
+| 1 | #129 | `fix/backtest-setup-panel-dead-band` | `main` |
+| 2 | #169 | `fix/backtest-run-provenance` | `main` |
+| 3 | #273, #308 | `fix/backtest-cancel-and-memory` | **PR 2's branch** |
+| 4 | #390, #365 | `fix/leaderboard-curve-integrity` | `main` |
+
+PRs 1, 2 and 4 are independent and are built in parallel worktrees under
+`../ATL-worktrees/`. PR 3 branches off PR 2 because both change the status contract and
+the slot dict; stacking keeps each reviewable without merging either. GitHub retargets
+PR 3 automatically when PR 2 merges.
+
+**Nothing merges** unless a branch genuinely blocks another — standing instruction for
+this workstream.
+
+## Testing
+
+- **#129** — source-shape guard, in the style of `test_frontend_live_trading_board.py`:
+  assert the re-show rule shares a breakpoint with the hide rule. A rendering test
+  cannot run here (no browser in WSL), so the guard is on the CSS structure.
+- **#169** — a run whose every step fell back must not report a clean success;
+  `llm_calls > 0` with `llm_decisions == 0` must classify as `rule_based`, which is the
+  case a coverage check keyed on `llm_calls` would pass.
+- **#273** — cancel terminates the child, releases the slot, refunds the credit, and
+  reports `cancelled` rather than `error`. A cancel against someone else's run and
+  against an unknown id both answer 404.
+- **#308** — the retained-output cap holds against a child that writes far more than it;
+  the AHF pre-flight refuses an over-bound window with a usable message.
+- **#390** — a `NULL` equity point renders as a gap, never as `0`, and never drags the
+  shared axis.
+- **#365** — a run with `NULL` `initial_equity` is skipped and logged rather than
+  published at `scale = 1.0`; two runs at different seeds do not collide in the cache.
+
+Full suite green before each PR opens: `pytest dashboard/backend/tests/ -v`.
+
+## Follow-ups to file, not fix here
+
+- **#346** — unadjusted A-share 除权除息 reads as a real loss. Needs iFinD credentials
+  prod does not carry.
+- **#123** — `RunManifest.news_sentiment_source` never assigned. v2 agent surface.
+- **User-facing docs** — `docs/source/lab/getting_started.rst` gains a cancel control
+  and a decision-source line on the result. Add to the batch backlog at
+  `docs/superpowers/notes/2026-09-10-user-facing-docs-backlog.md`; do **not** fix
+  piecemeal.


### PR DESCRIPTION
Design + plan for the six backtest issues gating the onboarding loop that PR #451 made the primary first-run task.

**P1 — the loop holds:** #129 (reachable), #169 (honest), #273 (escapable), #308 (survivable).
**P2 — the payoff is fair:** #390, #365.

Five of the six are one defect class the repo already names — *fail-closed is not fail-visible*: a correct value computed, then discarded at a boundary. The table in the spec lists each.

Ships as four PRs; PR 3 (#273+#308) stacks on PR 2 (#169) because both change the `/backtest/status` contract and the slot dict. Out of scope and filed separately: #346, #123.

The plan file doubles as the workstream's live progress log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PdsVmuCNd8iaC2Sff5B8jZ