### PR TITLE
fix: backtest setup panel 901-1200px dead band

### DIFF
--- a/dashboard/backend/tests/test_frontend_setup_panel_breakpoint.py
+++ b/dashboard/backend/tests/test_frontend_setup_panel_breakpoint.py
@@ -1,0 +1,98 @@
+"""Source guard for the backtest setup panel's responsive dead band.
+
+Issue #129: `.left-panel` (the backtest setup/config panel on /app's Playground
+tab) was hidden at `@media (max-width: 1200px)`, but the rule that restores it
+-- `.playground-backtest-panel .left-panel { display: flex; }`, which wins on
+specificity -- lived in the separate `@media (max-width: 900px)` block. Since
+the two breakpoints differ, a viewport between 901px and 1200px matched only
+the hide rule: the panel disappeared with no replacement across most laptops
+in a split window and every tablet in landscape. That panel is where a user
+configures and launches a backtest (the primary onboarding task as of PR
+#451), so the dead band made the product's main task unreachable there.
+
+/app has no build step and no CSS test toolchain, so this asserts against the
+shipped styles.css as text -- the convention set by test_ai_hedge_fund_frontend.py
+(see _frontend_source.py for the shared reader).
+"""
+
+import re
+
+from ._frontend_source import STYLES
+
+
+def _strip_css_comments(source: str) -> str:
+    """`/* ... */` removed. styles.css has no `//` comments and no URL literals
+    that would make a smarter, quote-aware stripper necessary here."""
+    return re.sub(r"/\*.*?\*/", "", source, flags=re.DOTALL)
+
+
+_SOURCE = _strip_css_comments(STYLES)
+
+
+def _media_max_width_blocks(source: str) -> list[tuple[int, str]]:
+    """Every top-level `@media (max-width: Npx) { ... }` block, brace-matched.
+
+    Returns (breakpoint, body) pairs. Brace-matched rather than sliced to a
+    fixed width: a rule's own `{ ... }` body is itself nested one level inside
+    the @media block, so a naive "up to the next '}'" slice would truncate at
+    the first rule instead of the block's real end.
+    """
+    blocks: list[tuple[int, str]] = []
+    for match in re.finditer(r"@media\s*\(max-width:\s*(\d+)px\)\s*\{", source):
+        breakpoint = int(match.group(1))
+        open_brace = match.end() - 1
+        depth = 0
+        index = open_brace
+        while True:
+            if source[index] == "{":
+                depth += 1
+            elif source[index] == "}":
+                depth -= 1
+                if depth == 0:
+                    break
+            index += 1
+        blocks.append((breakpoint, source[open_brace + 1 : index]))
+    return blocks
+
+
+def _breakpoint_of(selector_pattern: str, declaration: str) -> int:
+    """The max-width breakpoint of the one `@media` block holding a rule whose
+    selector matches `selector_pattern` and whose body contains `declaration`.
+
+    `selector_pattern` is anchored to the start of its line (only leading
+    whitespace before it): a bare `\\.left-panel` must not match inside the
+    longer `.playground-backtest-panel .left-panel`, which contains it as a
+    literal substring. Every selector in this file starts its own line, so the
+    anchor reliably tells the two apart.
+    """
+    rule_re = re.compile(
+        r"^[ \t]*" + selector_pattern + r"\s*\{[^}]*" + re.escape(declaration) + r"[^}]*\}",
+        re.MULTILINE,
+    )
+    hits = [bp for bp, body in _media_max_width_blocks(_SOURCE) if rule_re.search(body)]
+    assert hits, (
+        f"no @media (max-width: ...) block has a rule matching /{selector_pattern}/ "
+        f"with `{declaration}` -- has the selector or declaration changed?"
+    )
+    assert len(hits) == 1, (
+        f"rule matching /{selector_pattern}/ with `{declaration}` appears in more "
+        f"than one max-width breakpoint: {hits}"
+    )
+    return hits[0]
+
+
+def test_setup_panel_reshow_breakpoint_matches_its_hide_breakpoint():
+    """The re-show rule's breakpoint must equal the hide rule's.
+
+    A test that only asserted both rules exist would have passed before this
+    fix too -- that is exactly the regression this must catch, so it compares
+    the two breakpoints rather than just their presence.
+    """
+    hide_at = _breakpoint_of(r"\.left-panel", "display: none")
+    reshow_at = _breakpoint_of(r"\.playground-backtest-panel \.left-panel", "display: flex")
+    assert reshow_at == hide_at, (
+        f".left-panel is hidden at max-width:{hide_at}px but only restored "
+        f"(.playground-backtest-panel .left-panel) at max-width:{reshow_at}px -- "
+        "every viewport width between the two leaves the setup panel gone with "
+        "no replacement (issue #129)"
+    )

--- a/dashboard/backend/tests/test_frontend_setup_panel_breakpoint.py
+++ b/dashboard/backend/tests/test_frontend_setup_panel_breakpoint.py
@@ -12,11 +12,29 @@ configures and launches a backtest (the primary onboarding task as of PR
 
 /app has no build step and no CSS test toolchain, so this asserts against the
 shipped styles.css as text -- the convention set by test_ai_hedge_fund_frontend.py.
-The helpers below are adapted from test_vnpy_simulation_frontend.py, the
-closer precedent for asserting on CSS specifically: same `_media_block` brace
-counting and `_declarations`/`_has_declaration` shape, generalized to scan
-every breakpoint rather than one named up front, since the whole point here is
-to discover which breakpoint a rule lives in and compare it to another rule's.
+The helpers below started from test_vnpy_simulation_frontend.py, the closer
+precedent for asserting on CSS specifically, and differ in three ways that the
+dead-band question forces:
+
+1. They scan **every** `@media` block at a breakpoint, not the first. styles.css
+   has four `@media (max-width: 1200px)` blocks, five at 1100px and eight at
+   600px, so "the 1200px block" does not exist. A first-block-only scan reports
+   the re-show rule present while an identical-specificity `display: none` in a
+   *later* 1200px block silently wins the cascade and reinstates issue #129.
+2. They report a **list** of breakpoints rather than asserting a unique one, and
+   the test below compares coverage instead of equality (see its docstring).
+3. They run on comment-stripped CSS. This stylesheet's house style quotes rules
+   verbatim in comments (`/* Beat `.section-card h3 { font-size: 12px }` */` at
+   lines 9345, 10869, 11103, 11203), so scanning raw text lets a *comment*
+   register as a declaration -- and a `{` or `}` inside one also desynchronises
+   the brace counter in `_media_blocks`.
+
+Know what this still cannot prove. Resolution here is last-wins among
+*textually identical* selectors, where specificity is equal by construction.
+It does not model the cascade: a hide rule written at higher specificity
+(`.main-container.playground-backtest-panel .left-panel`), inside a `min-width`
+block, or with `!important` would defeat the re-show rule and pass this file.
+Only a real browser can settle layout; treat this as a wiring guard.
 """
 
 import re
@@ -28,103 +46,151 @@ _FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
 _STYLES = _FRONTEND / "styles.css"
 
 
-def _media_block(css: str, query: str) -> str:
-    """Return the body of the first ``@media`` block matching ``query``.
+def _strip_comments(css: str) -> str:
+    """Blank out `/* ... */` comments, preserving the file's line structure.
 
-    Brace-counted rather than regexed to the closing ``}``, since the block
-    contains nested rules.
+    Line count is preserved so that `line_anchored=True` below keeps meaning
+    what it says; the content is dropped so that a rule quoted inside a comment
+    -- this stylesheet does that habitually -- cannot register as a declaration,
+    and so that a brace inside one cannot desynchronise `_media_blocks`.
     """
-    start = re.search(
-        r"@media\s*\(\s*max-width:\s*%s\s*\)\s*\{" % re.escape(query), css
+    return re.sub(
+        r"/\*.*?\*/", lambda m: "\n" * m.group(0).count("\n"), css, flags=re.DOTALL
     )
-    assert start, f"no @media (max-width: {query}) block in styles.css"
-
-    depth, i = 1, start.end()
-    while i < len(css) and depth:
-        depth += {"{": 1, "}": -1}.get(css[i], 0)
-        i += 1
-    assert not depth, f"unbalanced braces in @media (max-width: {query})"
-    return css[start.end() : i - 1]
 
 
-def _declaration_block(css: str, selector: str, *, line_anchored: bool = False) -> str | None:
-    """The declaration body for ``selector`` in ``css``, or None if absent.
+def _media_blocks(css: str, query: str) -> list[str]:
+    """The bodies of *every* `@media` block matching `query`, in source order.
 
-    Adapted from test_vnpy_simulation_frontend.py's ``_declarations``: this
-    returns None instead of asserting, because ``_breakpoint_declaring`` below
-    calls it once per candidate breakpoint and most breakpoints legitimately
-    do not contain the rule at all -- an assertion there would abort the scan
-    instead of just ruling that breakpoint out.
+    Brace-counted rather than regexed to the closing `}`, since each block
+    contains nested rules. Returning all of them (not the first) is the point:
+    styles.css repeats most breakpoints several times, and only the last
+    declaration among them survives the cascade.
+    """
+    bodies = []
+    for start in re.finditer(
+        r"@media\s*\(\s*max-width:\s*%s\s*\)\s*\{" % re.escape(query), css
+    ):
+        depth, i = 1, start.end()
+        while i < len(css) and depth:
+            depth += {"{": 1, "}": -1}.get(css[i], 0)
+            i += 1
+        assert not depth, f"unbalanced braces in @media (max-width: {query})"
+        bodies.append(css[start.end() : i - 1])
+    return bodies
 
-    ``line_anchored=True`` requires the selector to start its own line (only
-    leading whitespace before it). Needed for the bare ``.left-panel`` lookup:
-    it is a literal substring of the longer
-    ``.playground-backtest-panel .left-panel``, so an unanchored search can
-    match inside that compound selector instead of the standalone rule. Every
-    selector in this file starts its own line, so the anchor reliably tells
-    the two apart.
+
+def _declaration_blocks(css: str, selector: str, *, line_anchored: bool = False) -> list[str]:
+    """Every declaration body for `selector` in `css`, in source order.
+
+    `line_anchored=True` requires the selector to start its own line (only
+    leading whitespace before it). Needed for the bare `.left-panel` lookup: it
+    is a literal substring of the longer `.playground-backtest-panel
+    .left-panel`, so an unanchored search can match inside that compound
+    selector instead of the standalone rule. Every selector in this file starts
+    its own line, so the anchor reliably tells the two apart. The anchor also
+    excludes `.left-panel,` at the head of a grouped base rule (styles.css:918),
+    which is intended -- this guard is about the media-query overrides.
     """
     pattern = re.sub(r"\s+", r"\\s+", re.escape(selector).replace(r"\ ", " "))
     if line_anchored:
-        match = re.search(r"^[ \t]*" + pattern + r"\s*\{([^}]*)\}", css, re.MULTILINE)
+        rx = re.compile(r"^[ \t]*" + pattern + r"\s*\{([^}]*)\}", re.MULTILINE)
     else:
-        match = re.search(pattern + r"\s*\{([^}]*)\}", css)
-    return match.group(1) if match else None
+        rx = re.compile(pattern + r"\s*\{([^}]*)\}")
+    return [m.group(1) for m in rx.finditer(css)]
 
 
-def _has_declaration(css: str, selector: str, prop: str, value: str, **kwargs) -> bool:
-    block = _declaration_block(css, selector, **kwargs)
-    if block is None:
-        return False
-    return bool(re.search(rf"{re.escape(prop)}\s*:\s*{re.escape(value)}\s*;", block))
+def _effective_value(css: str, selector: str, prop: str, **kwargs) -> str | None:
+    """What `prop` resolves to for `selector` in `css`, or None if never set.
+
+    Among rules whose selector text is identical, specificity is identical too,
+    so the last declaration in source order is the one that wins. That is the
+    whole reason `_media_blocks` must return every block rather than the first.
+    """
+    value = None
+    for block in _declaration_blocks(css, selector, **kwargs):
+        for match in re.finditer(rf"{re.escape(prop)}\s*:\s*([^;]+);", block):
+            value = match.group(1).strip()
+    return value
 
 
 def _all_max_width_breakpoints(css: str) -> list[int]:
     return sorted({int(n) for n in re.findall(r"@media\s*\(\s*max-width:\s*(\d+)px\s*\)", css)})
 
 
-def _breakpoint_declaring(css: str, selector: str, prop: str, value: str, **kwargs) -> int:
-    """The one max-width breakpoint whose (first) block declares
-    ``selector { prop: value }``.
+def _breakpoints_declaring(css: str, selector: str, prop: str, value: str, **kwargs) -> list[int]:
+    """Max-width breakpoints at which `selector { prop: value }` is in effect.
 
-    Scans every distinct breakpoint present in the file rather than checking
-    one named up front (as ``test_mobile_backtest_exposes_setup_controls``
-    does): the point of this guard is to catch the rule moving to the *wrong*
-    breakpoint, not to re-assert a hardcoded one it might move to along with
-    the rule -- which would defeat the point of comparing two breakpoints.
+    Scans every distinct breakpoint present in the file rather than checking one
+    named up front (as `test_narrow_viewport_backtest_exposes_setup_controls` does): the
+    point of this guard is to catch the rule moving to the *wrong* breakpoint,
+    not to re-assert a hardcoded one it might move to along with the rule --
+    which would defeat the point of comparing two breakpoints.
+
+    Returns a list rather than asserting a unique hit. Declaring the same rule
+    at two breakpoints is redundant but harmless, and failing on it would make
+    this guard reject correct stylesheets.
     """
-    hits = [
+    return [
         bp
         for bp in _all_max_width_breakpoints(css)
-        if _has_declaration(_media_block(css, f"{bp}px"), selector, prop, value, **kwargs)
+        if _effective_value("\n".join(_media_blocks(css, f"{bp}px")), selector, prop, **kwargs)
+        == value
     ]
-    assert hits, f"no @media (max-width: ...) block declares {selector} {{ {prop}: {value} }}"
-    assert len(hits) == 1, (
-        f"{selector} {{ {prop}: {value} }} appears in more than one max-width "
-        f"breakpoint: {hits}"
-    )
-    return hits[0]
 
 
 @pytest.fixture(scope="module")
 def css() -> str:
-    return _STYLES.read_text(encoding="utf-8")
+    return _strip_comments(_STYLES.read_text(encoding="utf-8"))
 
 
-def test_setup_panel_reshow_breakpoint_matches_its_hide_breakpoint(css):
-    """The re-show rule's breakpoint must equal the hide rule's.
+def test_setup_panel_reshow_covers_every_breakpoint_that_hides_it(css):
+    """Every breakpoint that hides `.left-panel` must be covered by a re-show.
 
-    A test that only asserted both rules exist would have passed before this
-    fix too -- that is exactly the regression this must catch, so it compares
-    the two breakpoints rather than just their presence.
+    A test that only asserted both rules exist would have passed before this fix
+    too -- that is exactly the regression this must catch, so it compares the
+    two breakpoints rather than just their presence.
+
+    Coverage, not equality: `max-width: R` is active at every width where
+    `max-width: H` is, as long as R >= H, and the re-show selector
+    (`.playground-backtest-panel .left-panel`, specificity 0-2-0) outranks the
+    hide selector (`.left-panel`, 0-1-0) regardless of source order. Demanding
+    R == H would reject a correct stylesheet that re-showed the panel at a wider
+    breakpoint.
     """
-    hide_at = _breakpoint_declaring(css, ".left-panel", "display", "none", line_anchored=True)
-    reshow_at = _breakpoint_declaring(
+    hidden_at = _breakpoints_declaring(css, ".left-panel", "display", "none", line_anchored=True)
+    reshown_at = _breakpoints_declaring(
         css, ".playground-backtest-panel .left-panel", "display", "flex"
     )
-    assert reshow_at == hide_at, (
-        f".left-panel is hidden at max-width:{hide_at}px but only restored "
-        f"(.playground-backtest-panel .left-panel) at max-width:{reshow_at}px -- "
-        "every viewport width between the two leaves the setup panel gone with "
-        "no replacement (issue #129)"
+
+    if not hidden_at:
+        # No breakpoint hides the panel, so no dead band can exist. This is a
+        # legitimate end state, not a hole: once the hide and re-show rules sit
+        # at the same breakpoint the hide is dead code, and deleting both is
+        # strictly more correct than keeping them. Asserting the hide rule must
+        # exist would fail that cleanup -- the opposite of this file's purpose.
+        return
+
+    for hide_at in hidden_at:
+        assert [bp for bp in reshown_at if bp >= hide_at], (
+            f".left-panel is hidden at max-width:{hide_at}px but only restored "
+            f"(.playground-backtest-panel .left-panel) at {reshown_at or 'no breakpoint'} -- "
+            "every viewport width between the two leaves the setup panel gone with "
+            "no replacement (issue #129)"
+        )
+
+
+def test_breakpoint_scan_reads_every_block_not_just_the_first(css):
+    """Pins the helper contract whose absence was the original guard's bug.
+
+    styles.css repeats breakpoints, so a scan that stopped at the first matching
+    `@media` block would read a `display: none` added to a *later* block at the
+    same breakpoint as absent -- reporting the panel restored while the cascade
+    hides it. Asserting the repetition exists keeps that failure mode from
+    quietly becoming untestable if the helper regresses.
+    """
+    assert len(_media_blocks(css, "1200px")) > 1, (
+        "expected styles.css to declare @media (max-width: 1200px) more than once; "
+        "if that is no longer true, _media_blocks' scan-every-block contract still "
+        "must hold for the breakpoints that do repeat"
     )

--- a/dashboard/backend/tests/test_frontend_setup_panel_breakpoint.py
+++ b/dashboard/backend/tests/test_frontend_setup_panel_breakpoint.py
@@ -11,85 +11,117 @@ configures and launches a backtest (the primary onboarding task as of PR
 #451), so the dead band made the product's main task unreachable there.
 
 /app has no build step and no CSS test toolchain, so this asserts against the
-shipped styles.css as text -- the convention set by test_ai_hedge_fund_frontend.py
-(see _frontend_source.py for the shared reader).
+shipped styles.css as text -- the convention set by test_ai_hedge_fund_frontend.py.
+The helpers below are adapted from test_vnpy_simulation_frontend.py, the
+closer precedent for asserting on CSS specifically: same `_media_block` brace
+counting and `_declarations`/`_has_declaration` shape, generalized to scan
+every breakpoint rather than one named up front, since the whole point here is
+to discover which breakpoint a rule lives in and compare it to another rule's.
 """
 
 import re
+from pathlib import Path
 
-from ._frontend_source import STYLES
+import pytest
 
-
-def _strip_css_comments(source: str) -> str:
-    """`/* ... */` removed. styles.css has no `//` comments and no URL literals
-    that would make a smarter, quote-aware stripper necessary here."""
-    return re.sub(r"/\*.*?\*/", "", source, flags=re.DOTALL)
+_FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
+_STYLES = _FRONTEND / "styles.css"
 
 
-_SOURCE = _strip_css_comments(STYLES)
+def _media_block(css: str, query: str) -> str:
+    """Return the body of the first ``@media`` block matching ``query``.
 
-
-def _media_max_width_blocks(source: str) -> list[tuple[int, str]]:
-    """Every top-level `@media (max-width: Npx) { ... }` block, brace-matched.
-
-    Returns (breakpoint, body) pairs. Brace-matched rather than sliced to a
-    fixed width: a rule's own `{ ... }` body is itself nested one level inside
-    the @media block, so a naive "up to the next '}'" slice would truncate at
-    the first rule instead of the block's real end.
+    Brace-counted rather than regexed to the closing ``}``, since the block
+    contains nested rules.
     """
-    blocks: list[tuple[int, str]] = []
-    for match in re.finditer(r"@media\s*\(max-width:\s*(\d+)px\)\s*\{", source):
-        breakpoint = int(match.group(1))
-        open_brace = match.end() - 1
-        depth = 0
-        index = open_brace
-        while True:
-            if source[index] == "{":
-                depth += 1
-            elif source[index] == "}":
-                depth -= 1
-                if depth == 0:
-                    break
-            index += 1
-        blocks.append((breakpoint, source[open_brace + 1 : index]))
-    return blocks
+    start = re.search(
+        r"@media\s*\(\s*max-width:\s*%s\s*\)\s*\{" % re.escape(query), css
+    )
+    assert start, f"no @media (max-width: {query}) block in styles.css"
+
+    depth, i = 1, start.end()
+    while i < len(css) and depth:
+        depth += {"{": 1, "}": -1}.get(css[i], 0)
+        i += 1
+    assert not depth, f"unbalanced braces in @media (max-width: {query})"
+    return css[start.end() : i - 1]
 
 
-def _breakpoint_of(selector_pattern: str, declaration: str) -> int:
-    """The max-width breakpoint of the one `@media` block holding a rule whose
-    selector matches `selector_pattern` and whose body contains `declaration`.
+def _declaration_block(css: str, selector: str, *, line_anchored: bool = False) -> str | None:
+    """The declaration body for ``selector`` in ``css``, or None if absent.
 
-    `selector_pattern` is anchored to the start of its line (only leading
-    whitespace before it): a bare `\\.left-panel` must not match inside the
-    longer `.playground-backtest-panel .left-panel`, which contains it as a
-    literal substring. Every selector in this file starts its own line, so the
-    anchor reliably tells the two apart.
+    Adapted from test_vnpy_simulation_frontend.py's ``_declarations``: this
+    returns None instead of asserting, because ``_breakpoint_declaring`` below
+    calls it once per candidate breakpoint and most breakpoints legitimately
+    do not contain the rule at all -- an assertion there would abort the scan
+    instead of just ruling that breakpoint out.
+
+    ``line_anchored=True`` requires the selector to start its own line (only
+    leading whitespace before it). Needed for the bare ``.left-panel`` lookup:
+    it is a literal substring of the longer
+    ``.playground-backtest-panel .left-panel``, so an unanchored search can
+    match inside that compound selector instead of the standalone rule. Every
+    selector in this file starts its own line, so the anchor reliably tells
+    the two apart.
     """
-    rule_re = re.compile(
-        r"^[ \t]*" + selector_pattern + r"\s*\{[^}]*" + re.escape(declaration) + r"[^}]*\}",
-        re.MULTILINE,
-    )
-    hits = [bp for bp, body in _media_max_width_blocks(_SOURCE) if rule_re.search(body)]
-    assert hits, (
-        f"no @media (max-width: ...) block has a rule matching /{selector_pattern}/ "
-        f"with `{declaration}` -- has the selector or declaration changed?"
-    )
+    pattern = re.sub(r"\s+", r"\\s+", re.escape(selector).replace(r"\ ", " "))
+    if line_anchored:
+        match = re.search(r"^[ \t]*" + pattern + r"\s*\{([^}]*)\}", css, re.MULTILINE)
+    else:
+        match = re.search(pattern + r"\s*\{([^}]*)\}", css)
+    return match.group(1) if match else None
+
+
+def _has_declaration(css: str, selector: str, prop: str, value: str, **kwargs) -> bool:
+    block = _declaration_block(css, selector, **kwargs)
+    if block is None:
+        return False
+    return bool(re.search(rf"{re.escape(prop)}\s*:\s*{re.escape(value)}\s*;", block))
+
+
+def _all_max_width_breakpoints(css: str) -> list[int]:
+    return sorted({int(n) for n in re.findall(r"@media\s*\(\s*max-width:\s*(\d+)px\s*\)", css)})
+
+
+def _breakpoint_declaring(css: str, selector: str, prop: str, value: str, **kwargs) -> int:
+    """The one max-width breakpoint whose (first) block declares
+    ``selector { prop: value }``.
+
+    Scans every distinct breakpoint present in the file rather than checking
+    one named up front (as ``test_mobile_backtest_exposes_setup_controls``
+    does): the point of this guard is to catch the rule moving to the *wrong*
+    breakpoint, not to re-assert a hardcoded one it might move to along with
+    the rule -- which would defeat the point of comparing two breakpoints.
+    """
+    hits = [
+        bp
+        for bp in _all_max_width_breakpoints(css)
+        if _has_declaration(_media_block(css, f"{bp}px"), selector, prop, value, **kwargs)
+    ]
+    assert hits, f"no @media (max-width: ...) block declares {selector} {{ {prop}: {value} }}"
     assert len(hits) == 1, (
-        f"rule matching /{selector_pattern}/ with `{declaration}` appears in more "
-        f"than one max-width breakpoint: {hits}"
+        f"{selector} {{ {prop}: {value} }} appears in more than one max-width "
+        f"breakpoint: {hits}"
     )
     return hits[0]
 
 
-def test_setup_panel_reshow_breakpoint_matches_its_hide_breakpoint():
+@pytest.fixture(scope="module")
+def css() -> str:
+    return _STYLES.read_text(encoding="utf-8")
+
+
+def test_setup_panel_reshow_breakpoint_matches_its_hide_breakpoint(css):
     """The re-show rule's breakpoint must equal the hide rule's.
 
     A test that only asserted both rules exist would have passed before this
     fix too -- that is exactly the regression this must catch, so it compares
     the two breakpoints rather than just their presence.
     """
-    hide_at = _breakpoint_of(r"\.left-panel", "display: none")
-    reshow_at = _breakpoint_of(r"\.playground-backtest-panel \.left-panel", "display: flex")
+    hide_at = _breakpoint_declaring(css, ".left-panel", "display", "none", line_anchored=True)
+    reshow_at = _breakpoint_declaring(
+        css, ".playground-backtest-panel .left-panel", "display", "flex"
+    )
     assert reshow_at == hide_at, (
         f".left-panel is hidden at max-width:{hide_at}px but only restored "
         f"(.playground-backtest-panel .left-panel) at max-width:{reshow_at}px -- "

--- a/dashboard/backend/tests/test_vnpy_simulation_frontend.py
+++ b/dashboard/backend/tests/test_vnpy_simulation_frontend.py
@@ -118,9 +118,14 @@ def test_backtest_request_and_result_labels_include_data_source(js):
     assert "vn.py simulated data" in js
 
 
-def test_mobile_backtest_exposes_setup_controls(css):
+def test_narrow_viewport_backtest_exposes_setup_controls(css):
     """Wiring guard only -- see the module docstring on what CSS text cannot
-    prove about actual visibility."""
+    prove about actual visibility.
+
+    Named for "narrow", not "mobile": the setup panel's re-show rule sits at the
+    1200px breakpoint (issue #129), which is a laptop in a split window, while
+    the two rules under it remain 900px/phone-width ones.
+    """
     narrow = _media_block(css, "1200px")
     mobile = _media_block(css, "900px")
 

--- a/dashboard/backend/tests/test_vnpy_simulation_frontend.py
+++ b/dashboard/backend/tests/test_vnpy_simulation_frontend.py
@@ -8,11 +8,17 @@ a declaration inside a rule, an identifier in an expression -- via the helpers
 below.
 
 Know what these cannot prove. CSS text shows a rule exists, never that anything
-is visible at a given viewport: the ``@media (max-width: 900px)`` rules below
-coexist with a pre-existing ``.left-panel { display: none }`` at
-``max-width: 1200px``, so the setup panel is still hidden from 901-1200px and
-these assertions pass anyway. Layout needs a real browser; treat this file as a
-wiring guard only.
+is visible at a given viewport -- these assertions would pass even if the rule
+they check were shadowed by a higher-specificity or later-cascading one.
+Layout needs a real browser; treat this file as a wiring guard only.
+
+(The setup panel used to be exactly such a case: ``.playground-backtest-panel
+.left-panel { display: flex }`` lived in this file's ``900px`` block while the
+``.left-panel { display: none }`` it was meant to correct fired from
+``max-width: 1200px``, leaving the panel hidden with no replacement from
+901-1200px -- issue #129. The re-show rule now lives in the 1200px block, next
+to the hide rule it answers; see the breakpoint-equality guard in
+test_frontend_setup_panel_breakpoint.py.)
 """
 
 import re
@@ -115,9 +121,12 @@ def test_backtest_request_and_result_labels_include_data_source(js):
 def test_mobile_backtest_exposes_setup_controls(css):
     """Wiring guard only -- see the module docstring on what CSS text cannot
     prove about actual visibility."""
+    narrow = _media_block(css, "1200px")
     mobile = _media_block(css, "900px")
 
-    assert _has_declaration(mobile, ".playground-backtest-panel .left-panel", "display", "flex")
+    # Shares the 1200px breakpoint with the `.left-panel { display: none }`
+    # rule it corrects (issue #129) -- not the 900px block below.
+    assert _has_declaration(narrow, ".playground-backtest-panel .left-panel", "display", "flex")
     assert _has_declaration(mobile, ".playground-backtest-panel .right-panel", "display", "flex")
     assert _has_declaration(mobile, ".performance-card .section-header", "flex-direction", "column")
 

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -3664,6 +3664,13 @@ a.header-brand:hover .title-section h1 {
         display: none;
     }
 
+    /* Must share the hide rule's breakpoint above, not the ≤900px block's --
+       a narrower re-show threshold left the setup panel gone with no
+       replacement between this width and 900px (issue #129). */
+    .playground-backtest-panel .left-panel {
+        display: flex;
+    }
+
     .chart-legend {
         grid-template-columns: 1fr;
     }
@@ -3799,10 +3806,6 @@ a.header-brand:hover .title-section h1 {
 
     .main-container {
         grid-template-columns: 1fr;
-    }
-
-    .playground-backtest-panel .left-panel {
-        display: flex;
     }
 
     .playground-backtest-panel .right-panel {


### PR DESCRIPTION
Closes #129.

`.left-panel` (the backtest setup/config panel) was hidden at `@media (max-width: 1200px)` but only restored at `@media (max-width: 900px)`. Between 901-1200px the panel was gone with no replacement -- most laptops in a split window, every tablet in landscape.

Relocates the re-show rule into the 1200px block next to the hide rule it corrects, adds a source-shape test asserting the two breakpoints stay equal, and fixes an existing wiring-guard test + docstring that had documented the dead band as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PdsVmuCNd8iaC2Sff5B8jZ
