### PR TITLE
fix: report what actually drove a backtest

### DIFF
--- a/dashboard/backend/api/routers/backtests.py
+++ b/dashboard/backend/api/routers/backtests.py
@@ -292,6 +292,17 @@ class RunMetadata(BaseModel):
     timeframe: Optional[str] = None
     timezone: Optional[str] = None
     decision_source: Optional[str] = None
+    # What actually drove the run, beside `decision_source` above (what was
+    # asked for). Both are needed: they differ exactly in the case issue #169
+    # is about, and the results view renders the N-of-M badge off the counts
+    # rather than re-deriving a coverage threshold in the browser.
+    decision_provenance: Optional[str] = None
+    decision_fallback: Optional[bool] = None
+    decision_badge: Optional[str] = None
+    decision_note: Optional[str] = None
+    llm_calls: Optional[int] = None
+    llm_decisions: Optional[int] = None
+    decision_steps: Optional[int] = None
     benchmark: Optional[str] = None
     symbols: Optional[List[str]] = None
     universe_selection: Optional[Dict[str, Any]] = None
@@ -468,6 +479,13 @@ def _run_metadata_response(run: Dict[str, Any]) -> RunMetadata:
                     }
                 else:
                     payload[field] = metadata[field]
+    # After the metadata copy, so `decision_source` above is already the
+    # requested value and this cannot overwrite it with the observed one. The
+    # block is the single producer of both, so the two can never be computed
+    # from different readings of the same row.
+    provenance = run_decision_provenance(run)
+    if provenance:
+        payload.update(provenance)
     return RunMetadata(**payload)
 
 

--- a/dashboard/backend/api/routers/backtests.py
+++ b/dashboard/backend/api/routers/backtests.py
@@ -77,6 +77,11 @@ from dashboard.backend.domain.model_providers.service import (
     get_model_provider_service,
 )
 from dashboard.backend.domain.analytics import instrumentation as analytics_instrumentation
+from dashboard.backend.domain.backtesting.provenance import (
+    DECISION_STEPS_KEY,
+    describe_decision_provenance,
+    run_decision_provenance,
+)
 from dashboard.backend.domain.credits.service import credits_service
 from dashboard.backend.api.rate_limit import FixedWindowRateLimiter, client_key
 from dashboard.backend.domain.agents.service import agent_service
@@ -2163,6 +2168,34 @@ def run_backtest_endpoint(
         response["provider_id"] = provider_id
     return response
 
+def _finished_agent_run(
+    runs: List[Dict[str, Any]], live_run_id: Optional[str]
+) -> Optional[Dict[str, Any]]:
+    """The agent run a completed status call is reporting on, or None.
+
+    ``runs`` is already scoped to the caller's session, so matching inside it
+    preserves the ownership boundary the completed branch established;
+    ``db.get_run(live_run_id)`` would answer for any session's run.
+
+    The no-id fallback takes the newest row and only when it carries the
+    provenance witness. Baseline rows (buy-and-hold, DJIA) are inserted *after*
+    the agent run and never carry it, so they cannot be mistaken for the run --
+    and refusing to search further back means a caller with no ``live_run_id``
+    gets no verdict rather than an *earlier* run's verdict. Reporting a stale
+    run's provenance as this one's would be the same class of lie this endpoint
+    is being fixed for.
+    """
+    if live_run_id:
+        return next(
+            (run for run in runs if run.get("run_id") == live_run_id), None
+        )
+    newest = runs[0] if runs else None
+    metadata = newest.get("metadata") if newest else None
+    if isinstance(metadata, dict) and DECISION_STEPS_KEY in metadata:
+        return newest
+    return None
+
+
 @router.get("/backtest/status")
 def get_backtest_status(
     request: Request,
@@ -2244,7 +2277,7 @@ def get_backtest_status(
                 "message": "Session mismatch",
             }
 
-        return {
+        payload = {
             "running": False,
             "success": True,
             "runs_count": int(slot.get("runs_count") or 0),
@@ -2252,6 +2285,18 @@ def get_backtest_status(
             "live_run_id": slot.get("live_run_id"),
             "message": "Backtest completed successfully",
         }
+        # Additive: every field above keeps its name and meaning, because
+        # app.js and the legacy surface both poll this route. What changes is
+        # that a run the model never drove can no longer answer with a bare
+        # success -- the honest label was already in the row and this endpoint
+        # was the boundary it died at (issue #169).
+        provenance = run_decision_provenance(
+            _finished_agent_run(runs, slot.get("live_run_id"))
+        )
+        if provenance:
+            payload.update(provenance)
+            payload["message"] = describe_decision_provenance(provenance)
+        return payload
     else:
         return {
             "running": False,

--- a/dashboard/backend/database.py
+++ b/dashboard/backend/database.py
@@ -141,6 +141,7 @@ class BacktestDatabase:
                 max_drawdown REAL,
                 num_trades INTEGER DEFAULT 0,
                 llm_calls INTEGER DEFAULT 0,
+                llm_decisions INTEGER DEFAULT 0,
                 input_tokens INTEGER DEFAULT 0,
                 output_tokens INTEGER DEFAULT 0,
                 est_cost_usd REAL DEFAULT 0,
@@ -354,6 +355,12 @@ class BacktestDatabase:
             token_columns = [
                 ("llm_calls",
                  "ALTER TABLE agent_runs ADD COLUMN llm_calls INTEGER DEFAULT 0"),
+                # Steps the model actually drove, not billed calls. The two
+                # differ exactly when a billed response was unusable and the
+                # step silently traded rule-based, which is the run this column
+                # exists to make visible (issue #169).
+                ("llm_decisions",
+                 "ALTER TABLE agent_runs ADD COLUMN llm_decisions INTEGER DEFAULT 0"),
                 ("input_tokens",
                  "ALTER TABLE agent_runs ADD COLUMN input_tokens INTEGER DEFAULT 0"),
                 ("output_tokens",
@@ -631,11 +638,18 @@ class BacktestDatabase:
                    num_trades: int = 0,
                    llm_model: str = "rule-based",
                    llm_calls: int = 0,
+                   llm_decisions: int = 0,
                    input_tokens: int = 0,
                    output_tokens: int = 0,
                    est_cost_usd: float = 0.0,
                    metadata: Optional[Dict[str, Any]] = None) -> None:
         """Insert a new backtest run with session_id, LLM model and token-cost tracking.
+
+        ``llm_calls`` and ``llm_decisions`` are not two spellings of one number:
+        the first is billed API calls, the second is steps the model actually
+        drove. A run where every response was billed and unusable has
+        ``llm_calls == decision_steps`` and ``llm_decisions == 0``, and reading
+        provenance off ``llm_calls`` reports it as fully model-driven.
 
         ``metadata`` is an optional JSON config snapshot (e.g. the effective
         LLM_MAX_OUTPUT_TOKENS in force during the run)."""
@@ -647,12 +661,14 @@ class BacktestDatabase:
             (run_id, session_id, agent_name, mode, start_date, end_date,
              initial_equity, final_equity, total_return, sharpe_ratio,
              max_drawdown, num_trades, llm_model,
-             llm_calls, input_tokens, output_tokens, est_cost_usd, metadata)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             llm_calls, llm_decisions, input_tokens, output_tokens,
+             est_cost_usd, metadata)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """, (run_id, session_id, agent_name, mode, start_date, end_date,
               initial_equity, final_equity, total_return, sharpe_ratio,
               max_drawdown, num_trades, llm_model,
-              llm_calls, input_tokens, output_tokens, est_cost_usd,
+              llm_calls, llm_decisions, input_tokens, output_tokens,
+              est_cost_usd,
               json.dumps(metadata) if metadata is not None else None))
 
         conn.commit()

--- a/dashboard/backend/database_postgres.py
+++ b/dashboard/backend/database_postgres.py
@@ -121,6 +121,7 @@ class PostgresBacktestDatabase:
                         num_trades INTEGER DEFAULT 0,
                         llm_model TEXT DEFAULT 'rule-based',
                         llm_calls INTEGER DEFAULT 0,
+                        llm_decisions INTEGER DEFAULT 0,
                         input_tokens INTEGER DEFAULT 0,
                         output_tokens INTEGER DEFAULT 0,
                         est_cost_usd DOUBLE PRECISION DEFAULT 0,
@@ -251,6 +252,13 @@ class PostgresBacktestDatabase:
                 cur.execute(
                     "ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS "
                     "llm_calls INTEGER DEFAULT 0"
+                )
+                # Prod runs this twin for agent_runs, so a column added to the
+                # SQLite store alone is a prod-only UndefinedColumn that local
+                # tests cannot reach.
+                cur.execute(
+                    "ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS "
+                    "llm_decisions INTEGER DEFAULT 0"
                 )
                 cur.execute(
                     "ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS "
@@ -475,6 +483,7 @@ class PostgresBacktestDatabase:
                    num_trades: int = 0,
                    llm_model: str = "rule-based",
                    llm_calls: int = 0,
+                   llm_decisions: int = 0,
                    input_tokens: int = 0,
                    output_tokens: int = 0,
                    est_cost_usd: float = 0.0,
@@ -539,8 +548,9 @@ class PostgresBacktestDatabase:
                     (run_id, session_id, agent_name, mode, start_date, end_date,
                      initial_equity, final_equity, total_return, sharpe_ratio,
                      max_drawdown, num_trades, llm_model,
-                     llm_calls, input_tokens, output_tokens, est_cost_usd, metadata)
-                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                     llm_calls, llm_decisions, input_tokens, output_tokens,
+                     est_cost_usd, metadata)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                     ON CONFLICT (run_id) DO UPDATE SET
                         session_id = EXCLUDED.session_id,
                         agent_name = EXCLUDED.agent_name,
@@ -555,6 +565,7 @@ class PostgresBacktestDatabase:
                         num_trades = EXCLUDED.num_trades,
                         llm_model = EXCLUDED.llm_model,
                         llm_calls = EXCLUDED.llm_calls,
+                        llm_decisions = EXCLUDED.llm_decisions,
                         input_tokens = EXCLUDED.input_tokens,
                         output_tokens = EXCLUDED.output_tokens,
                         est_cost_usd = EXCLUDED.est_cost_usd,
@@ -565,7 +576,8 @@ class PostgresBacktestDatabase:
                         run_id, session_id, agent_name, mode, start_date, end_date,
                         initial_equity, final_equity, total_return, sharpe_ratio,
                         max_drawdown, num_trades, llm_model,
-                        llm_calls, input_tokens, output_tokens, est_cost_usd,
+                        llm_calls, llm_decisions, input_tokens, output_tokens,
+                        est_cost_usd,
                         json.dumps(metadata) if metadata is not None else None,
                     ),
                 )

--- a/dashboard/backend/domain/backtesting/engine.py
+++ b/dashboard/backend/domain/backtesting/engine.py
@@ -289,6 +289,19 @@ class HourlyBacktester:
             self.profile,
             requested_decision_source,
         )
+        # The resolved *request*, frozen here because the two availability
+        # downgrades below rewrite `self.decision_source` in place and
+        # `_agent_run_metadata` persists whatever it holds at the end of the
+        # run. Without this the headline case of #169 -- "I asked for a model
+        # and every step traded rule-based" -- persisted identically to a run
+        # the caller deliberately ordered rule-based, and the surfaces reading
+        # the row reported the silent fallback as exactly what was ordered.
+        #
+        # Resolved rather than raw: `resolve_decision_source` is what validates
+        # the request against the market profile and fills in that profile's
+        # default, so the raw argument is None on the common path and says
+        # nothing about what the run was going to do.
+        self.requested_decision_source = self.decision_source
         self.strict_llm = bool(execution_client) or (
             decision_source is not None
             and data_source == IFIND_ASHARE
@@ -980,6 +993,18 @@ class HourlyBacktester:
         decision_source = getattr(self, "decision_source", None)
         if decision_source is not None:
             meta["decision_source"] = decision_source
+        # What the run asked for, beside what it ended up doing. These differ
+        # only when the model was unavailable, which is precisely the run that
+        # has to be reported as a fallback rather than as a choice -- and
+        # `decision_source` above has already been overwritten with the
+        # outcome by then. Written unconditionally (not only when they differ)
+        # so its *presence* separates a row this code wrote from one that
+        # predates the key, the same way `decision_steps` does for the
+        # counters: a reader cannot otherwise tell "asked for rule-based" from
+        # "nobody recorded the question".
+        requested_decision_source = getattr(self, "requested_decision_source", None)
+        if requested_decision_source is not None:
+            meta["requested_decision_source"] = requested_decision_source
         decision_steps = getattr(self, "llm_decision_steps", None)
         if decision_steps is not None:
             # Denominator for "did the model actually drive this run?" --

--- a/dashboard/backend/domain/backtesting/engine.py
+++ b/dashboard/backend/domain/backtesting/engine.py
@@ -980,6 +980,19 @@ class HourlyBacktester:
         decision_source = getattr(self, "decision_source", None)
         if decision_source is not None:
             meta["decision_source"] = decision_source
+        decision_steps = getattr(self, "llm_decision_steps", None)
+        if decision_steps is not None:
+            # Denominator for "did the model actually drive this run?" --
+            # llm_decisions / decision_steps, the same ratio the leaderboard's
+            # H6 guard applies, under the name it already uses for it.
+            #
+            # Its *presence* is also the witness that this row records
+            # llm_decisions at all: that column was added with DEFAULT 0, so
+            # every row written before it existed reads back as 0, and a bare 0
+            # cannot tell "the model drove nothing" from "nobody was counting".
+            # Reading provenance off such a row without this key would accuse
+            # every historical run of a fallback it never had.
+            meta["decision_steps"] = int(decision_steps)
         if self.use_llm:
             meta["llm_max_output_tokens"] = llm_harness.DEFAULT_MAX_OUTPUT_TOKENS
         llm_execution = getattr(self, "_llm_execution_evidence", None)
@@ -1620,6 +1633,36 @@ class HourlyBacktester:
         # row self-consistent rather than silently understating the run.
         llm_calls_total = manager.llm_calls + runtime_calls
 
+        # Steps the model actually drove, and the steps it was asked to drive.
+        # Persisted beside llm_calls because they answer different questions:
+        # llm_calls is the *billing* counter and ticks on a truncated or
+        # unparseable response that then traded rule-based, so a run with
+        # llm_calls == decision_steps and llm_decisions == 0 is a total
+        # fallback wearing the model's name. Nothing downstream could see that
+        # before -- dashboard backtests are subprocesses, so PortfolioManager's
+        # in-process counter (and the H6 guard that reads it) never crossed
+        # back to the parent. Issue #169.
+        if self.runtime_type == PIPELINE_RUNTIME_TYPE:
+            llm_decisions_total = manager.llm_decisions
+            decision_steps_total = total_steps
+        else:
+            # A hosted runtime decides once per trading day and holds on every
+            # other bar, so the hourly bar count is not its denominator: it
+            # would report a genuine run as ~1/7 covered. `runtime_calls` is
+            # every step it drove, and each entry in `runtime_step_failures` is
+            # a step it was asked for and could not answer -- their sum is the
+            # steps the model was actually asked to decide. There is no
+            # billed-but-unusable case on this path (the bridge reports no
+            # usage at all), which is why numerator and billing counter
+            # coincide here and must not be collapsed anywhere else.
+            llm_decisions_total = runtime_calls
+            decision_steps_total = runtime_calls + len(self.runtime_step_failures)
+        # Read back out of `self` by _agent_run_metadata below, the same way it
+        # already reads decision_source and the execution evidence. Not named
+        # `decision_steps`: that spelling is already taken in this module for
+        # the *pipeline's* decision stages, which is a different thing entirely.
+        self.llm_decision_steps = decision_steps_total
+
         llm_execution = None
         execution_client = getattr(self, "execution_client", None)
         if execution_client is not None:
@@ -1664,6 +1707,7 @@ class HourlyBacktester:
             num_trades=len(manager.trades),
             llm_model=llm_model,  # Track which model was used
             llm_calls=llm_calls_total,
+            llm_decisions=llm_decisions_total,
             input_tokens=manager.input_tokens,
             output_tokens=manager.output_tokens,
             est_cost_usd=est_cost,

--- a/dashboard/backend/domain/backtesting/provenance.py
+++ b/dashboard/backend/domain/backtesting/provenance.py
@@ -105,6 +105,13 @@ DECISION_PROVENANCE_UNKNOWN = "unknown"
 #: records ``llm_decisions`` at all. See ``run_decision_provenance``.
 DECISION_STEPS_KEY = "decision_steps"
 
+#: Metadata key carrying what the run *asked* for, as opposed to what it did.
+#: ``decision_source`` cannot answer that: the engine overwrites it with
+#: ``rule_based`` when no model client is available, so the one run that must
+#: be reported as a fallback is the one whose row denies being one. See
+#: ``run_decision_provenance``.
+REQUESTED_DECISION_SOURCE_KEY = "requested_decision_source"
+
 # Labels the engine persists when no model drove the run. "rule-based" is the
 # one it actually writes (engine.py); the rest are defensive, since a caller
 # with no model configured can leave the column empty or null.
@@ -185,10 +192,20 @@ def run_decision_provenance(run: Optional[Mapping[str, Any]]) -> Optional[Dict[s
 
     Returns both facts side by side, because the bug is precisely that they can
     differ: ``decision_source`` is what the caller *asked* for (the meaning that
-    name already carries in ``POST /backtest/run``'s response and in this row's
-    own metadata) and ``decision_provenance`` is what actually happened.
-    ``decision_fallback`` is the two disagreeing -- the run asked for the model
-    and did not get it.
+    name already carries in ``POST /backtest/run``'s response) and
+    ``decision_provenance`` is what actually happened. ``decision_fallback`` is
+    the two disagreeing -- the run asked for the model and did not get it.
+
+    The request is read from ``metadata.requested_decision_source``, **not**
+    from ``metadata.decision_source``, which is the *effective* source: the
+    engine rewrites its own ``decision_source`` to ``rule_based`` when no model
+    client is available, so on the one run that most needs reporting -- asked
+    for a model, never called one -- that key holds the outcome and claims it
+    was the request. Reading it as intent reported the headline failure as a
+    deliberate rule-based run: no fallback, no badge, and a note telling the
+    user this is what they ordered. Rows written before the engine recorded the
+    two separately fall back to it, since it is the only source they carry and
+    it is correct for every run that was not downgraded.
 
     ``metadata.decision_steps`` is the witness that this row records
     ``llm_decisions``. The column was added with ``DEFAULT 0``, so every row
@@ -217,7 +234,15 @@ def run_decision_provenance(run: Optional[Mapping[str, Any]]) -> Optional[Dict[s
         decision_steps=decision_steps,
     )
 
-    requested = metadata.get("decision_source")
+    requested = metadata.get(REQUESTED_DECISION_SOURCE_KEY)
+    if requested is None:
+        # A row written before the engine recorded the two separately. Its
+        # ``decision_source`` is the *effective* source, which equals the
+        # request on every run that was not downgraded -- so it is the right
+        # answer for most historical rows and the only one available for any of
+        # them. The rows it cannot speak for are exactly the downgraded ones,
+        # and those are the rows that never recorded the question.
+        requested = metadata.get("decision_source")
     requested = str(requested) if requested else None
     # Only claimed when the request is on record. Inferring intent from
     # ``llm_model`` cannot work here: a total fallback persists the honest

--- a/dashboard/backend/domain/backtesting/provenance.py
+++ b/dashboard/backend/domain/backtesting/provenance.py
@@ -1,0 +1,214 @@
+"""What actually drove a finished backtest's decisions (issue #169).
+
+A dashboard backtest could fall back to rule-based logic on *every* step and
+still report "Backtest completed successfully". Two independent layers made
+that possible, and this module is the second half of closing both.
+
+**The run row was already honest and nothing read it.** ``engine.py`` defaults
+``llm_model`` to ``"rule-based"`` and promotes it to the model's name only
+after a call succeeds, so a run where every step held already persisted the
+honest label -- ``/backtest/status`` simply never looked at it.
+
+**The counter that catches the worst case was never persisted.** A run whose
+every step made a billed call whose response failed to parse has
+``llm_calls == decision_steps`` and ``llm_model == "claude-..."`` while the
+model drove nothing at all. Only ``llm_decisions`` separates that from a clean
+run, and ``agent_runs`` had no column for it -- so the one component that could
+tell them apart, the leaderboard's H6 guard, could not: it runs in-process and
+dashboard backtests are subprocesses.
+
+Hence ``llm_calls`` is never a coverage numerator here. It is the *billing*
+counter: it ticks on a truncated or unparseable response that then traded
+rule-based, which is exactly the run this module exists to name.
+
+The threshold is imported from the leaderboard domain rather than restated.
+Two owners of one number disagree eventually, and "the dashboard and the
+leaderboard disagree about whether the model drove this run" is the same defect
+one layer up.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping, Optional
+
+from dashboard.backend.domain.leaderboard.service import MIN_LLM_DECISION_COVERAGE
+from dashboard.backend.infrastructure.market_data.profiles import (
+    LLM_DECISION_SOURCE,
+    RULE_BASED_DECISION_SOURCE,
+)
+
+# The observed verdict deliberately reuses the *requested* decision-source
+# vocabulary, so "what you asked for" and "what you got" are comparable with
+# ``==`` instead of through a translation table that can drift.
+DECISION_PROVENANCE_LLM = LLM_DECISION_SOURCE
+DECISION_PROVENANCE_RULE_BASED = RULE_BASED_DECISION_SOURCE
+DECISION_PROVENANCE_PARTIAL = "partial"
+#: The row predates the counter, so no verdict can be drawn from it. Distinct
+#: from ``rule_based`` on purpose -- see ``run_decision_provenance``.
+DECISION_PROVENANCE_UNKNOWN = "unknown"
+
+#: Metadata key carrying the coverage denominator, and the witness that a row
+#: records ``llm_decisions`` at all. See ``run_decision_provenance``.
+DECISION_STEPS_KEY = "decision_steps"
+
+# Labels the engine persists when no model drove the run. "rule-based" is the
+# one it actually writes (engine.py); the rest are defensive, since a caller
+# with no model configured can leave the column empty or null.
+_RULE_BASED_MODEL_LABELS = frozenset({"", "rule-based", "rule_based", "none", "null"})
+
+
+def _as_int(value: Any) -> int:
+    """``value`` as a count, treating anything unreadable as zero."""
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def classify_decision_provenance(
+    *,
+    llm_model: Optional[str],
+    llm_calls: Optional[int],
+    llm_decisions: Optional[int],
+    decision_steps: Optional[int] = None,
+) -> str:
+    """What drove this run: ``llm``, ``partial``, ``rule_based`` or ``unknown``.
+
+    The load-bearing case is ``llm_calls == decision_steps`` with
+    ``llm_decisions == 0``: every step made a billed call, every response was
+    unusable, every step traded rule-based. A coverage check keyed on
+    ``llm_calls`` reports that run as 100% model-driven, which is why the two
+    counters exist separately.
+
+    ``llm_decisions=None`` means "not recorded", and answers ``unknown`` rather
+    than ``rule_based``. A run written before the column existed reads back as
+    0 like any other, and accusing every historical run of a fallback it did
+    not have would be the same kind of lie in the other direction.
+
+    ``decision_steps`` is the denominator the leaderboard's H6 guard uses --
+    steps the model was *asked* to decide. Falling back to ``llm_calls`` when
+    it is unknown keeps the total-fallback case correct (0 decisions out of
+    anything is still rule-based) but understates a run that skipped the model
+    on some steps entirely, so record it where you can.
+    """
+    if (llm_model or "").strip().lower() in _RULE_BASED_MODEL_LABELS:
+        return DECISION_PROVENANCE_RULE_BASED
+
+    calls = _as_int(llm_calls)
+    if calls <= 0:
+        # A model name beside zero calls is a rule-based curve wearing that
+        # model's name -- the same shape the H6 guard refuses to publish.
+        return DECISION_PROVENANCE_RULE_BASED
+
+    if llm_decisions is None:
+        return DECISION_PROVENANCE_UNKNOWN
+
+    decisions = _as_int(llm_decisions)
+    if decisions <= 0:
+        return DECISION_PROVENANCE_RULE_BASED
+
+    steps = _as_int(decision_steps)
+    denominator = steps if steps > 0 else calls
+    # Same comparison as the H6 guard, inverted: it raises when
+    # ``llm_decisions < MIN_LLM_DECISION_COVERAGE * decision_steps``.
+    if decisions >= MIN_LLM_DECISION_COVERAGE * denominator:
+        return DECISION_PROVENANCE_LLM
+    return DECISION_PROVENANCE_PARTIAL
+
+
+def run_decision_provenance(run: Optional[Mapping[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Provenance block for one persisted ``agent_runs`` row, or None.
+
+    Returns both facts side by side, because the bug is precisely that they can
+    differ: ``decision_source`` is what the caller *asked* for (the meaning that
+    name already carries in ``POST /backtest/run``'s response and in this row's
+    own metadata) and ``decision_provenance`` is what actually happened.
+    ``decision_fallback`` is the two disagreeing -- the run asked for the model
+    and did not get it.
+
+    ``metadata.decision_steps`` is the witness that this row records
+    ``llm_decisions``. The column was added with ``DEFAULT 0``, so every row
+    written before it existed reads back as 0 and a bare 0 cannot distinguish
+    "the model drove nothing" from "nobody was counting". The metadata key is
+    written by the same code path that writes the column, so its presence is
+    the one thing that can.
+    """
+    if not run:
+        return None
+
+    metadata = run.get("metadata")
+    if not isinstance(metadata, Mapping):
+        metadata = {}
+
+    recorded = DECISION_STEPS_KEY in metadata
+    decision_steps = _as_int(metadata.get(DECISION_STEPS_KEY)) if recorded else None
+    llm_decisions = _as_int(run.get("llm_decisions")) if recorded else None
+
+    llm_model = run.get("llm_model")
+    llm_calls = _as_int(run.get("llm_calls"))
+    verdict = classify_decision_provenance(
+        llm_model=llm_model,
+        llm_calls=llm_calls,
+        llm_decisions=llm_decisions,
+        decision_steps=decision_steps,
+    )
+
+    requested = metadata.get("decision_source")
+    requested = str(requested) if requested else None
+    # Only claimed when the request is on record. Inferring intent from
+    # ``llm_model`` cannot work here: a total fallback persists the honest
+    # "rule-based" label, so the model's name is gone exactly when a fallback
+    # happened -- which would report the worst case as "no fallback".
+    fallback = requested == LLM_DECISION_SOURCE and verdict in (
+        DECISION_PROVENANCE_RULE_BASED,
+        DECISION_PROVENANCE_PARTIAL,
+    )
+
+    block: Dict[str, Any] = {
+        "decision_provenance": verdict,
+        "decision_source": requested,
+        "decision_fallback": fallback,
+        "llm_model": llm_model,
+        "llm_calls": llm_calls,
+        "llm_decisions": llm_decisions,
+        "decision_steps": decision_steps,
+    }
+    block["decision_note"] = decision_provenance_note(block)
+    return block
+
+
+def decision_provenance_note(provenance: Mapping[str, Any]) -> Optional[str]:
+    """Short clause for a surface that has already said the run finished.
+
+    Single owner of this copy. The browser renders whatever this returns rather
+    than composing its own sentence out of the same counters, because the same
+    fields worded twice is two owners of one message, and they disagree the
+    moment either side's wording moves.
+
+    None for a clean run and for ``unknown``: a run the model drove needs no
+    note, and a row written before the counters existed has nothing to report
+    -- saying anything there would be inventing a finding out of missing data.
+    """
+    verdict = provenance.get("decision_provenance")
+    decisions = _as_int(provenance.get("llm_decisions"))
+    steps = _as_int(provenance.get("decision_steps"))
+
+    if verdict == DECISION_PROVENANCE_PARTIAL:
+        scale = f" only {decisions} of {steps} steps" if steps else " only part of it"
+        return (
+            f"The model drove{scale} — the rest fell back to rule-based logic."
+        )
+    if verdict == DECISION_PROVENANCE_RULE_BASED:
+        if provenance.get("decision_fallback"):
+            return (
+                "No step used the model — every decision fell back to "
+                "rule-based logic."
+            )
+        return "Rule-based strategy — no model decisions."
+    return None
+
+
+def describe_decision_provenance(provenance: Mapping[str, Any]) -> str:
+    """The completion message for one run, as a whole sentence."""
+    note = decision_provenance_note(provenance)
+    return f"Backtest completed. {note}" if note else "Backtest completed successfully"

--- a/dashboard/backend/domain/backtesting/provenance.py
+++ b/dashboard/backend/domain/backtesting/provenance.py
@@ -95,18 +95,28 @@ def classify_decision_provenance(
         return DECISION_PROVENANCE_RULE_BASED
 
     calls = _as_int(llm_calls)
-    if calls <= 0:
-        # A model name beside zero calls is a rule-based curve wearing that
-        # model's name -- the same shape the H6 guard refuses to publish.
-        return DECISION_PROVENANCE_RULE_BASED
 
     if llm_decisions is None:
-        return DECISION_PROVENANCE_UNKNOWN
+        # A model name beside zero calls is a rule-based curve wearing that
+        # model's name -- the same shape the H6 guard refuses to publish. With
+        # no decision count on the row, the call count is the only evidence
+        # left, so it decides here and only here.
+        return (
+            DECISION_PROVENANCE_RULE_BASED if calls <= 0
+            else DECISION_PROVENANCE_UNKNOWN
+        )
 
     decisions = _as_int(llm_decisions)
     if decisions <= 0:
+        # Covers zero calls too: nothing the model drove, whatever was billed.
         return DECISION_PROVENANCE_RULE_BASED
 
+    # Deliberately NOT short-circuited on ``calls <= 0`` above. `llm_calls` is
+    # only incremented for a response whose usage could be read
+    # (``PortfolioManager._record_llm_usage``), so a provider that reports no
+    # usage yields llm_calls == 0 on a run the model genuinely drove every step
+    # of. Reading that as rule-based would be a false accusation -- the exact
+    # failure in the other direction from the one this module exists for.
     steps = _as_int(decision_steps)
     denominator = steps if steps > 0 else calls
     # Same comparison as the H6 guard, inverted: it raises when
@@ -174,7 +184,35 @@ def run_decision_provenance(run: Optional[Mapping[str, Any]]) -> Optional[Dict[s
         "decision_steps": decision_steps,
     }
     block["decision_note"] = decision_provenance_note(block)
+    block["decision_badge"] = decision_coverage_badge(block)
     return block
+
+
+def decision_coverage_badge(provenance: Mapping[str, Any]) -> Optional[str]:
+    """"N of M steps model-driven", or None when there is nothing to flag.
+
+    **Fires below 100%, not below the H6 threshold, and that gap is the point.**
+    ``MIN_LLM_DECISION_COVERAGE`` answers "may this publish to the leaderboard";
+    this answers "should the user be told something degraded". A 159/161 run
+    passes the first and still has two steps the user paid for and did not get,
+    so the counts drive the badge and the threshold drives the verdict. They are
+    never collapsed into one number.
+
+    None for a run the caller explicitly ordered rule-based: there is no model
+    coverage to report a ratio about, and ``decision_provenance_note`` already
+    labels it. None when the counts are unknown, for the usual reason -- a row
+    that predates the counters must not be shown a ratio invented from a
+    defaulted 0.
+    """
+    decisions = provenance.get("llm_decisions")
+    steps = provenance.get("decision_steps")
+    if decisions is None or not steps:
+        return None
+    if provenance.get("decision_source") == RULE_BASED_DECISION_SOURCE:
+        return None
+    if _as_int(decisions) >= _as_int(steps):
+        return None
+    return f"{_as_int(decisions)} of {_as_int(steps)} steps model-driven"
 
 
 def decision_provenance_note(provenance: Mapping[str, Any]) -> Optional[str]:
@@ -185,14 +223,24 @@ def decision_provenance_note(provenance: Mapping[str, Any]) -> Optional[str]:
     fields worded twice is two owners of one message, and they disagree the
     moment either side's wording moves.
 
-    None for a clean run and for ``unknown``: a run the model drove needs no
-    note, and a row written before the counters existed has nothing to report
-    -- saying anything there would be inventing a finding out of missing data.
+    None only for a run the model drove *entirely* and for ``unknown``. An
+    ``llm`` verdict still gets a note when any step fell back: the H6 threshold
+    decides whether a curve is publishable, not whether the user should be told
+    they paid for steps the model did not answer. A row written before the
+    counters existed has nothing to report -- saying anything there would be
+    inventing a finding out of missing data.
     """
     verdict = provenance.get("decision_provenance")
+    recorded = provenance.get("llm_decisions") is not None
     decisions = _as_int(provenance.get("llm_decisions"))
     steps = _as_int(provenance.get("decision_steps"))
 
+    if verdict == DECISION_PROVENANCE_LLM and recorded and steps and decisions < steps:
+        held = steps - decisions
+        return (
+            f"{held} of {steps} steps fell back to rule-based logic; the model "
+            "drove the rest."
+        )
     if verdict == DECISION_PROVENANCE_PARTIAL:
         scale = f" only {decisions} of {steps} steps" if steps else " only part of it"
         return (

--- a/dashboard/backend/domain/backtesting/provenance.py
+++ b/dashboard/backend/domain/backtesting/provenance.py
@@ -47,10 +47,22 @@ helper, since that is where the fallbacks happen -- and it closes. Two shapes,
 with very different symptoms:
 
 * **A module-level import takes the app down at startup**, and the whole test
-  session with it, in conftest before any test body runs. The traceback names
-  neither file whose relationship caused it; the line to recognise is
-  ``cannot import name 'MIN_LLM_DECISION_COVERAGE' from partially initialized
-  module``. No guard can fire here -- nothing is left running to fire one.
+  session with it, in conftest before any test body runs. No guard can fire
+  here -- nothing is left running to fire one -- so recognise it by sight::
+
+      ImportError: cannot import name 'MIN_LLM_DECISION_COVERAGE' from
+      partially initialized module 'dashboard.backend.domain.leaderboard.service'
+      (most likely due to a circular import)
+
+  **That error blames the wrong edge, and this is the expensive part.** The two
+  modules it names -- ``provenance`` and ``leaderboard/service`` -- are the
+  edge that was always there and is correct. The edge that broke it is the
+  import you just added, which appears only as one unremarkable frame in the
+  middle of the traceback. The head of that traceback is whichever route
+  imported first (measured: ``app`` -> ``api/router`` -> ``external_backtest``
+  -> ``external_run_service`` -> ``portfolio_manager``), so the reader starts
+  in an API module with nothing to do with either package. Read the traceback
+  for *who imported ``provenance``*, not for the modules in the error text.
 * **A function-local import collects green and ships.** It raises on the first
   fallback step, in production, on the path that is already the least
   exercised. ``test_provenance_is_not_reachable_from_the_leaderboard_package``

--- a/dashboard/backend/domain/backtesting/provenance.py
+++ b/dashboard/backend/domain/backtesting/provenance.py
@@ -25,6 +25,48 @@ The threshold is imported from the leaderboard domain rather than restated.
 Two owners of one number disagree eventually, and "the dashboard and the
 leaderboard disagree about whether the model drove this run" is the same defect
 one layer up.
+
+WHO MAY IMPORT THIS MODULE
+--------------------------
+**``portfolio_manager``, ``constants`` and ``metrics`` must not.** Neither must
+anything else in this package that ``domain/leaderboard`` can reach.
+
+``MIN_LLM_DECISION_COVERAGE`` is an H6 *publish* policy -- "may this curve go on
+the leaderboard" -- so the leaderboard owns it, and importing it here points a
+dependency from ``domain/backtesting`` at ``domain/leaderboard``. The reverse
+edge already exists: ``leaderboard/service.py`` imports
+``leaderboard.strategies``, whose ``llm_agent`` imports
+``backtesting.portfolio_manager``, and ``leaderboard/baselines.py`` imports
+``backtesting.constants`` and ``backtesting.metrics``. So the two packages are
+already a cycle at package level, and this module sits inside it.
+
+It works today only because the cycle does not close *on this module*: nothing
+reachable from ``domain/leaderboard`` imports ``provenance``. Add one import
+from ``portfolio_manager`` -- the most natural place to reach for a verdict
+helper, since that is where the fallbacks happen -- and it closes. Two shapes,
+with very different symptoms:
+
+* **A module-level import takes the app down at startup**, and the whole test
+  session with it, in conftest before any test body runs. The traceback names
+  neither file whose relationship caused it; the line to recognise is
+  ``cannot import name 'MIN_LLM_DECISION_COVERAGE' from partially initialized
+  module``. No guard can fire here -- nothing is left running to fire one.
+* **A function-local import collects green and ships.** It raises on the first
+  fallback step, in production, on the path that is already the least
+  exercised. ``test_provenance_is_not_reachable_from_the_leaderboard_package``
+  (in ``tests/test_architecture_boundaries.py``, which is why it lives there
+  and not beside the other provenance tests) catches this one and prints the
+  import chain.
+
+Import it from ``api/`` and from the engine's *callers* instead. ``engine.py``
+deliberately does not: it only needs to *write* the counters, and the backtest
+subprocess would otherwise carry the whole leaderboard package's import weight
+inside a 512MB instance.
+
+The direction of the dependency is the price of having one owner of the
+threshold, and it is worth paying. Do not "fix" the cycle by moving the
+constant into ``domain/backtesting`` -- that inverts who owns a leaderboard
+policy, which is the actual defect the single owner prevents.
 """
 
 from __future__ import annotations

--- a/dashboard/backend/domain/leaderboard/service.py
+++ b/dashboard/backend/domain/leaderboard/service.py
@@ -996,11 +996,13 @@ def ensure_leaderboard_runs(
         # baselines (LLM entries carry auto_compute=false and deploy manually via
         # deploy_model_run). Guard here too so a misconfigured LLM entry can't
         # slip a rule-based fallback onto the board without the manual override.
+        auto_llm_calls = int(getattr(strategy_impl, "llm_calls", 0) or 0)
+        auto_llm_decisions = _reported_int(strategy_impl, "llm_decisions")
         _reject_if_llm_fallback(
             strategy_id,
             strategy_impl,
-            int(getattr(strategy_impl, "llm_calls", 0) or 0),
-            llm_decisions=_reported_int(strategy_impl, "llm_decisions"),
+            auto_llm_calls,
+            llm_decisions=auto_llm_decisions,
             decision_steps=int(getattr(strategy_impl, "decision_steps", 0) or 0),
             model=strategy.get("model"),
             model_id=getattr(strategy_impl, "model_id", None) or strategy.get("model_id"),
@@ -1020,6 +1022,16 @@ def ensure_leaderboard_runs(
             max_drawdown=metrics["max_drawdown"],
             num_trades=strategy_impl.num_trades(),
             llm_model=strategy_id,
+            # The numbers the guard immediately above just measured. This path
+            # is meant for rule-based baselines, where both are 0 -- but it
+            # publishes any entry the guard lets through, and dropping them
+            # wrote `llm_model = <entry>` beside `llm_calls = 0`, which is the
+            # exact shape `classify_decision_provenance` reads as a rule-based
+            # curve wearing that model's name.
+            llm_calls=auto_llm_calls,
+            llm_decisions=(
+                auto_llm_calls if auto_llm_decisions is None else auto_llm_decisions
+            ),
             metadata=_with_market_data_provenance(
                 _llm_run_metadata(
                     strategy_id,
@@ -1357,6 +1369,16 @@ def deploy_model_run(
         num_trades=strategy_impl.num_trades(),
         llm_model=entry_id,
         llm_calls=llm_calls,
+        # The same number `_reject_if_llm_fallback` just admitted this run on.
+        # Persisting only `llm_calls` left the column at its DEFAULT 0 on the
+        # rows H6 governs, and the billing counter cannot stand in for it --
+        # that substitution is what the two counters were split to prevent.
+        #
+        # `_reported_int` answers None for a strategy shape that does not
+        # report the counter, and the guard's documented response to that is to
+        # measure `llm_calls` instead; the row mirrors it rather than writing
+        # NULL, which would read back as "nobody counted" on a run that was.
+        llm_decisions=llm_calls if llm_decisions is None else llm_decisions,
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         est_cost_usd=est_cost,

--- a/dashboard/backend/tests/backtesting/test_engine_move.py
+++ b/dashboard/backend/tests/backtesting/test_engine_move.py
@@ -626,6 +626,60 @@ def test_hosted_run_row_reports_runtime_calls_not_zero(patched_engine):
     assert "gpt-4.1" not in str(run_row["llm_model"])
 
 
+def test_rule_based_run_persists_zero_model_decisions_and_its_step_count(
+    patched_engine,
+):
+    """Layer B of #169: the counter that catches a silent fallback had to exist
+    in the row at all. A dashboard backtest is a subprocess, so the in-process
+    H6 guard never sees these numbers -- persisting them is the only way they
+    cross back."""
+    run_id, equity_curve = _run_rule_based(patched_engine)
+
+    run = patched_engine.runs[0]
+    assert run["run_id"] == run_id
+    assert run["llm_calls"] == 0
+    assert run["llm_decisions"] == 0
+    # The coverage denominator: steps the model was asked to decide. The
+    # non-intraday path marks equity once per decision step, so the curve
+    # length is that count without restating it here.
+    assert run["metadata"]["decision_steps"] == len(equity_curve)
+
+
+def test_hosted_run_counts_decisions_over_the_steps_it_was_asked_for(
+    patched_engine,
+):
+    """A hosted runtime decides once per trading day and holds on every other
+    bar, so the hourly bar count is not its denominator -- it would report a
+    healthy run as roughly 1/7 covered. Steps it drove plus steps it was asked
+    for and could not answer is."""
+    from dashboard.backend.infrastructure.ai_hedge_fund.adapter import (
+        AiHedgeFundRuntimeError,
+    )
+
+    class FlakyRunner:
+        def __init__(self):
+            self.calls = 0
+
+        def run(self, payload, *, timeout_seconds):
+            self.calls += 1
+            if self.calls == 2:
+                raise AiHedgeFundRuntimeError("timed out after 300 seconds")
+            return {"decisions": {"AAPL": {"action": "hold", "quantity": 0,
+                                           "confidence": 55.0, "reasoning": "ok"}}}
+
+    bt = _hosted_backtester(FlakyRunner())
+    bt.run_agent_backtest()
+
+    run = patched_engine.runs[0]
+    drove = bt.runtime_dispatcher.calls
+    held = len(bt.runtime_step_failures)
+    assert drove > 0 and held == 1
+    assert run["llm_decisions"] == drove
+    assert run["metadata"]["decision_steps"] == drove + held
+    # Well short of the bar count, which is the point of not using it.
+    assert run["metadata"]["decision_steps"] < len(bt.all_data["AAPL"])
+
+
 def test_hosted_run_that_never_reached_the_model_is_not_attributed_to_it(
     patched_engine, monkeypatch
 ):

--- a/dashboard/backend/tests/backtesting/test_engine_move.py
+++ b/dashboard/backend/tests/backtesting/test_engine_move.py
@@ -680,6 +680,68 @@ def test_hosted_run_counts_decisions_over_the_steps_it_was_asked_for(
     assert run["metadata"]["decision_steps"] < len(bt.all_data["AAPL"])
 
 
+def test_a_run_downgraded_for_want_of_a_model_records_what_it_asked_for(
+    patched_engine, monkeypatch
+):
+    """The headline case of #169, and the one the persisted `decision_source`
+    cannot report.
+
+    Both availability downgrades in __init__ rewrite `self.decision_source` to
+    rule_based, and _agent_run_metadata persists whatever that attribute holds
+    at the end. So a run that asked for a model and never got one persisted
+    byte-identically to one the caller ordered rule-based -- and the surface
+    reading it then told the first user that rule-based logic was what they
+    ordered. The request is captured before the downgrade for that reason.
+    """
+    monkeypatch.setattr(engine_mod, "HAS_ANTHROPIC", True)
+    monkeypatch.setattr(engine_mod, "make_llm_client", lambda *a, **k: None)
+
+    bt = HourlyBacktester(
+        "2026-03-01", "2026-04-01", "downgraded",
+        use_llm=True, decision_source="llm",
+    )
+    # The downgrade this test exists for: no client, not strict, so the run
+    # proceeds rule-based instead of raising.
+    assert bt.use_llm is False
+    assert bt.decision_source == "rule_based"
+    assert bt.requested_decision_source == "llm"
+
+    bt.load_data()
+    bt.calculate_indicators()
+    bt.run_agent_backtest()
+
+    metadata = patched_engine.runs[0]["metadata"]
+    assert metadata["decision_source"] == "rule_based"      # what it did
+    assert metadata["requested_decision_source"] == "llm"   # what it was asked
+
+
+def test_a_missing_sdk_downgrade_also_records_the_request(
+    patched_engine, monkeypatch
+):
+    """The second downgrade site. It leaves `use_llm` True for the client
+    lookup below it, so it is reached on a different condition than the one
+    above and has to record the request just the same."""
+    monkeypatch.setattr(engine_mod, "HAS_ANTHROPIC", False)
+
+    bt = HourlyBacktester(
+        "2026-03-01", "2026-04-01", "no-sdk",
+        use_llm=True, decision_source="llm",
+    )
+    assert bt.decision_source == "rule_based"
+    assert bt.requested_decision_source == "llm"
+
+
+def test_an_intentionally_rule_based_run_asked_for_rule_based(patched_engine):
+    """The other half of the same key: it must not turn every rule-based run
+    into a fallback. A caller that ordered rule-based logic got exactly what it
+    ordered, and the two rows differ only in this field."""
+    run_id, _ = _run_rule_based(patched_engine)
+
+    metadata = patched_engine.runs[0]["metadata"]
+    assert metadata["decision_source"] == "rule_based"
+    assert metadata["requested_decision_source"] == "rule_based"
+
+
 def test_hosted_run_that_never_reached_the_model_is_not_attributed_to_it(
     patched_engine, monkeypatch
 ):

--- a/dashboard/backend/tests/backtesting/test_ifind_ashare_engine.py
+++ b/dashboard/backend/tests/backtesting/test_ifind_ashare_engine.py
@@ -431,6 +431,10 @@ def test_ifind_engine_uses_profile_symbols_in_explicit_rule_mode(monkeypatch):
         "timeframe": "60m",
         "timezone": "Asia/Shanghai",
         "decision_source": "rule_based",
+        # Coverage denominator for llm_decisions (issue #169): steps the model
+        # was asked to decide. A rule-based run asked it none, so the row says
+        # 0 of 60 rather than leaving the denominator absent.
+        "decision_steps": 60,
         "benchmark": "equal_weight_buyhold",
         "t_plus_one_enabled": True,
         "symbols": list(A_SHARE_DEMO_6_SYMBOLS),

--- a/dashboard/backend/tests/backtesting/test_ifind_ashare_engine.py
+++ b/dashboard/backend/tests/backtesting/test_ifind_ashare_engine.py
@@ -431,6 +431,12 @@ def test_ifind_engine_uses_profile_symbols_in_explicit_rule_mode(monkeypatch):
         "timeframe": "60m",
         "timezone": "Asia/Shanghai",
         "decision_source": "rule_based",
+        # What the caller asked for, beside what the run did. They agree here
+        # because nothing was downgraded -- and that agreement is the only
+        # thing separating this row from a run that asked for a model and
+        # silently traded rule-based, which persists the same
+        # `decision_source` (issue #169).
+        "requested_decision_source": "rule_based",
         # Coverage denominator for llm_decisions (issue #169): steps the model
         # was asked to decide. A rule-based run asked it none, so the row says
         # 0 of 60 rather than leaving the denominator absent.

--- a/dashboard/backend/tests/domain/leaderboard/test_deploy_guard.py
+++ b/dashboard/backend/tests/domain/leaderboard/test_deploy_guard.py
@@ -462,3 +462,81 @@ def test_default_model_name_is_gateway_aware(monkeypatch):
     monkeypatch.setenv("COMMONSTACK_API_KEY", "x")
     assert bh.default_model_name() == bh.COMMONSTACK_MODEL_NAME
     assert bh.default_model_name("openrouter") == bh.OPENROUTER_MODEL_NAME
+
+
+def test_a_published_row_records_the_decisions_the_guard_measured(guard_env, monkeypatch):
+    """The number the guard admitted the run on has to reach the row.
+
+    ``deploy_model_run`` reads ``llm_decisions`` to decide whether a curve may
+    publish and then wrote a row carrying only ``llm_calls``, leaving the
+    column at its ``DEFAULT 0`` on exactly the runs H6 exists to police. The
+    billing counter cannot stand in for it -- that substitution is the defect
+    the two counters were split to prevent -- and anything reading provenance
+    off a board row gets a zero nobody measured.
+    """
+    _use(monkeypatch, FakeLLMStrategy(
+        used_llm=True, llm_calls=100, llm_decisions=96, decision_steps=100))
+
+    result = canon_service.deploy_model_run("claude_haiku_4_5", force_refresh=True)
+
+    row = guard_env.get_run(result["run_id"])
+    assert row["llm_calls"] == 100
+    assert row["llm_decisions"] == 96
+
+
+def test_a_strategy_that_reports_no_decisions_still_records_what_was_measured(
+    guard_env, monkeypatch
+):
+    """`_reported_int` answers None for a strategy shape that does not report
+    the counter, and the guard's documented response is to measure `llm_calls`
+    instead. Handing that None straight to `insert_run` writes NULL -- which
+    reads back as "nobody counted" on a run that was counted, and is the
+    absent-versus-zero confusion this whole column exists to end, one layer
+    down."""
+    _use(monkeypatch, FakeLLMStrategy(
+        used_llm=True, llm_calls=95, decision_steps=100, report_decisions=False))
+
+    result = canon_service.deploy_model_run("claude_haiku_4_5", force_refresh=True)
+
+    row = guard_env.get_run(result["run_id"])
+    assert row["llm_decisions"] == 95   # the number the guard admitted it on
+
+
+def test_the_auto_compute_path_records_the_counters_it_guarded_on(tmp_path, monkeypatch):
+    """The same defect as above, at the sibling insert.
+
+    `ensure_leaderboard_runs` reads both counters to run the belt-and-suspenders
+    guard and then wrote a row carrying neither, so an LLM entry that passed it
+    landed with `llm_calls = 0` and `llm_decisions = 0` -- the exact shape
+    `classify_decision_provenance` reads as a rule-based curve wearing the
+    model's name. The row has to say what the guard measured.
+    """
+    cfg = {
+        "session_id": "lb-auto-test",
+        "start_date": "2026-04-15",
+        "end_date": "2026-05-15",
+        "initial_capital": 100000,
+        "strategies": [
+            {"id": "sneaky_llm", "name": "Sneaky", "model": "Sneaky",
+             "strategy": "llm_agent", "auto_compute": True},
+        ],
+    }
+    test_db = BacktestDatabase(db_path=tmp_path / "lb.db")
+    monkeypatch.setattr(canon_service, "db", test_db)
+    monkeypatch.setattr(canon_service, "load_leaderboard_config", lambda: dict(cfg))
+    monkeypatch.setattr(canon_service, "get_strategy", lambda entry: FakeLLMStrategy(
+        used_llm=True, llm_calls=100, llm_decisions=96, decision_steps=100))
+    monkeypatch.setattr(canon_service, "fetch_hourly_bars", lambda syms, s, e: {"AAPL": object()})
+    monkeypatch.setattr(canon_service, "calc_metrics", lambda curve, cap: {
+        "initial_equity": cap, "final_equity": cap, "total_return": 0.0,
+        "sharpe_ratio": 0.0, "max_drawdown": 0.0,
+    })
+    monkeypatch.setattr(canon_service.token_cost, "estimate_cost_usd", lambda m, i, o: 0.0)
+
+    canon_service.ensure_leaderboard_runs(force_refresh=True)
+
+    run_id = canon_service._run_id("sneaky_llm", "2026-04-15", "2026-05-15")
+    row = test_db.get_run(run_id)
+    assert row is not None
+    assert row["llm_calls"] == 100
+    assert row["llm_decisions"] == 96

--- a/dashboard/backend/tests/integration/test_ifind_ashare_backtest.py
+++ b/dashboard/backend/tests/integration/test_ifind_ashare_backtest.py
@@ -648,6 +648,11 @@ def test_ifind_offline_response_reaches_engine_database_and_chart(
         "timeframe": "60m",
         "timezone": "Asia/Shanghai",
         "decision_source": "rule_based",
+        # The request, recorded beside the outcome. Equal here because this
+        # run asked for rule-based logic and got it -- and that equality is
+        # the only difference from a run that asked for a model and silently
+        # traded rule-based, which writes the same `decision_source` (#169).
+        "requested_decision_source": "rule_based",
         "benchmark": "equal_weight_buyhold",
         "t_plus_one_enabled": True,
         "symbols": list(symbols),

--- a/dashboard/backend/tests/integration/test_ifind_ashare_backtest.py
+++ b/dashboard/backend/tests/integration/test_ifind_ashare_backtest.py
@@ -676,6 +676,14 @@ def test_ifind_offline_response_reaches_engine_database_and_chart(
             "scope": "full_day_suspension_and_closing_limits",
         },
     }
+    # Coverage denominator for llm_decisions (issue #169): steps the model was
+    # asked to decide. Pulled out of the exact comparison because it is a
+    # property of this universe's data rather than a fixed constant -- but
+    # asserted against the curve, not against itself, so a run that stopped
+    # recording it cannot pass.
+    decision_steps = agent_run["metadata"].pop("decision_steps")
+    assert decision_steps == len(test_db.get_equity_curve(agent_run_id))
+    assert agent_run["llm_decisions"] == 0
     # A run with no fills writes no cost totals. The baseline may have initial
     # fills, so its totals are asserted separately below.
     assert agent_run["metadata"] == expected_metadata

--- a/dashboard/backend/tests/llm/test_backtest_harness.py
+++ b/dashboard/backend/tests/llm/test_backtest_harness.py
@@ -674,6 +674,47 @@ def test_post_parse_exception_is_billed_but_not_a_decision():
     assert pm.llm_decisions == 0    # but not a usable model decision
 
 
+def test_missing_client_is_neither_billed_nor_a_decision():
+    """The first fallback site: no client, or the SDK is absent.
+
+    Nothing was called, so nothing is billed -- and the step traded rule-based,
+    so nothing is a model decision either. Both counters staying 0 is what lets
+    a run with a model name on it and no usable decisions be told apart from
+    one that never had a client at all.
+    """
+    pm = bha.PortfolioManager(100000)
+    out = pm.make_trading_decision_with_llm(_portfolio_state(), None)
+    assert out == pm.make_trading_decision(_portfolio_state())
+    assert pm.llm_calls == 0
+    assert pm.llm_decisions == 0
+
+
+def test_pipeline_with_no_parseable_decision_is_billed_but_not_a_decision(monkeypatch):
+    """The pipeline path's own fallback, which the single-prompt cases miss.
+
+    ``run_pipeline_decision`` bills every sub-agent step it ran before giving
+    up, so this is the multi-step shape of the same defect: real spend, a
+    rule-based curve, and -- before llm_decisions was persisted -- a run row
+    that looked like four clean model calls.
+    """
+    pm = bha.PortfolioManager(100000)
+    monkeypatch.setattr(
+        portfolio_manager_module,
+        "run_pipeline_decision",
+        lambda *args, **kwargs: (None, (120, 40), 4, []),
+    )
+
+    out = pm.make_trading_decision_with_llm(
+        _portfolio_state(),
+        _FakeClient(_FakeResponse("unused")),
+        pipeline=[{"role": "analyst"}],
+    )
+
+    assert out == pm.make_trading_decision(_portfolio_state())
+    assert pm.llm_calls == 4        # every sub-agent step was billed
+    assert pm.llm_decisions == 0    # and none of them drove the step
+
+
 def test_malformed_action_item_is_billed_but_not_a_decision():
     # A non-empty actions list whose items are the wrong shape (strings, not
     # dicts) also throws inside the processing loop → rule-based fallback.

--- a/dashboard/backend/tests/test_architecture_boundaries.py
+++ b/dashboard/backend/tests/test_architecture_boundaries.py
@@ -422,6 +422,95 @@ def test_discord_bot_imports_without_secrets():
 # Settlement semantics come from the market profile, never a constructor default
 # ---------------------------------------------------------------------------
 
+def test_provenance_is_not_reachable_from_the_leaderboard_package():
+    """The import cycle this module sits inside, kept open at one point.
+
+    ``provenance`` imports ``leaderboard/service.py`` for the threshold, and
+    the leaderboard already imports back into ``domain/backtesting``
+    (``strategies/llm_agent`` -> ``portfolio_manager``; ``baselines`` ->
+    ``constants``/``metrics``). ``domain/backtesting`` <-> ``domain/leaderboard``
+    is therefore a package-level cycle already, and it is survivable only
+    because it does not close on *this* module: nothing the leaderboard can
+    reach imports ``provenance``.
+
+    One import from ``portfolio_manager`` -- the most natural place someone
+    would reach for a verdict helper, since that is where the fallbacks happen
+    -- closes it, and the app dies at import with a traceback naming neither of
+    the two files whose relationship caused it. This fails first, and prints
+    the chain.
+
+    Deliberately a reachability walk rather than a deny-list of three module
+    names: the invariant is "nothing the leaderboard can reach", which widens
+    by itself the day the leaderboard imports another backtesting module.
+
+    **What this can and cannot catch, measured rather than assumed.** A plain
+    module-level import closing the cycle takes the whole pytest session down
+    in conftest setup, before any test body runs -- this one included. That
+    case needs no guard: it is an unmissable ImportError storm, and the
+    recognisable line is "cannot import name 'MIN_LLM_DECISION_COVERAGE' from
+    partially initialized module".
+
+    The case this guard is actually for is the *deferred* one: a
+    function-local ``from ...provenance import ...`` inside a module the
+    leaderboard reaches. That collects green, passes CI, and raises on the
+    first fallback step in production. ``ast.walk`` sees imports at any depth,
+    so it is caught here; verified by adding exactly that import and watching
+    this fail while the rest of the suite stayed green.
+    """
+    backend, repo_root = _BACKEND, _REPO_ROOT
+
+    graph: dict[str, set[str]] = {}
+    for path in backend.rglob("*.py"):
+        parts = path.relative_to(backend).parts
+        if "tests" in parts or "__pycache__" in parts:
+            continue
+        module = ".".join(path.relative_to(repo_root).with_suffix("").parts)
+        edges = set()
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+            if isinstance(node, ast.Import):
+                edges.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module and not node.level:
+                edges.add(node.module)
+                edges.update(f"{node.module}.{a.name}" for a in node.names)
+        graph[module] = {e for e in edges if e.startswith("dashboard.backend")}
+
+    # A package import reaches its __init__, which may re-export submodules.
+    def _targets(name: str) -> set[str]:
+        return {m for m in graph if m == name or m == f"{name}.__init__"}
+
+    parent: dict[str, str] = {}
+    frontier = [m for m in graph if m.startswith("dashboard.backend.domain.leaderboard")]
+    seen = set(frontier)
+    while frontier:
+        module = frontier.pop()
+        for edge in graph.get(module, ()):
+            for target in _targets(edge):
+                if target not in seen:
+                    seen.add(target)
+                    parent[target] = module
+                    frontier.append(target)
+
+    # Non-vacuity: the reverse edge really is there, so an empty walk (a broken
+    # parser, a renamed package) cannot pass this as "no cycle".
+    assert "dashboard.backend.domain.backtesting.portfolio_manager" in seen, (
+        "the leaderboard no longer reaches portfolio_manager -- this walk is "
+        "not measuring what it claims to"
+    )
+
+    offender = "dashboard.backend.domain.backtesting.provenance"
+    if offender in seen:
+        chain, cursor = [offender], offender
+        while cursor in parent:
+            cursor = parent[cursor]
+            chain.append(cursor)
+        pytest.fail(
+            "provenance imports domain/leaderboard for MIN_LLM_DECISION_COVERAGE, "
+            "so the leaderboard must not reach provenance -- that closes the "
+            "cycle and kills app import. Chain:\n  "
+            + "\n  ".join(reversed(chain))
+        )
+
+
 def test_portfolio_manager_construction_always_declares_settlement():
     """Every production PortfolioManager must pass ``t_plus_one_enabled``.
 

--- a/dashboard/backend/tests/test_backtest_run_provenance.py
+++ b/dashboard/backend/tests/test_backtest_run_provenance.py
@@ -36,7 +36,12 @@ from dashboard.backend.domain.backtesting.provenance import (
     run_decision_provenance,
 )
 from dashboard.backend.domain.leaderboard import service as leaderboard_service
-from dashboard.backend.tests._frontend_source import APP_JS, fn_body, strip_comments
+from dashboard.backend.tests._frontend_source import (
+    APP_HTML,
+    APP_JS,
+    fn_body,
+    strip_comments,
+)
 
 
 # ===========================================================================
@@ -127,6 +132,19 @@ def test_a_missing_denominator_still_catches_the_total_fallback():
         llm_decisions=0,
         decision_steps=None,
     ) == DECISION_PROVENANCE_RULE_BASED
+
+
+def test_a_usage_blind_provider_is_not_mistaken_for_a_fallback():
+    """``llm_calls`` only ticks for a response whose usage could be read
+    (``PortfolioManager._record_llm_usage``), so a provider that reports none
+    yields 0 calls on a run the model drove every step of. Reading that as
+    rule-based is the same lie in the other direction."""
+    assert classify_decision_provenance(
+        llm_model="claude-haiku-4-5",
+        llm_calls=0,
+        llm_decisions=30,
+        decision_steps=30,
+    ) == DECISION_PROVENANCE_LLM
 
 
 def test_the_threshold_has_exactly_one_owner():
@@ -244,6 +262,109 @@ def test_a_row_without_the_witness_reports_unknown():
 
 def test_no_row_yields_no_block():
     assert run_decision_provenance(None) is None
+
+
+# ===========================================================================
+# The N-of-M badge, and why its bar is not the H6 bar
+# ===========================================================================
+
+def test_a_publishable_run_still_badges_below_one_hundred_percent():
+    """The acceptance criterion, and the whole reason the badge is driven by
+    the counts rather than by the verdict.
+
+    159/161 clears MIN_LLM_DECISION_COVERAGE, so the leaderboard would publish
+    it and the verdict stays ``llm``. The user still paid for two steps the
+    model did not answer, and "may this publish" is not the same question as
+    "should the user be told something degraded".
+    """
+    block = run_decision_provenance(
+        _row(
+            llm_calls=161,
+            llm_decisions=159,
+            metadata={"decision_source": "llm", "decision_steps": 161},
+        )
+    )
+
+    assert block["decision_provenance"] == DECISION_PROVENANCE_LLM
+    assert block["decision_fallback"] is False
+    assert block["decision_badge"] == "159 of 161 steps model-driven"
+    assert block["decision_note"] is not None
+
+
+def test_full_coverage_shows_no_badge():
+    assert run_decision_provenance(_row())["decision_badge"] is None
+
+
+def test_the_badge_fires_on_a_single_held_step():
+    """One step short of 100% is still short of 100%. The bar is equality, so
+    there is no second threshold here to drift away from the first."""
+    block = run_decision_provenance(
+        _row(
+            llm_calls=30,
+            llm_decisions=29,
+            metadata={"decision_source": "llm", "decision_steps": 30},
+        )
+    )
+    assert block["decision_badge"] == "29 of 30 steps model-driven"
+
+
+def test_a_total_fallback_badges_zero_of_n():
+    block = run_decision_provenance(
+        _row(llm_decisions=0, metadata={"decision_source": "llm", "decision_steps": 30})
+    )
+    assert block["decision_badge"] == "0 of 30 steps model-driven"
+
+
+def test_an_intentional_rule_based_run_shows_no_coverage_ratio():
+    """There is no model coverage to report a ratio about -- the caller asked
+    for none. The note already labels the run."""
+    block = run_decision_provenance(
+        _row(
+            llm_model="rule-based",
+            llm_calls=0,
+            llm_decisions=0,
+            metadata={"decision_source": "rule_based", "decision_steps": 30},
+        )
+    )
+    assert block["decision_badge"] is None
+    assert block["decision_note"] == "Rule-based strategy — no model decisions."
+
+
+def test_a_row_without_the_witness_shows_no_badge():
+    """A ratio invented out of a defaulted 0 would read as a finding."""
+    block = run_decision_provenance(
+        _row(llm_decisions=0, metadata={"data_source": "alpaca"})
+    )
+    assert block["decision_badge"] is None
+
+
+def test_the_badge_bar_and_the_publish_bar_are_different_numbers():
+    """Pins the asymmetry itself, not one example of it.
+
+    Sweeping the whole coverage range: every run short of 100% badges, while
+    only runs under MIN_LLM_DECISION_COVERAGE lose the ``llm`` verdict. A
+    change that collapsed the two would break this and nothing else.
+    """
+    steps = 100
+    badged = set()
+    verdicts = {}
+    for decisions in range(steps + 1):
+        block = run_decision_provenance(
+            _row(
+                llm_calls=steps,
+                llm_decisions=decisions,
+                metadata={"decision_source": "llm", "decision_steps": steps},
+            )
+        )
+        if block["decision_badge"]:
+            badged.add(decisions)
+        verdicts[decisions] = block["decision_provenance"]
+
+    assert badged == set(range(steps))            # everything below 100%
+    assert steps not in badged                    # and nothing at it
+    publishable = {n for n, v in verdicts.items() if v == DECISION_PROVENANCE_LLM}
+    assert min(publishable) == 95                 # the H6 bar, not 100
+    assert publishable < badged | {steps}         # strictly the looser test
 
 
 # ===========================================================================
@@ -484,6 +605,97 @@ def test_status_never_answers_with_another_runs_provenance(status_mirror):
     assert again.json()["decision_provenance"] == DECISION_PROVENANCE_RULE_BASED
 
 
+def test_status_carries_the_badge_for_a_publishable_but_degraded_run(status_mirror):
+    """Coverage over the H6 bar and under 100%: no fallback warning, but the
+    user is still told two steps were not model-driven."""
+    session_id = str(uuid.uuid4())
+    body = _finished_status(
+        status_mirror,
+        session_id,
+        f"agent_{uuid.uuid4().hex[:8]}",
+        llm_model="claude-haiku-4-5",
+        llm_calls=161,
+        llm_decisions=159,
+        metadata={"decision_source": "llm", "decision_steps": 161},
+    )
+
+    assert body["decision_provenance"] == DECISION_PROVENANCE_LLM
+    assert body["decision_fallback"] is False
+    assert body["decision_badge"] == "159 of 161 steps model-driven"
+    assert body["llm_decisions"] == 159 and body["decision_steps"] == 161
+
+
+# ===========================================================================
+# The badge survives the poll: it rides the run record too
+# ===========================================================================
+
+def test_the_run_record_carries_the_verdict_and_the_counts():
+    """``/backtest/status`` is transient -- the panel it feeds is gone seconds
+    after the run ends and never comes back on a reload. The results view reads
+    the run record, so the badge has to live there or it is not really on the
+    result at all."""
+    session_id = str(uuid.uuid4())
+    run_id = f"agent_{uuid.uuid4().hex[:8]}"
+    db.insert_run(
+        run_id=run_id,
+        session_id=session_id,
+        agent_name="Agent",
+        mode="backtest",
+        start_date="2026-03-01",
+        end_date="2026-04-01",
+        initial_equity=100000.0,
+        final_equity=101000.0,
+        total_return=0.01,
+        llm_model="claude-haiku-4-5",
+        llm_calls=30,
+        llm_decisions=10,
+        metadata={"decision_source": "llm", "decision_steps": 30},
+    )
+
+    resp = TestClient(app).get(
+        "/api/backtest/runs", headers={"X-Session-Id": session_id}
+    )
+    assert resp.status_code == 200, resp.text
+    record = next(r for r in resp.json() if r["run_id"] == run_id)
+
+    assert record["decision_source"] == "llm"        # asked for
+    assert record["decision_provenance"] == DECISION_PROVENANCE_PARTIAL  # got
+    assert record["decision_badge"] == "10 of 30 steps model-driven"
+    assert record["decision_fallback"] is True
+    assert record["llm_calls"] == 30
+    assert record["llm_decisions"] == 10
+    assert record["decision_steps"] == 30
+
+
+def test_the_run_record_keeps_requested_and_observed_apart():
+    """`decision_source` on this model already meant "what was requested"
+    before this feature. The provenance block is applied after the metadata
+    copy and must not overwrite it with the observed verdict."""
+    session_id = str(uuid.uuid4())
+    run_id = f"agent_{uuid.uuid4().hex[:8]}"
+    db.insert_run(
+        run_id=run_id,
+        session_id=session_id,
+        agent_name="Agent",
+        mode="backtest",
+        start_date="2026-03-01",
+        end_date="2026-04-01",
+        initial_equity=100000.0,
+        llm_model="claude-haiku-4-5",
+        llm_calls=30,
+        llm_decisions=0,
+        metadata={"decision_source": "llm", "decision_steps": 30},
+    )
+
+    resp = TestClient(app).get(
+        "/api/backtest/runs", headers={"X-Session-Id": session_id}
+    )
+    record = next(r for r in resp.json() if r["run_id"] == run_id)
+
+    assert record["decision_source"] == "llm"
+    assert record["decision_provenance"] == DECISION_PROVENANCE_RULE_BASED
+
+
 # ===========================================================================
 # /app renders it
 # ===========================================================================
@@ -502,6 +714,26 @@ def test_a_fallback_run_does_not_auto_hide_the_panel():
     # The auto-hide must be *inside* that guard, not beside it.
     guarded = body[body.index("backtestFellBackFromTheModel(status)"):]
     assert guarded.index("showBacktestRunProgress(false), 2500") < guarded.index("} else {")
+
+
+def test_the_results_view_renders_the_coverage_badge():
+    """The persistent half: a cell on the run's own config panel, so the
+    N-of-M indicator is still there after the completion panel is gone."""
+    assert 'id="backtestConfigDecisionCoverageRow"' in APP_HTML
+    assert 'id="backtestConfigDecisionCoverage"' in APP_HTML
+    body = strip_comments(fn_body("function renderBacktestRunConfig"))
+    assert "run?.decision_badge" in body
+    assert "coverageRow.hidden = !coverageBadge" in body
+
+
+def test_the_browser_owns_no_coverage_threshold():
+    """The badge's bar is equality with the step count and the verdict's bar is
+    the server's constant. Neither is a number the frontend may hold: a copy of
+    0.95 here is how the dashboard and the leaderboard start disagreeing about
+    whether the model drove a run."""
+    body = strip_comments(fn_body("function renderBacktestRunConfig"))
+    assert "0.95" not in body
+    assert "MIN_LLM_DECISION_COVERAGE" not in strip_comments(APP_JS)
 
 
 def test_the_browser_does_not_compose_its_own_provenance_copy():

--- a/dashboard/backend/tests/test_backtest_run_provenance.py
+++ b/dashboard/backend/tests/test_backtest_run_provenance.py
@@ -17,6 +17,9 @@ the in-process H6 guard that would have caught it never sees the run.
 """
 
 import copy
+import json
+import shutil
+import subprocess
 import uuid
 
 import pytest
@@ -39,6 +42,7 @@ from dashboard.backend.tests._frontend_source import (
     APP_HTML,
     APP_JS,
     fn_body,
+    js_const,
     strip_comments,
 )
 
@@ -233,6 +237,77 @@ def test_an_intentional_rule_based_run_is_labelled_but_not_a_fallback():
     assert block["decision_provenance"] == DECISION_PROVENANCE_RULE_BASED
     assert block["decision_fallback"] is False
     assert "fell back" not in block["decision_note"]
+
+
+def test_a_silently_downgraded_run_is_a_fallback_not_a_choice():
+    """The run this whole feature is named for, and the one shape that got it
+    backwards.
+
+    Both LLM-availability downgrades in the engine rewrite `decision_source` to
+    rule_based, so the row a silent fallback writes carries the *outcome* under
+    the name that is supposed to carry the *request*. Read that way, the worst
+    case in the system -- asked for a model, never called one -- reported as an
+    intentional rule-based run, with no badge and a note telling the user this
+    is what they ordered. The request is recorded under its own key so the two
+    can disagree, which is the entire point of the block.
+    """
+    block = run_decision_provenance(
+        _row(
+            llm_model="rule-based",
+            llm_calls=0,
+            llm_decisions=0,
+            metadata={
+                "decision_source": "rule_based",        # what it did
+                "requested_decision_source": "llm",     # what it was asked
+                "decision_steps": 30,
+            },
+        )
+    )
+
+    assert block["decision_source"] == "llm"
+    assert block["decision_provenance"] == DECISION_PROVENANCE_RULE_BASED
+    assert block["decision_fallback"] is True
+    assert "fell back" in block["decision_note"]
+    # And the ratio is no longer suppressed as "nothing to report about a
+    # rule-based run": zero of thirty is the finding.
+    assert block["decision_badge"] == "0 of 30 steps model-driven"
+
+
+def test_an_intentional_rule_based_run_records_the_same_source_twice():
+    """The other half of the same key. A caller that ordered rule-based logic
+    got what it ordered, and the *only* thing separating that row from the
+    fallback above is these two fields agreeing."""
+    block = run_decision_provenance(
+        _row(
+            llm_model="rule-based",
+            llm_calls=0,
+            llm_decisions=0,
+            metadata={
+                "decision_source": "rule_based",
+                "requested_decision_source": "rule_based",
+                "decision_steps": 30,
+            },
+        )
+    )
+
+    assert block["decision_source"] == "rule_based"
+    assert block["decision_fallback"] is False
+    assert block["decision_badge"] is None
+    assert "fell back" not in block["decision_note"]
+
+
+def test_a_row_written_before_the_request_key_reads_the_source_it_has():
+    """Rows already in the database carry only `decision_source`, and for a run
+    that was never downgraded it *is* the request. Withholding the verdict from
+    them would trade one wrong answer for no answer on every historical row;
+    the rows this cannot speak for are the downgraded ones, which are also the
+    rows that never recorded the question."""
+    block = run_decision_provenance(
+        _row(llm_decisions=0, metadata={"decision_source": "llm", "decision_steps": 30})
+    )
+
+    assert block["decision_source"] == "llm"
+    assert block["decision_fallback"] is True
 
 
 def test_a_clean_run_gets_no_note():
@@ -705,14 +780,117 @@ def test_the_success_branch_renders_the_verdict():
     assert "formatDecisionProvenance(status)" in body
 
 
-def test_a_fallback_run_does_not_auto_hide_the_panel():
-    """2.5s is not long enough to read a sentence nobody expected, and the
-    numbers loadData() has just painted stay on screen afterwards."""
+def _settle(status):
+    """Run the completion branch's panel decision under node, as it is actually
+    reached: after loadData() has already hidden the panel.
+
+    Executed rather than grepped because the first cut of this guard asserted
+    the *shape* of the branch -- a `if (!backtestFellBackFromTheModel(status))`
+    wrapping the dismissal timer -- and that shape was satisfied by code which
+    could not work. `await loadData()` runs first and hides this panel on its
+    way past, so withholding the 2.5s timeout withheld a hide from an
+    already-hidden panel, and the fallback sentence the branch existed to keep
+    on screen was never on screen. A source-shape assertion cannot see that;
+    only running the thing against a panel loadData() has just hidden can.
+
+    Returns the panel state a user would be looking at once the dismissal
+    timer, if one was scheduled, has fired.
+    """
+    harness = """
+        let panelVisible = false;   // loadData() has just hidden it
+        let panelMessage = 'Completed in 1:01.';
+        let panelFinished = false;
+        const timers = [];
+        function showBacktestRunProgress(show, { isFinished = false } = {}) {
+            panelVisible = !!show;
+            panelFinished = !!isFinished;
+        }
+        function updateBacktestRunProgress({ message }) {
+            if (message) panelMessage = message;
+        }
+        globalThis.setTimeout = (fn) => { timers.push(fn); };
+    """
+    script = "\n".join(
+        [
+            js_const("BACKTEST_COMPLETION_DISMISS_MS"),
+            fn_body("function backtestFellBackFromTheModel"),
+            fn_body("function settleFinishedBacktestPanel"),
+            harness,
+            f"settleFinishedBacktestPanel({json.dumps(status)}, 61, "
+            f"{json.dumps(_COMPLETION_MESSAGE)});",
+            "const scheduled = timers.length;",
+            "timers.forEach((fn) => fn());",   # the dismissal timeout elapses
+            "console.log(JSON.stringify("
+            "{ panelVisible, panelMessage, panelFinished, scheduled }));",
+        ]
+    )
+    result = subprocess.run(
+        ["node", "-e", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+_COMPLETION_MESSAGE = (
+    "Completed in 1:01. No step used the model \u2014 every decision fell back "
+    "to rule-based logic."
+)
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+def test_a_fallback_run_still_has_its_panel_up_after_loaddata_hid_it():
+    """The load-bearing case: loadData() has already hidden the panel, so the
+    branch has to put it back rather than decline to take it down."""
+    settled = _settle({"success": True, "decision_fallback": True})
+
+    assert settled["panelVisible"] is True
+    assert settled["panelMessage"] == _COMPLETION_MESSAGE
+    assert settled["scheduled"] == 0   # and nothing is queued to take it away
+    # A panel that outlives its run must stop describing one in flight: the
+    # markup's defaults are "Backtest in progress", a progress track and a
+    # hint about the 60-minute limit, all of which were only ever true while
+    # something was still happening.
+    assert settled["panelFinished"] is True
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+def test_a_clean_run_dismisses_itself():
+    """The other half. A run the model drove says only that it finished, which
+    the results loadData() has just painted say better."""
+    settled = _settle({"success": True, "decision_fallback": False})
+
+    assert settled["panelVisible"] is False
+    assert settled["scheduled"] == 1
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+def test_a_run_that_predates_the_provenance_fields_dismisses_itself():
+    """A status payload from a backend that does not send `decision_fallback`
+    is not a fallback. Treating "no answer" as "yes" would pin the panel open
+    on every run during a rolling deploy."""
+    settled = _settle({"success": True})
+
+    assert settled["panelVisible"] is False
+    assert settled["scheduled"] == 1
+
+
+def test_a_finished_panel_stops_advertising_a_run_in_flight():
+    """`isFinished` has to reach the three elements the markup defaults for a
+    running backtest -- the title, the progress track and the wait hint. The
+    elapsed clock is deliberately not one of them: on a finished run it is the
+    duration."""
+    body = strip_comments(fn_body("function showBacktestRunProgress"))
+    assert "'Backtest complete'" in body
+    assert "track.hidden = isError || isFinished" in body
+    assert "hint.hidden = isError || isFinished" in body
+    assert "elapsed.hidden = !!isError" in body
+
+
+def test_the_panel_is_settled_after_loaddata_not_before():
+    """The ordering is the whole bug. Settling first would re-show a panel that
+    loadData() then hides, which is the same failure facing the other way."""
     body = strip_comments(fn_body("function ensureBacktestPolling"))
-    assert "if (!backtestFellBackFromTheModel(status)) {" in body
-    # The auto-hide must be *inside* that guard, not beside it.
-    guarded = body[body.index("backtestFellBackFromTheModel(status)"):]
-    assert guarded.index("showBacktestRunProgress(false), 2500") < guarded.index("} else {")
+    assert body.index("await loadData();") < body.index("settleFinishedBacktestPanel(")
 
 
 def test_the_results_view_renders_the_coverage_badge():

--- a/dashboard/backend/tests/test_backtest_run_provenance.py
+++ b/dashboard/backend/tests/test_backtest_run_provenance.py
@@ -1,0 +1,485 @@
+"""A finished backtest must say what actually produced its numbers (#169).
+
+A dashboard backtest could fall back to rule-based logic on every single step
+and still answer ``/backtest/status`` with "Backtest completed successfully".
+Two layers had to be closed, and the tests split the same way:
+
+* the run row was already honest (``llm_model`` stays ``"rule-based"`` when no
+  call ever succeeded) and nothing read it at the HTTP boundary;
+* ``llm_decisions`` -- steps the model actually drove -- was never persisted at
+  all, so the *worst* case was invisible: every step made a billed call, every
+  response was unusable, and the row reads ``llm_calls = 30``,
+  ``llm_model = "claude-..."``, which looks perfectly clean.
+
+That second case is the one this file exists for. A coverage check keyed on
+``llm_calls`` waves it through, and dashboard backtests are subprocesses, so
+the in-process H6 guard that would have caught it never sees the run.
+"""
+
+import copy
+import json
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from dashboard.backend.app import app
+from dashboard.backend.database import db
+import dashboard.backend.api.routers.backtests as bt
+from dashboard.backend.domain.backtesting import provenance
+from dashboard.backend.domain.backtesting.provenance import (
+    DECISION_PROVENANCE_LLM,
+    DECISION_PROVENANCE_PARTIAL,
+    DECISION_PROVENANCE_RULE_BASED,
+    DECISION_PROVENANCE_UNKNOWN,
+    classify_decision_provenance,
+    run_decision_provenance,
+)
+from dashboard.backend.domain.leaderboard import service as leaderboard_service
+from dashboard.backend.tests._frontend_source import APP_JS, fn_body, strip_comments
+
+
+# ===========================================================================
+# The verdict helper
+# ===========================================================================
+
+def test_every_step_billed_and_none_usable_is_rule_based():
+    """The case the two counters exist for.
+
+    ``llm_calls == decision_steps`` with ``llm_decisions == 0``: every step
+    reached the model, every response was billed, and every one of them was
+    unusable, so every step traded rule-based. Coverage keyed on ``llm_calls``
+    reports this run as 100% model-driven -- which is exactly how a curve the
+    model never drove gets published under its name.
+    """
+    assert classify_decision_provenance(
+        llm_model="claude-haiku-4-5",
+        llm_calls=30,
+        llm_decisions=0,
+        decision_steps=30,
+    ) == DECISION_PROVENANCE_RULE_BASED
+
+
+def test_a_clean_llm_run_classifies_as_llm():
+    assert classify_decision_provenance(
+        llm_model="claude-haiku-4-5",
+        llm_calls=30,
+        llm_decisions=30,
+        decision_steps=30,
+    ) == DECISION_PROVENANCE_LLM
+
+
+def test_a_run_just_over_the_threshold_is_still_llm():
+    """A genuine run absorbs a transient blip; that is what the margin is for."""
+    assert classify_decision_provenance(
+        llm_model="claude-haiku-4-5",
+        llm_calls=161,
+        llm_decisions=159,
+        decision_steps=161,
+    ) == DECISION_PROVENANCE_LLM
+
+
+def test_a_mostly_rule_based_run_classifies_as_partial():
+    assert classify_decision_provenance(
+        llm_model="claude-haiku-4-5",
+        llm_calls=30,
+        llm_decisions=10,
+        decision_steps=30,
+    ) == DECISION_PROVENANCE_PARTIAL
+
+
+def test_the_honest_rule_based_label_is_taken_at_its_word():
+    """Layer A: the engine already persists this label; nothing read it."""
+    assert classify_decision_provenance(
+        llm_model="rule-based", llm_calls=0, llm_decisions=0, decision_steps=30
+    ) == DECISION_PROVENANCE_RULE_BASED
+
+
+def test_a_model_name_beside_zero_calls_is_rule_based():
+    """The shape H6 refuses to publish: a rule-based curve wearing a name."""
+    assert classify_decision_provenance(
+        llm_model="claude-haiku-4-5",
+        llm_calls=0,
+        llm_decisions=0,
+        decision_steps=30,
+    ) == DECISION_PROVENANCE_RULE_BASED
+
+
+def test_an_unrecorded_counter_is_unknown_not_an_accusation():
+    """A row written before the column existed reads back as 0 like any other.
+
+    Reporting those as rule-based would be the same lie in the other direction
+    -- and every historical run is one of them.
+    """
+    assert classify_decision_provenance(
+        llm_model="claude-haiku-4-5",
+        llm_calls=30,
+        llm_decisions=None,
+        decision_steps=None,
+    ) == DECISION_PROVENANCE_UNKNOWN
+
+
+def test_a_missing_denominator_still_catches_the_total_fallback():
+    """Zero usable decisions is rule-based however many steps there were."""
+    assert classify_decision_provenance(
+        llm_model="claude-haiku-4-5",
+        llm_calls=30,
+        llm_decisions=0,
+        decision_steps=None,
+    ) == DECISION_PROVENANCE_RULE_BASED
+
+
+def test_the_threshold_has_exactly_one_owner():
+    """The dashboard and the leaderboard must not be able to disagree about
+    "the model drove it" -- restating 0.95 here is how they start to."""
+    assert (
+        provenance.MIN_LLM_DECISION_COVERAGE
+        is leaderboard_service.MIN_LLM_DECISION_COVERAGE
+    )
+    source = (
+        provenance.__file__
+    )
+    with open(source, encoding="utf-8") as handle:
+        text = handle.read()
+    assert "0.95" not in text
+
+
+def test_the_verdict_matches_the_h6_guard_on_the_same_numbers():
+    """Same numbers, same answer: whatever the leaderboard refuses to publish
+    as a fallback must not read as model-driven on the dashboard."""
+
+    class _LlmEntry:
+        used_llm = True
+
+    for decisions, expected_refusal in ((0, True), (10, True), (29, False)):
+        refused = False
+        try:
+            leaderboard_service._reject_if_llm_fallback(
+                "entry",
+                _LlmEntry(),
+                30,
+                llm_decisions=decisions,
+                decision_steps=30,
+            )
+        except leaderboard_service.LeaderboardFallbackError:
+            refused = True
+        assert refused is expected_refusal
+        verdict = classify_decision_provenance(
+            llm_model="claude-haiku-4-5",
+            llm_calls=30,
+            llm_decisions=decisions,
+            decision_steps=30,
+        )
+        assert (verdict != DECISION_PROVENANCE_LLM) is expected_refusal
+
+
+# ===========================================================================
+# Reading one persisted row
+# ===========================================================================
+
+def _row(**overrides):
+    row = {
+        "run_id": "agent_1",
+        "llm_model": "claude-haiku-4-5",
+        "llm_calls": 30,
+        "llm_decisions": 30,
+        "metadata": {"decision_source": "llm", "decision_steps": 30},
+    }
+    row.update(overrides)
+    return row
+
+
+def test_a_row_reports_what_was_asked_for_and_what_happened():
+    block = run_decision_provenance(
+        _row(llm_decisions=0, metadata={"decision_source": "llm", "decision_steps": 30})
+    )
+
+    assert block["decision_source"] == "llm"          # what the caller asked for
+    assert block["decision_provenance"] == DECISION_PROVENANCE_RULE_BASED
+    assert block["decision_fallback"] is True         # the two disagreeing
+    assert block["llm_calls"] == 30
+    assert block["llm_decisions"] == 0
+    assert block["decision_steps"] == 30
+    assert "fell back" in block["decision_note"]
+
+
+def test_an_intentional_rule_based_run_is_labelled_but_not_a_fallback():
+    block = run_decision_provenance(
+        _row(
+            llm_model="rule-based",
+            llm_calls=0,
+            llm_decisions=0,
+            metadata={"decision_source": "rule_based", "decision_steps": 30},
+        )
+    )
+
+    assert block["decision_provenance"] == DECISION_PROVENANCE_RULE_BASED
+    assert block["decision_fallback"] is False
+    assert "fell back" not in block["decision_note"]
+
+
+def test_a_clean_run_gets_no_note():
+    block = run_decision_provenance(_row())
+
+    assert block["decision_provenance"] == DECISION_PROVENANCE_LLM
+    assert block["decision_note"] is None
+    assert block["decision_fallback"] is False
+
+
+def test_a_row_without_the_witness_reports_unknown():
+    """``metadata.decision_steps`` is what says this row records llm_decisions.
+
+    The column was added with DEFAULT 0, so a pre-migration row comes back with
+    llm_decisions == 0 exactly like a total fallback does. Without the witness
+    every run that predates this feature would be accused of one.
+    """
+    block = run_decision_provenance(
+        _row(llm_decisions=0, metadata={"data_source": "alpaca"})
+    )
+
+    assert block["decision_provenance"] == DECISION_PROVENANCE_UNKNOWN
+    assert block["llm_decisions"] is None
+    assert block["decision_note"] is None
+
+
+def test_no_row_yields_no_block():
+    assert run_decision_provenance(None) is None
+
+
+# ===========================================================================
+# The column round-trips
+# ===========================================================================
+
+def test_llm_decisions_round_trips_through_insert_run():
+    """Distinct values on purpose: a write that dropped the new argument and
+    echoed llm_calls into it would pass with the two set equal."""
+    run_id = f"prov_{uuid.uuid4().hex[:8]}"
+    db.insert_run(
+        run_id=run_id,
+        session_id="provenance-session",
+        agent_name="Agent",
+        mode="backtest",
+        start_date="2026-03-01",
+        end_date="2026-04-01",
+        initial_equity=100000.0,
+        final_equity=101000.0,
+        total_return=0.01,
+        num_trades=3,
+        llm_model="claude-haiku-4-5",
+        llm_calls=30,
+        llm_decisions=7,
+        metadata={"decision_source": "llm", "decision_steps": 30},
+    )
+
+    stored = db.get_run(run_id)
+    assert stored["llm_calls"] == 30
+    assert stored["llm_decisions"] == 7
+    assert stored["metadata"]["decision_steps"] == 30
+    assert (
+        run_decision_provenance(stored)["decision_provenance"]
+        == DECISION_PROVENANCE_PARTIAL
+    )
+
+
+def test_insert_run_defaults_llm_decisions_for_callers_that_have_none():
+    """Baselines and paper trading call insert_run without it and must not
+    start failing; their rows are rule-based by construction anyway."""
+    run_id = f"prov_{uuid.uuid4().hex[:8]}"
+    db.insert_run(
+        run_id=run_id,
+        session_id="provenance-session",
+        agent_name="buy-and-hold",
+        mode="backtest",
+        start_date="2026-03-01",
+        end_date="2026-04-01",
+        initial_equity=100000.0,
+    )
+
+    assert db.get_run(run_id)["llm_decisions"] == 0
+
+
+# ===========================================================================
+# GET /backtest/status
+# ===========================================================================
+
+@pytest.fixture
+def status_mirror():
+    """Save/restore the legacy ``backtest_status`` mirror this route falls back
+    to when no slot is registered (the shape the existing router tests use)."""
+    original = copy.deepcopy(bt.backtest_status)
+    yield bt.backtest_status
+    bt.backtest_status.clear()
+    bt.backtest_status.update(original)
+
+
+def _finished_status(status_mirror, session_id, run_id, **run_kwargs):
+    db.insert_run(
+        run_id=run_id,
+        session_id=session_id,
+        agent_name="Agent",
+        mode="backtest",
+        start_date="2026-03-01",
+        end_date="2026-04-01",
+        initial_equity=100000.0,
+        final_equity=101000.0,
+        total_return=0.01,
+        **run_kwargs,
+    )
+    status_mirror.update({
+        "running": False,
+        "error": None,
+        "runs_count": 1,
+        "started_at": None,
+        "progress_file": None,
+        "live_run_id": run_id,
+    })
+    resp = TestClient(app).get(
+        "/backtest/status", headers={"X-Session-Id": session_id}
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def test_status_cannot_report_a_silent_fallback_as_a_clean_success(status_mirror):
+    """The bug, end to end: every step billed, none usable, reported clean."""
+    session_id = str(uuid.uuid4())
+    body = _finished_status(
+        status_mirror,
+        session_id,
+        f"agent_{uuid.uuid4().hex[:8]}",
+        llm_model="claude-haiku-4-5",
+        llm_calls=30,
+        llm_decisions=0,
+        metadata={"decision_source": "llm", "decision_steps": 30},
+    )
+
+    assert body["success"] is True
+    assert body["decision_provenance"] == DECISION_PROVENANCE_RULE_BASED
+    assert body["decision_fallback"] is True
+    assert body["llm_calls"] == 30
+    assert body["llm_decisions"] == 0
+    assert body["decision_steps"] == 30
+    assert body["message"] != "Backtest completed successfully"
+    assert "fell back" in body["message"]
+
+
+def test_status_keeps_every_field_it_already_had(status_mirror):
+    """Additive only: app.js and the legacy surface both poll this route."""
+    session_id = str(uuid.uuid4())
+    run_id = f"agent_{uuid.uuid4().hex[:8]}"
+    body = _finished_status(
+        status_mirror,
+        session_id,
+        run_id,
+        llm_model="claude-haiku-4-5",
+        llm_calls=30,
+        llm_decisions=30,
+        metadata={"decision_source": "llm", "decision_steps": 30},
+    )
+
+    assert body["running"] is False
+    assert body["success"] is True
+    assert body["runs_count"] == 1
+    assert body["session_id"] == session_id
+    assert body["live_run_id"] == run_id
+    assert body["message"] == "Backtest completed successfully"
+    assert body["decision_provenance"] == DECISION_PROVENANCE_LLM
+    assert body["decision_note"] is None
+
+
+def test_status_reports_a_partial_fallback(status_mirror):
+    session_id = str(uuid.uuid4())
+    body = _finished_status(
+        status_mirror,
+        session_id,
+        f"agent_{uuid.uuid4().hex[:8]}",
+        llm_model="claude-haiku-4-5",
+        llm_calls=30,
+        llm_decisions=10,
+        metadata={"decision_source": "llm", "decision_steps": 30},
+    )
+
+    assert body["decision_provenance"] == DECISION_PROVENANCE_PARTIAL
+    assert body["decision_fallback"] is True
+    assert "10 of 30" in body["message"]
+
+
+def test_status_does_not_accuse_a_run_that_predates_the_counter(status_mirror):
+    session_id = str(uuid.uuid4())
+    body = _finished_status(
+        status_mirror,
+        session_id,
+        f"agent_{uuid.uuid4().hex[:8]}",
+        llm_model="claude-haiku-4-5",
+        llm_calls=30,
+        metadata={"data_source": "alpaca"},
+    )
+
+    assert body["decision_provenance"] == DECISION_PROVENANCE_UNKNOWN
+    assert body["message"] == "Backtest completed successfully"
+
+
+def test_status_never_answers_with_another_runs_provenance(status_mirror):
+    """A baseline row is inserted *after* the agent run and carries no witness.
+
+    ``get_runs_by_session`` is newest-first, so a fallback that simply took the
+    first row would report the DJIA baseline's counters as the agent's.
+    """
+    session_id = str(uuid.uuid4())
+    agent_run = f"agent_{uuid.uuid4().hex[:8]}"
+    body = _finished_status(
+        status_mirror,
+        session_id,
+        agent_run,
+        llm_model="claude-haiku-4-5",
+        llm_calls=30,
+        llm_decisions=0,
+        metadata={"decision_source": "llm", "decision_steps": 30},
+    )
+    assert body["decision_provenance"] == DECISION_PROVENANCE_RULE_BASED
+
+    db.insert_run(
+        run_id=f"djia_index_{uuid.uuid4().hex[:8]}",
+        session_id=session_id,
+        agent_name="DJIA",
+        mode="backtest",
+        start_date="2026-03-01",
+        end_date="2026-04-01",
+        initial_equity=100000.0,
+        metadata={"data_source": "alpaca"},
+    )
+    again = TestClient(app).get(
+        "/backtest/status", headers={"X-Session-Id": session_id}
+    )
+    assert again.json()["decision_provenance"] == DECISION_PROVENANCE_RULE_BASED
+
+
+# ===========================================================================
+# /app renders it
+# ===========================================================================
+
+def test_the_success_branch_renders_the_verdict():
+    """A finished run's only "what produced this" surface is this panel."""
+    body = strip_comments(fn_body("function ensureBacktestPolling"))
+    assert "formatDecisionProvenance(status)" in body
+
+
+def test_a_fallback_run_does_not_auto_hide_the_panel():
+    """2.5s is not long enough to read a sentence nobody expected, and the
+    numbers loadData() has just painted stay on screen afterwards."""
+    body = strip_comments(fn_body("function ensureBacktestPolling"))
+    assert "if (!backtestFellBackFromTheModel(status)) {" in body
+    # The auto-hide must be *inside* that guard, not beside it.
+    guarded = body[body.index("backtestFellBackFromTheModel(status)"):]
+    assert guarded.index("showBacktestRunProgress(false), 2500") < guarded.index("} else {")
+
+
+def test_the_browser_does_not_compose_its_own_provenance_copy():
+    """One message, one owner. A template here would drift from the server's
+    wording the first time either side is edited."""
+    body = strip_comments(fn_body("function formatDecisionProvenance"))
+    assert "status?.decision_note" in body
+    # The wording lives on the server; a copy of it here is a second owner.
+    shipped = strip_comments(APP_JS)
+    for phrase in ("fell back to rule-based logic", "no model decisions"):
+        assert phrase not in shipped

--- a/dashboard/backend/tests/test_backtest_run_provenance.py
+++ b/dashboard/backend/tests/test_backtest_run_provenance.py
@@ -816,12 +816,19 @@ def _settle(status):
             fn_body("function backtestFellBackFromTheModel"),
             fn_body("function settleFinishedBacktestPanel"),
             harness,
-            f"settleFinishedBacktestPanel({json.dumps(status)}, 61, "
-            f"{json.dumps(_COMPLETION_MESSAGE)});",
+            # Parenthesised: an implicit concatenation between two list items
+            # is indistinguishable from a missing comma, which here would
+            # silently drop a statement from the script instead of failing.
+            (
+                f"settleFinishedBacktestPanel({json.dumps(status)}, 61, "
+                f"{json.dumps(_COMPLETION_MESSAGE)});"
+            ),
             "const scheduled = timers.length;",
             "timers.forEach((fn) => fn());",   # the dismissal timeout elapses
-            "console.log(JSON.stringify("
-            "{ panelVisible, panelMessage, panelFinished, scheduled }));",
+            (
+                "console.log(JSON.stringify("
+                "{ panelVisible, panelMessage, panelFinished, scheduled }));"
+            ),
         ]
     )
     result = subprocess.run(

--- a/dashboard/backend/tests/test_backtest_run_provenance.py
+++ b/dashboard/backend/tests/test_backtest_run_provenance.py
@@ -281,6 +281,36 @@ def test_llm_decisions_round_trips_through_insert_run():
     )
 
 
+def test_the_postgres_backfill_carries_llm_decisions():
+    """The SQLite -> Postgres copy must not drop the counter.
+
+    0 is also what a row with no counter reads as, so a backfill that omitted
+    it would republish every migrated LLM run as a total fallback.
+    """
+    from dashboard.scripts import backfill_runs_to_postgres as backfill
+
+    captured: dict = {}
+
+    class _Target:
+        def insert_run(self, **kwargs):
+            captured.update(kwargs)
+
+    backfill._insert_one_run(_Target(), {
+        "run_id": "r",
+        "session_id": "s",
+        "agent_name": "Agent",
+        "mode": "backtest",
+        "start_date": "2026-03-01",
+        "end_date": "2026-04-01",
+        "initial_equity": 100000.0,
+        "llm_calls": 30,
+        "llm_decisions": 29,
+    })
+
+    assert captured["llm_calls"] == 30
+    assert captured["llm_decisions"] == 29
+
+
 def test_insert_run_defaults_llm_decisions_for_callers_that_have_none():
     """Baselines and paper trading call insert_run without it and must not
     start failing; their rows are rule-based by construction anyway."""

--- a/dashboard/backend/tests/test_backtest_run_provenance.py
+++ b/dashboard/backend/tests/test_backtest_run_provenance.py
@@ -17,7 +17,6 @@ the in-process H6 guard that would have caught it never sees the run.
 """
 
 import copy
-import json
 import uuid
 
 import pytest

--- a/dashboard/backend/tests/test_database_lazy_migrations.py
+++ b/dashboard/backend/tests/test_database_lazy_migrations.py
@@ -36,6 +36,7 @@ from dashboard.backend.database import BacktestDatabase
 # string default keeps its quotes.
 _TOKEN_COLUMNS = {
     "llm_calls": ("INTEGER", 0, "0"),
+    "llm_decisions": ("INTEGER", 0, "0"),
     "input_tokens": ("INTEGER", 0, "0"),
     "output_tokens": ("INTEGER", 0, "0"),
     "est_cost_usd": ("REAL", 0, "0"),

--- a/dashboard/backend/tests/test_ifind_ashare_frontend.py
+++ b/dashboard/backend/tests/test_ifind_ashare_frontend.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 import pytest
 
+from dashboard.backend.tests._frontend_source import fn_body, strip_comments
+
 
 _FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
 _APP_HTML = _FRONTEND / "app.html"
@@ -346,7 +348,14 @@ def test_backtest_launch_failure_remains_visible_instead_of_loading_history(js):
     assert re.search(r"function\s+showBacktestLaunchFailure\s*\(", js)
     assert "statusLabel: 'Failed'" in js
     assert "Backtest did not start." in js
-    assert "isError ? 'Backtest did not start' : 'Backtest in progress'" in js
+    # A failed launch retitles the panel, so the error state is never shown
+    # under "Backtest in progress". Asserted as the branch rather than as one
+    # ternary's spelling: the same helper grew a third title ("Backtest
+    # complete", for a panel that outlives its run) and an exact-source match
+    # failed on a change that kept this contract intact.
+    panel = strip_comments(fn_body("function showBacktestRunProgress", js))
+    assert "if (isError) title.textContent = 'Backtest did not start';" in panel
+    assert "title.textContent = 'Backtest in progress';" in panel
     assert re.search(
         r"!runningId\s*&&\s*\(liveBacktestLaunchPending\s*\|\|\s*liveBacktestLaunchError\)",
         js,

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -1250,6 +1250,7 @@
                                 <div class="backtest-config-detail-cell"><span>Symbols</span><strong id="backtestConfigSymbols">—</strong></div>
                                 <div class="backtest-config-detail-cell"><span>Decision bars</span><strong id="backtestConfigTimeframe">—</strong></div>
                                 <div class="backtest-config-detail-cell"><span>Decision method</span><strong id="backtestConfigDecisionSource">—</strong></div>
+                                <div class="backtest-config-detail-cell" id="backtestConfigDecisionCoverageRow" hidden><span>Model coverage</span><strong id="backtestConfigDecisionCoverage">—</strong></div>
                                 <div class="backtest-config-detail-cell"><span>Status</span><strong id="backtestConfigStatus">—</strong></div>
                                 <div class="backtest-config-detail-cell" id="backtestConfigFrequencyRow" hidden><span>Data cadence</span><strong id="backtestConfigFrequency">—</strong></div>
                                 <div class="backtest-config-detail-cell" id="backtestConfigDataQualityRow" hidden><span>Data quality</span><strong id="backtestConfigDataQuality">—</strong></div>

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -7305,6 +7305,37 @@ function formatBacktestElapsed(seconds) {
 /** A progress file older than this is reported as stale (seconds). */
 const BACKTEST_STALE_SECONDS = 120;
 
+/**
+ * What actually drove a finished run, or null when there is nothing to say.
+ *
+ * The sentence comes from the server (`decision_note`) rather than being
+ * templated here from the same counters: one message with two owners disagrees
+ * the moment either side's wording moves, and "the dashboard and the backend
+ * describe this run differently" is the bug one layer up from the one this
+ * exists to fix (issue #169).
+ *
+ * Null for a clean `llm` run — it already reads "Completed in 1:23." and a line
+ * confirming the model drove it adds nothing — and null for `unknown`, a run
+ * written before the counters existed, which must not be accused of a fallback
+ * nobody recorded.
+ */
+function formatDecisionProvenance(status) {
+    return status?.decision_note || null;
+}
+
+/**
+ * True when the run asked for the model and did not get it.
+ *
+ * Reads the server's `decision_fallback` instead of comparing
+ * `decision_source` against `decision_provenance` here, so "was this a
+ * fallback?" keeps one owner. An intentionally rule-based run is not one: it
+ * is labelled, but it is also exactly what was ordered, so it does not hold the
+ * completion panel open.
+ */
+function backtestFellBackFromTheModel(status) {
+    return status?.decision_fallback === true;
+}
+
 /** The /backtest/status URL for one run, or for "whatever this browser runs".
  *
  * Three callers build this URL and the interesting half is what happens when
@@ -8120,9 +8151,13 @@ function ensureBacktestPolling() {
                         message,
                     });
                 } else if (status.success) {
+                    const provenance = formatDecisionProvenance(status);
                     updateBacktestRunProgress({
                         elapsedSeconds: displayElapsed,
-                        message: `Completed in ${formatBacktestElapsed(displayElapsed)}.`,
+                        message: [
+                            `Completed in ${formatBacktestElapsed(displayElapsed)}.`,
+                            provenance,
+                        ].filter(Boolean).join(' '),
                     });
                     if (finishedId) {
                         localStorage.setItem(SELECTED_BACKTEST_RUN_KEY, finishedId);
@@ -8130,7 +8165,13 @@ function ensureBacktestPolling() {
                         localStorage.removeItem(SELECTED_BACKTEST_RUN_KEY);
                     }
                     await loadData();
-                    setTimeout(() => showBacktestRunProgress(false), 2500);
+                    // A run the model never drove keeps the panel up. This is
+                    // the only surface that says what produced the numbers
+                    // loadData() has just painted, and 2.5s is not long enough
+                    // to read a sentence the user was not expecting.
+                    if (!backtestFellBackFromTheModel(status)) {
+                        setTimeout(() => showBacktestRunProgress(false), 2500);
+                    }
                 } else {
                     showBacktestRunProgress(false);
                 }

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -9336,6 +9336,25 @@ function renderBacktestRunConfig(
         'backtestConfigDecisionSource',
         decisionSourceLabel,
     );
+    // "N of M steps model-driven", beside the decision method the run asked
+    // for. The server sends the label only when coverage is below 100% and the
+    // run actually asked for a model, so this cell appearing at all IS the
+    // signal -- there is no threshold reproduced here, and none to drift.
+    const coverageBadge = running ? null : (run?.decision_badge || null);
+    const coverageRow = document.getElementById('backtestConfigDecisionCoverageRow');
+    if (coverageRow) {
+        coverageRow.hidden = !coverageBadge;
+        // Degraded styling only once the shortfall is large enough that the
+        // leaderboard would refuse the curve. A couple of held steps on an
+        // otherwise clean run is worth stating, not worth alarming about.
+        coverageRow.classList.toggle(
+            'is-degraded',
+            Boolean(coverageBadge) && run?.decision_provenance !== LLM_DECISION_SOURCE,
+        );
+    }
+    if (coverageBadge) {
+        setBacktestConfigText('backtestConfigDecisionCoverage', coverageBadge);
+    }
     setBacktestConfigText(
         'backtestConfigWindow',
         start && end ? `${start} → ${end}` : '—',

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -7336,6 +7336,37 @@ function backtestFellBackFromTheModel(status) {
     return status?.decision_fallback === true;
 }
 
+/** How long a clean completion message stays up before the panel dismisses. */
+const BACKTEST_COMPLETION_DISMISS_MS = 2500;
+
+/**
+ * Settle the completion panel for a run that has just finished.
+ *
+ * Called *after* `await loadData()`, and it re-shows the panel rather than
+ * only withholding the dismissal timer, because loadData() hides this panel on
+ * its way past: with the finished run no longer reported as running, its
+ * backtest branch falls through to `showBacktestRunProgress(false)`
+ * unconditionally. A guard that merely skipped the timeout therefore read as
+ * "keep the panel up" and kept nothing up -- the sentence was already off
+ * screen, and the timer it skipped would have fired against a hidden panel.
+ * Nothing about that is visible at the call site, which is why the decision
+ * lives here where it can be executed by a test instead of read.
+ *
+ * A clean run still auto-dismisses: its message only says the run finished,
+ * which the results loadData() has just painted say better.
+ */
+function settleFinishedBacktestPanel(status, elapsedSeconds, message) {
+    if (!backtestFellBackFromTheModel(status)) {
+        setTimeout(
+            () => showBacktestRunProgress(false),
+            BACKTEST_COMPLETION_DISMISS_MS,
+        );
+        return;
+    }
+    showBacktestRunProgress(true, { isFinished: true });
+    updateBacktestRunProgress({ elapsedSeconds, message });
+}
+
 /** The /backtest/status URL for one run, or for "whatever this browser runs".
  *
  * Three callers build this URL and the interesting half is what happens when
@@ -7630,7 +7661,18 @@ function deriveRunningProgress(running) {
     };
 }
 
-function showBacktestRunProgress(show, { isError = false } = {}) {
+/**
+ * `isFinished` is for a panel that outlives the run it describes.
+ *
+ * Every other caller shows this panel while something is still happening, so
+ * the markup's defaults -- the title "Backtest in progress", a progress track,
+ * and a hint about the 60-minute limit -- were always true for as long as it
+ * was on screen. A fallback run now holds the panel open indefinitely after
+ * the run is over (see `settleFinishedBacktestPanel`), and those three would
+ * otherwise sit under a finished backtest telling the user to keep waiting for
+ * it. The elapsed clock stays: on a finished run it is the duration.
+ */
+function showBacktestRunProgress(show, { isError = false, isFinished = false } = {}) {
     const panel = document.getElementById('backtestRunProgress');
     if (!panel) return;
     panel.hidden = !show;
@@ -7639,10 +7681,14 @@ function showBacktestRunProgress(show, { isError = false } = {}) {
     const elapsed = panel.querySelector('.backtest-run-elapsed');
     const track = panel.querySelector('.backtest-run-progress-track');
     const hint = panel.querySelector('.backtest-run-progress-hint');
-    if (title) title.textContent = isError ? 'Backtest did not start' : 'Backtest in progress';
+    if (title) {
+        if (isError) title.textContent = 'Backtest did not start';
+        else if (isFinished) title.textContent = 'Backtest complete';
+        else title.textContent = 'Backtest in progress';
+    }
     if (elapsed) elapsed.hidden = !!isError;
-    if (track) track.hidden = !!isError;
-    if (hint) hint.hidden = !!isError;
+    if (track) track.hidden = isError || isFinished;
+    if (hint) hint.hidden = isError || isFinished;
 }
 
 /**
@@ -8152,12 +8198,13 @@ function ensureBacktestPolling() {
                     });
                 } else if (status.success) {
                     const provenance = formatDecisionProvenance(status);
+                    const completionMessage = [
+                        `Completed in ${formatBacktestElapsed(displayElapsed)}.`,
+                        provenance,
+                    ].filter(Boolean).join(' ');
                     updateBacktestRunProgress({
                         elapsedSeconds: displayElapsed,
-                        message: [
-                            `Completed in ${formatBacktestElapsed(displayElapsed)}.`,
-                            provenance,
-                        ].filter(Boolean).join(' '),
+                        message: completionMessage,
                     });
                     if (finishedId) {
                         localStorage.setItem(SELECTED_BACKTEST_RUN_KEY, finishedId);
@@ -8165,13 +8212,18 @@ function ensureBacktestPolling() {
                         localStorage.removeItem(SELECTED_BACKTEST_RUN_KEY);
                     }
                     await loadData();
-                    // A run the model never drove keeps the panel up. This is
-                    // the only surface that says what produced the numbers
-                    // loadData() has just painted, and 2.5s is not long enough
-                    // to read a sentence the user was not expecting.
-                    if (!backtestFellBackFromTheModel(status)) {
-                        setTimeout(() => showBacktestRunProgress(false), 2500);
-                    }
+                    // After loadData(), never before: it repaints this panel
+                    // too, so a run the model never drove has to have its
+                    // message re-asserted rather than merely left alone. The
+                    // message is passed along because re-showing the panel is
+                    // not enough on its own -- the text is what says what
+                    // produced the numbers now on screen, and 2.5s was never
+                    // long enough to read a sentence nobody expected.
+                    settleFinishedBacktestPanel(
+                        status,
+                        displayElapsed,
+                        completionMessage,
+                    );
                 } else {
                     showBacktestRunProgress(false);
                 }

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -6220,6 +6220,14 @@ a.header-brand:hover .title-section h1 {
     overflow-wrap: anywhere;
 }
 
+/* Model coverage below the leaderboard's publishable floor. Colour alone is
+   not the signal -- the cell only renders at all when coverage is under 100%,
+   and its label carries the counts -- so this reads as emphasis rather than as
+   the only thing separating a degraded run from a clean one. */
+.backtest-config-detail-cell.is-degraded strong {
+    color: var(--warning-color);
+}
+
 .backtest-config-meta-row {
     display: flex;
     justify-content: space-between;

--- a/dashboard/scripts/backfill_runs_to_postgres.py
+++ b/dashboard/scripts/backfill_runs_to_postgres.py
@@ -458,6 +458,10 @@ def _insert_one_run(target: "PostgresBacktestDatabase", run: Dict[str, Any]) -> 
         num_trades=_coalesce(run, "num_trades", 0),
         llm_model=_coalesce(run, "llm_model", "rule-based"),
         llm_calls=_coalesce(run, "llm_calls", 0),
+        # Not a second spelling of llm_calls: steps the model actually drove.
+        # Dropping it here would republish every migrated LLM run as a total
+        # fallback, since 0 is what a row with no counter also reads as.
+        llm_decisions=_coalesce(run, "llm_decisions", 0),
         input_tokens=_coalesce(run, "input_tokens", 0),
         output_tokens=_coalesce(run, "output_tokens", 0),
         est_cost_usd=_coalesce(run, "est_cost_usd", 0.0),


### PR DESCRIPTION
Closes #169.

A dashboard backtest could fall back to rule-based logic on **every** step and still report `"Backtest completed successfully"`. Two independent layers.

**A — the run row was already honest and nothing read it.** `engine.py` keeps `llm_model = "rule-based"` until a call succeeds, so a wholly fallen-back run already persisted the honest label. `/backtest/status` returned a fixed success string and never looked.

**B — `llm_decisions` was never persisted.** `llm_calls` is the *billing* counter: it ticks on a truncated or unparseable response that then trades rule-based. So a run whose every step made a billed call that failed to parse reads `llm_calls = 30`, `llm_model = "claude-…"` and looks clean. `agent_runs` had no `llm_decisions` column, and dashboard backtests are subprocesses, so the in-process H6 guard that keys on that counter never saw them.

## What ships

- `agent_runs.llm_decisions` in both twins (CREATE + lazy migration, SQLite and Postgres), through `insert_run` and through the Postgres backfill script.
- `domain/backtesting/provenance.py` — one verdict helper (`llm` / `partial` / `rule_based` / `unknown`), importing `MIN_LLM_DECISION_COVERAGE` from the leaderboard rather than restating 0.95.
- `/backtest/status` **and** `/api/backtest/runs` gain `decision_provenance` (observed), `decision_source` (requested — the meaning that name already carries), `decision_fallback`, `decision_badge`, `decision_note`, and the counts. Additive; no existing field renamed or removed.
- `/app` renders a **"N of M steps model-driven"** cell on the run's config panel, and the completion panel stops auto-hiding when the model was asked for and did not answer.

## Two bars, deliberately not one number

`MIN_LLM_DECISION_COVERAGE` answers *may this publish to the leaderboard* and owns the verdict. The badge answers *should the user be told something degraded* and fires on **any** shortfall below 100%, driven by the counts. A 159/161 run keeps its `llm` verdict and still shows the badge. Neither bar reaches the browser — the badge's test is equality with the step count, and a guard asserts no threshold constant lives in `app.js`.

## Fallback sites

Walked every path in `portfolio_manager.py` — missing client, unserializable snapshot, pipeline with no decision, no-text retries exhausted, unparseable response, empty actions, post-parse exception, strict-LLM absorb — and confirmed each is accounted for by the persisted counters. Two had no `llm_decisions` coverage (missing client, pipeline fallback) and now do.

Also fixes a false accusation found on the way: `_record_llm_usage` does not tick `llm_calls` when a response's usage cannot be read, so a usage-blind provider yields `llm_calls == 0` on a run the model drove every step of. The zero-calls shortcut now applies only when no decision count was recorded.

The load-bearing test remains `llm_calls == decision_steps` with `llm_decisions == 0` classifying as `rule_based` — the case a coverage check keyed on `llm_calls` waves through.

## Review fixes (3 commits after review)

- **`decision_source` was the *effective* source, not the requested one.** Both LLM-availability downgrades in `engine.py` rewrite `self.decision_source`, so the silent-fallback run this PR is named for persisted identically to an intentional rule-based one and was reported as such. The resolved request is now frozen before the downgrade under its own metadata key; rows without it fall back to `decision_source`.
- **The "fallback keeps the panel up" branch was unreachable.** It ran after `await loadData()`, which hides that panel unconditionally, so it withheld a hide from an already-hidden panel. Moved into `settleFinishedBacktestPanel`, which re-shows and repaints — and is executed by a node test rather than grepped, because the three source-shape guards passed on the broken version.
- **Both leaderboard insert paths dropped the counters the H6 guard measured.** `deploy_model_run` and `ensure_leaderboard_runs` now persist `llm_decisions` (and `llm_calls`, on the auto-compute path), including the guard's documented `llm_calls` default for strategies that don't report it.

Backend suite green end-to-end: 4494 passed, 163 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PdsVmuCNd8iaC2Sff5B8jZ


