### PR TITLE
fix: leaderboard curve integrity and one capital base

### DIFF
--- a/dashboard/backend/domain/leaderboard/service.py
+++ b/dashboard/backend/domain/leaderboard/service.py
@@ -66,6 +66,11 @@ _warned_seed_mismatch: set[Tuple[str, float, float]] = set()
 # (configured_capital, stale_capitals) pairs already reported — see
 # _warn_on_capital_drift.
 _warned_capital_drift: set[Tuple[float, Tuple[float, ...]]] = set()
+# (entry_id, run_id) pairs already reported — see _warn_on_prompt_drift.
+_warned_prompt_drift: set[Tuple[str, str]] = set()
+# (entry_id, run_id, rendered_condition) triples already reported — see
+# _report_curve_integrity.
+_warned_curve_integrity: set[Tuple[str, str, str]] = set()
 # How a cached row compares to what the board is asking for. STALE is the only
 # value that refuses a row, and it is deliberately the only one a *recorded*
 # disagreement can produce — see _cache_match_rank.
@@ -268,6 +273,7 @@ def _daily_models_status(config: Dict[str, Any]) -> Dict[str, Any]:
         {e["id"]: e.get("strategy_prompt") for e in entries},
     )
     cached = 0
+    drifted = 0
     pending_ids: List[str] = []
     for entry in entries:
         entry_id = entry["id"]
@@ -276,6 +282,16 @@ def _daily_models_status(config: Dict[str, Any]) -> Dict[str, Any]:
             # `maybe_schedule_daily_leaderboard_refresh` spends money on. See
             # `_resolve_cached_run`.
             cached += 1
+            # ⚠ Counted HERE, not as `len(drifted_ids)`. `_cached_run_index`
+            # ranks every run in the session and window — the five baselines
+            # included — while every other number in this dict is computed over
+            # `llm_leaderboard_entries` alone. Taking the raw set size let a
+            # drifted baseline report `models_config_drift` above `models_total`,
+            # i.e. more of a population drifted than the population has members.
+            # Intersecting with the entries actually counted keeps the invariant
+            # drift ≤ cached ≤ total, which is what makes the dict readable.
+            if entry_id in drifted_ids:
+                drifted += 1
         else:
             pending_ids.append(entry_id)
     total = len(entries)
@@ -283,7 +299,7 @@ def _daily_models_status(config: Dict[str, Any]) -> Dict[str, Any]:
         "trading_date": config["start_date"],
         "models_total": total,
         "models_cached": cached,
-        "models_config_drift": len(drifted_ids),
+        "models_config_drift": drifted,
         "models_pending": len(pending_ids),
         "pending_entry_ids": pending_ids,
         "refresh_in_progress": _daily_refresh_running,
@@ -792,6 +808,24 @@ def _finite_positive(value: Any) -> Optional[float]:
     if not math.isfinite(num) or num <= 0:
         return None
     return num
+
+
+def _finite(value: Any) -> Optional[float]:
+    """``value`` as a finite float, or None when it is not a number at all.
+
+    The twin of ``_finite_positive`` for the columns where ``0`` and a negative
+    are *real observations* rather than a missing one: a final equity, a return,
+    a drawdown. ``_finite_positive`` must reject zero because its callers divide
+    by the result; these callers rank on it, and refusing an account that truly
+    went to zero would be the same absent-as-a-value conflation one column over.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        num = float(value)
+    except (TypeError, ValueError):
+        return None
+    return num if math.isfinite(num) else None
 
 
 def _run_seed(run: Dict[str, Any]) -> Optional[float]:
@@ -1474,8 +1508,14 @@ def _warn_on_capital_drift(
         f"WARNING: leaderboard has cached runs seeded at {rendered} while the "
         f"board publishes ${wanted:,.2f}. Curves seeded at different capital "
         "are not comparable — a smaller account trades a coarser share quantum, "
-        "so the returns differ, not just the dollar levels. Force-refresh to "
-        "recompute, or align initial_capital in dashboard/config/leaderboard.json."
+        "so the returns differ, not just the dollar levels. Align initial_capital "
+        "in dashboard/config/leaderboard.json to the seed the rows were actually "
+        "run at, or re-run BOTH halves of the board. ⚠ Do not force-refresh on "
+        "its own: `ensure_leaderboard_runs` recomputes only the auto_compute "
+        "baselines, so it moves those to the new seed and strands the LLM "
+        "entries at the old one — which mixes the board rather than aligning it, "
+        "and drops whichever half lands in the minority. The LLM half is "
+        "redeployed by deploy_model_run(force_refresh=True)."
     )
 
 
@@ -1576,7 +1616,12 @@ def deploy_model_run(
         # billable re-run of the whole board. `force_refresh=True` is the
         # operator's way to ask for it on purpose.
         if existing_rank == _CACHE_STALE:
+            # Both reasons a row can be stale, because only one of them has a
+            # board-wide scan behind it. `_warn_on_capital_drift` finds nothing
+            # when the disagreement is the prompt, so before the second call a
+            # drifted instruction produced no signal anywhere.
             _warn_on_capital_drift([existing], initial_capital)
+            _warn_on_prompt_drift(entry_id, existing, entry.get("strategy_prompt"))
         return {
             "entry_id": entry_id,
             "run_id": existing["run_id"],
@@ -1685,12 +1730,39 @@ def deploy_model_run(
 
 
 def _rank_sort_key(entry: Dict[str, Any]) -> tuple:
-    """Official rank is by final portfolio value (nof1-style); tie-break on return."""
-    pv = entry.get("portfolio_value")
-    if pv is None:
-        # Unit tests / partial fixtures may omit dollars — fall back to return.
-        pv = entry.get("cumulative_return") or 0
-    return (-float(pv), -(entry.get("cumulative_return") or 0))
+    """Official rank is by final portfolio value (nof1-style); tie-break on return.
+
+    ⚠ **Never rank a return against dollars.** The old fallback was
+    ``pv = entry.get("cumulative_return") or 0``, which was harmless only while
+    ``portfolio_value`` could not be None — and this change is precisely what
+    made it nullable. Reachable, it hands the sort a *fraction* (``0.07``) to
+    compare against its neighbours' *dollars* (``107494``), so an entry whose
+    final equity nobody recorded ranks **dead last** no matter how well it
+    actually did. That is the same defect this module just removed from the
+    Value column — an absent number published as a real one — pointing the other
+    way, and it lands in the column the board is ranked on.
+
+    So the absent case is put back on the dollar axis instead: the entry carries
+    the seed the board publishes and the return the run recorded, and
+    ``seed × (1 + return)`` is the final equity those two imply. This value is a
+    **sort key only** — ``portfolio_value`` stays ``None`` on the wire and both
+    tables still render it as an em dash. Ranking is a total order over the
+    board and has to produce *some* position; inventing a displayed dollar
+    figure is what must not happen.
+    """
+    ret = _finite(entry.get("cumulative_return"))
+    value = _finite(entry.get("portfolio_value"))
+    if value is None:
+        seed = _finite_positive(entry.get("initial_equity"))
+        if seed is not None and ret is not None:
+            value = seed * (1.0 + ret)
+    if value is None:
+        # Neither dollars nor a seed to rebuild them from. Only partial fixtures
+        # reach this — every entry `get_leaderboard` builds sets `initial_equity`
+        # to the board's published capital — and there the whole board is
+        # dimensionless, so ranking on the return alone compares like with like.
+        value = ret if ret is not None else 0.0
+    return (-value, -(ret if ret is not None else 0.0))
 
 
 def _rank_entries(entries: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -1718,15 +1790,8 @@ def _scaled_level(value: Any, scale: float) -> Optional[float]:
     A real ``0.0`` is still a real ``0.0`` and passes through — an account that
     actually went to zero did lose 100%.
     """
-    if value is None or isinstance(value, bool):
-        return None
-    try:
-        num = float(value)
-    except (TypeError, ValueError):
-        return None
-    if not math.isfinite(num):
-        return None
-    return num * scale
+    num = _finite(value)
+    return None if num is None else num * scale
 
 
 def _stored_seed(run: Dict[str, Any], equity_hourly: List[Dict[str, Any]]) -> Optional[float]:
@@ -1757,29 +1822,43 @@ def _report_curve_integrity(
     report a total contract break, so the wholesale boundary — no points at all,
     or every point unusable — logs ERROR, while a partial gap logs a single
     aggregate WARNING naming the count rather than one line per point.
+
+    **Once per distinct condition per process**, like ``_warn_on_capital_drift``
+    and ``_warn_on_seed_mismatch`` beside it, and for the reason those two give:
+    this runs on a public unauthenticated GET, once per entry, so an undeduped
+    line turns one broken curve into twelve lines every time anybody loads the
+    board — and an alert channel has a credibility budget that every repeat
+    spends. The key carries the *counts*, not just the run, so a curve that
+    degrades further still reports the new state.
     """
     total = len(scaled_hourly)
+    missing = sum(1 for point in scaled_hourly if point.get("equity") is None)
     if not total:
-        print(
+        message = (
             f"ERROR: leaderboard entry '{entry_id}' (run {run_id}): the stored "
             "run has no equity points at all — the board can draw only its "
             "opening tick. A cached run with no curve is a broken write, not an "
             "empty window."
         )
-        return
-    missing = sum(1 for point in scaled_hourly if point.get("equity") is None)
-    if missing == total:
-        print(
+    elif missing == total:
+        message = (
             f"ERROR: leaderboard entry '{entry_id}' (run {run_id}): all {total} "
             "stored equity points are NULL or unparseable — this curve is "
             "broken, not absent."
         )
     elif missing:
-        print(
+        message = (
             f"WARNING: leaderboard entry '{entry_id}' (run {run_id}): {missing} "
             f"of {total} equity points carry no value; the chart draws them as "
             "gaps."
         )
+    else:
+        return
+    key = (entry_id, run_id, f"{missing}/{total}")
+    if key in _warned_curve_integrity:
+        return
+    _warned_curve_integrity.add(key)
+    print(message)
 
 
 def _warn_on_seed_mismatch(
@@ -1809,6 +1888,47 @@ def _warn_on_seed_mismatch(
     )
 
 
+def _warn_on_prompt_drift(
+    entry_id: str, run: Dict[str, Any], wanted_prompt: Optional[str]
+) -> None:
+    """Say out loud that a cached curve predates the instruction now configured.
+
+    The prompt twin of ``_warn_on_capital_drift``, and it exists because
+    ``_cache_match_rank`` returns ``_CACHE_STALE`` for **two** reasons — a
+    recorded seed that disagrees, and a recorded prompt that disagrees — while
+    only the first had a reporter. ``deploy_model_run`` short-circuits a stale
+    row to the cached curve either way (deliberately: re-running on a config
+    edit answers one line of JSON with a billable redeploy of the whole board),
+    so a changed instruction reused the old curve in total silence. That is
+    CLAUDE.md's fail-closed-is-not-fail-visible shape exactly: "nobody changed
+    the prompt" and "the prompt changed and is being ignored" were byte-identical
+    from outside.
+
+    Once per (entry, run) per process, for the reason the two warnings above it
+    give. The prompt text itself is deliberately **not** printed: it is operator
+    config that can run to paragraphs, and a log line nobody can read is one
+    more way to spend the channel's credibility.
+    """
+    wanted = _wanted_prompt(wanted_prompt)
+    if wanted is None:
+        return
+    stored = _run_strategy_prompt(run)
+    if stored is None or stored == wanted:
+        return
+    run_id = str(run.get("run_id") or "")
+    key = (entry_id, run_id)
+    if key in _warned_prompt_drift:
+        return
+    _warned_prompt_drift.add(key)
+    print(
+        f"WARNING: leaderboard entry '{entry_id}' (run {run_id}) was computed "
+        "under a different strategy_prompt than dashboard/config/leaderboard.json "
+        "now configures; the cached curve is published as-is rather than "
+        "answering a config edit with a billable re-run. Redeploy this entry "
+        "with force_refresh=True to run it under the current instruction."
+    )
+
+
 def _board_capital_base(
     seeds: List[float], display_capital: float
 ) -> Optional[float]:
@@ -1826,9 +1946,15 @@ def _board_capital_base(
     So: the largest group of mutually-equal seeds wins, and everything outside
     it is dropped by the caller. Ties go to the group matching the config, then
     to the first seen, so the choice is deterministic rather than dict-ordered.
-    **This can never return None for a non-empty board** — the winning group is
-    the largest, so it always has at least one member — which is the property
+    **This can never return None for a non-empty ``seeds``** — the winning group
+    is the largest, so it always has at least one member — which is the property
     that makes a one-character config typo unable to empty the board.
+
+    ⚠ ``seeds`` holds only the seeds rows actually **recorded**; the caller
+    filters. A derived seed is an estimate read off a curve's first point and
+    must not get a vote on what the board's base is — see the caller for why.
+    So None here means "no row on this board wrote down its seed", not "no
+    rows", and the caller answers it by publishing every row unfiltered.
     """
     groups: List[Tuple[float, int]] = []
     for seed in seeds:
@@ -1906,14 +2032,36 @@ def get_leaderboard(
     # LLM entries before it looks anything up (they deploy manually), which is
     # precisely the half the mixing lives in.
     _warn_on_capital_drift(board_runs, display_capital)
-    capital_base = _board_capital_base(
-        [seed for _, _, seed, _ in resolved], display_capital
-    )
+    # ⚠ ONLY A RECORDED SEED VOTES, AND ONLY A RECORDED SEED CAN BE OUTVOTED.
+    # `_stored_seed` falls back to the curve's own first equity point, and that
+    # point is the equity at the END of the run's first hour — seed plus one
+    # hour of P&L. So a run seeded at exactly $100,000 that moved 0.4% in hour
+    # one derives $100,400, and comparing THAT against the board's base at a
+    # one-cent tolerance is not a capital check, it is a check on whether the
+    # strategy happened to be flat at the open. Every derived row that moved at
+    # all failed it and vanished from the public Competition board — the same
+    # absent-treated-as-a-measurement defect this change exists to remove, and
+    # a strictly worse outcome than the unscaled row that used to publish.
+    #
+    # The tolerance is right for what it was written for: a *recorded* seed is
+    # an exact stored number (100000.00000000003 is a float round-trip, not a
+    # different capital), so a penny of disagreement there really does mean two
+    # runs at two capitals. A derived seed simply cannot carry that signal.
+    # Hence the split: recorded seeds decide the base and are held to it;
+    # derived rows publish through the scaling shim and are reported by
+    # `_warn_on_seed_mismatch` — which is what that warning was written for and
+    # was, before this, unreachable whenever the board agreed with its config.
+    recorded_seeds = [
+        seed for _, run, seed, _ in resolved if _run_seed(run) is not None
+    ]
+    capital_base = _board_capital_base(recorded_seeds, display_capital)
 
     # SECOND PASS: publish the entries that share the board's one capital base.
     for strategy, run, stored_initial, equity_hourly in resolved:
-        if capital_base is not None and (
-            abs(stored_initial - capital_base) > _SEED_MATCH_TOLERANCE
+        if (
+            capital_base is not None
+            and _run_seed(run) is not None
+            and abs(stored_initial - capital_base) > _SEED_MATCH_TOLERANCE
         ):
             # An outlier in a board that otherwise agrees. Ranking it against
             # the rest would compare runs that were not measured the same way.
@@ -1922,7 +2070,9 @@ def get_leaderboard(
                 f"{run['run_id']}) was run at ${stored_initial:,.2f} while the "
                 f"rest of this board was run at ${capital_base:,.2f} — omitted "
                 "rather than ranked against curves it is not comparable with "
-                "(issue #365). Force-refresh to re-run it at the board's seed."
+                "(issue #365). Re-run this entry at the board's seed: a "
+                "force-refresh does that only for an auto_compute baseline, an "
+                "LLM entry needs deploy_model_run(force_refresh=True)."
             )
             continue
         # SCALING IS A COMPATIBILITY SHIM, NOT A RE-RUN, and it is only honest

--- a/dashboard/backend/domain/leaderboard/service.py
+++ b/dashboard/backend/domain/leaderboard/service.py
@@ -11,6 +11,7 @@ moved.
 from __future__ import annotations
 
 import json
+import math
 import os
 import secrets
 import tempfile
@@ -54,6 +55,23 @@ _daily_refresh_lock = threading.Lock()
 _daily_refresh_running = False
 # (configured_feed, stale_feeds) pairs already reported — see _warn_on_feed_drift.
 _warned_feed_drift: set[Tuple[str, Tuple[str, ...]]] = set()
+# Two seeds are "the same seed" within this many dollars. A stored
+# ``initial_equity`` has been through a backtest and a JSON round-trip — the
+# committed board carries 100000.00000000003 for one entry — so `==` here would
+# report a mismatch nobody made.
+_SEED_MATCH_TOLERANCE = 0.01
+# (entry_id, stored_seed, display_capital) triples already reported — see
+# _warn_on_seed_mismatch.
+_warned_seed_mismatch: set[Tuple[str, float, float]] = set()
+# (configured_capital, stale_capitals) pairs already reported — see
+# _warn_on_capital_drift.
+_warned_capital_drift: set[Tuple[float, Tuple[float, ...]]] = set()
+# How a cached row compares to what the board is asking for. STALE is the only
+# value that refuses a row, and it is deliberately the only one a *recorded*
+# disagreement can produce — see _cache_match_rank.
+_CACHE_MATCH = 0
+_CACHE_UNRECORDED = 1
+_CACHE_STALE = 2
 
 # Daily board window is the last *completed* US cash session, not UTC-yesterday.
 _US_EASTERN = ZoneInfo("America/New_York")
@@ -201,37 +219,62 @@ def _set_daily_refresh_running(value: bool) -> None:
 
 
 def _cached_run_index(
-    start_date: str, end_date: str, session_id: str
-) -> Dict[str, Dict[str, Any]]:
-    """``llm_model`` → cached leaderboard run for one window, in one query.
+    start_date: str,
+    end_date: str,
+    session_id: str,
+    initial_capital: Optional[float] = None,
+    prompt_by_entry: Optional[Dict[str, Optional[str]]] = None,
+) -> Tuple[Dict[str, Dict[str, Any]], set]:
+    """``(cached run by llm_model, entry ids whose row drifted from the config)``.
 
     ``_find_cached_run`` rescans the whole session per lookup, so calling it in
-    a loop is O(entries × runs) DB work on a request path. First match wins,
-    matching ``_find_cached_run``'s semantics exactly.
+    a loop is O(entries × runs) DB work on a request path. Same predicate and
+    the same ranking, one query — see ``_cache_match_rank``.
+
+    A drifted entry appears in **both** returns: it is still a cached row (so
+    ``models_pending`` cannot count it and trigger a billable redeploy — see
+    ``_resolve_cached_run``), and it is named so the caller can report it as
+    something other than healthy.
     """
+    wanted = _finite_positive(initial_capital)
+    prompts = prompt_by_entry or {}
     index: Dict[str, Dict[str, Any]] = {}
+    ranks: Dict[str, int] = {}
     for run in db.get_runs_by_session(session_id) or []:
-        if (
+        if not (
             run.get("mode") == LEADERBOARD_MODE
             and run.get("start_date") == start_date
             and run.get("end_date") == end_date
         ):
-            index.setdefault(run.get("llm_model"), run)
-    return index
+            continue
+        key = run.get("llm_model")
+        rank = _cache_match_rank(run, wanted, _wanted_prompt(prompts.get(key)))
+        if key not in index or rank < ranks[key]:
+            index[key] = run
+            ranks[key] = rank
+    drifted = {key for key, rank in ranks.items() if rank == _CACHE_STALE}
+    return index, drifted
 
 
 def _daily_models_status(config: Dict[str, Any]) -> Dict[str, Any]:
     """How many competition LLM curves exist for the current daily window."""
     entries = llm_leaderboard_entries(config)
     # Single scan: this runs on every public GET of the daily board.
-    cached_runs = _cached_run_index(
-        config["start_date"], config["end_date"], config["session_id"]
+    cached_runs, drifted_ids = _cached_run_index(
+        config["start_date"],
+        config["end_date"],
+        config["session_id"],
+        config.get("initial_capital", INITIAL_CAPITAL),
+        {e["id"]: e.get("strategy_prompt") for e in entries},
     )
     cached = 0
     pending_ids: List[str] = []
     for entry in entries:
         entry_id = entry["id"]
         if cached_runs.get(entry_id):
+            # Drifted rows count as CACHED, never pending: pending is what
+            # `maybe_schedule_daily_leaderboard_refresh` spends money on. See
+            # `_resolve_cached_run`.
             cached += 1
         else:
             pending_ids.append(entry_id)
@@ -240,7 +283,8 @@ def _daily_models_status(config: Dict[str, Any]) -> Dict[str, Any]:
         "trading_date": config["start_date"],
         "models_total": total,
         "models_cached": cached,
-        "models_pending": total - cached,
+        "models_config_drift": len(drifted_ids),
+        "models_pending": len(pending_ids),
         "pending_entry_ids": pending_ids,
         "refresh_in_progress": _daily_refresh_running,
     }
@@ -731,7 +775,48 @@ def resolve_leaderboard_config(period: Optional[str] = "contest") -> Dict[str, A
     }
 
 
+def _finite_positive(value: Any) -> Optional[float]:
+    """``value`` as a positive finite float, or None when it is not one.
+
+    ``None``, ``NaN``, ``inf``, a non-numeric string and ``0`` all answer None:
+    every one of them is a number this module must neither divide by nor
+    publish as a seed. ``bool`` is excluded explicitly because ``float(True)``
+    is ``1.0``, which would sail through every other check.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        num = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(num) or num <= 0:
+        return None
+    return num
+
+
+def _run_seed(run: Dict[str, Any]) -> Optional[float]:
+    """The seed a stored run was actually executed at, or None if unrecorded."""
+    return _finite_positive(run.get("initial_equity"))
+
+
 def _run_id(strategy_id: str, start_date: str, end_date: str) -> str:
+    """Deterministic id for one leaderboard run — deliberately seed-free.
+
+    ⚠ **Do not put the seed capital in here.** It was tried: the reasoning was
+    that ``insert_run`` is INSERT OR REPLACE on this id, so a re-run at a new
+    seed overwrites the old row rather than sitting beside it, and the
+    seed-aware lookup below then has nothing to choose between. True, and still
+    the wrong trade — because the twelve rows in the committed seed database
+    carry these *seed-free* ids. A suffixed id does not replace them, it
+    **inserts alongside** them, so the first force-refresh after such a change
+    doubles every entry on the board and orphans twelve equity curves that
+    nothing ever prunes. Duplicate history is worse than the ambiguity it buys.
+
+    One id per (entry, window) is the invariant: a refresh replaces the row and
+    its curve, so a window can hold exactly one seed and ``_cache_match_rank``'s
+    job is to notice when that seed is not the one the config publishes — not to
+    arbitrate between rival rows.
+    """
     return f"lb_{strategy_id}_{start_date.replace('-', '')}_{end_date.replace('-', '')}"
 
 
@@ -831,16 +916,142 @@ def _prune_stale_window_skips(
     return kept
 
 
-def _find_cached_run(strategy_id: str, start_date: str, end_date: str, session_id: str) -> Optional[Dict[str, Any]]:
+def _wanted_prompt(value: Any) -> Optional[str]:
+    """The strategy prompt to compare on, or None to not compare at all."""
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _run_strategy_prompt(run: Dict[str, Any]) -> Optional[str]:
+    """The instruction a published run recorded, or None if it recorded none.
+
+    Written by ``_llm_run_metadata`` into ``agent_runs.metadata`` (PR #366).
+    Every row in the committed seed database predates it and has
+    ``metadata = NULL``, which is exactly why an unrecorded prompt has to mean
+    *unknown* and not *empty*.
+    """
+    metadata = run.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    return _wanted_prompt(metadata.get("strategy_prompt"))
+
+
+def _cache_match_rank(
+    run: Dict[str, Any],
+    wanted_capital: Optional[float],
+    wanted_prompt: Optional[str],
+) -> int:
+    """How well one cached row answers what the board is asking for.
+
+    ``_CACHE_MATCH`` every recorded dimension agrees, ``_CACHE_UNRECORDED`` the
+    row never recorded one of them, ``_CACHE_STALE`` the row recorded one and it
+    disagrees. Shared by ``_resolve_cached_run`` and ``_cached_run_index`` so
+    the scan and its batched twin cannot drift.
+
+    **Only a recorded disagreement is stale.** The twelve rows in the committed
+    seed database carry no ``metadata`` at all, so treating *unrecorded* as a
+    mismatch would refuse the entire board — and refusing is not free even
+    though it never recomputes, because the entry then vanishes from a public
+    page. A dimension the *config* does not set is not compared either: the
+    prompt a run records is resolved off the strategy impl, not only off
+    ``leaderboard.json``, so a one-sided comparison would drop legitimate rows.
+    """
+    rank = _CACHE_MATCH
+    if wanted_capital is not None:
+        seed = _run_seed(run)
+        if seed is None:
+            rank = max(rank, _CACHE_UNRECORDED)
+        elif abs(seed - wanted_capital) > _SEED_MATCH_TOLERANCE:
+            return _CACHE_STALE
+    if wanted_prompt is not None:
+        stored = _run_strategy_prompt(run)
+        if stored is None:
+            rank = max(rank, _CACHE_UNRECORDED)
+        elif stored != wanted_prompt:
+            return _CACHE_STALE
+    return rank
+
+
+def _resolve_cached_run(
+    strategy_id: str,
+    start_date: str,
+    end_date: str,
+    session_id: str,
+    initial_capital: Optional[float] = None,
+    strategy_prompt: Optional[str] = None,
+) -> Tuple[Optional[Dict[str, Any]], int]:
+    """``(cached run, how well it matches)`` for one entry and window.
+
+    ⚠ **The config is a RANKING key here, never a filter, and that is a spend
+    control.** A row for this window is always returned if one exists; the rank
+    only says whether it was produced under the config the board now publishes.
+    Refusing a drifted row would make it *missing*, and missing is not a quiet
+    state in this module:
+
+    * ``ensure_leaderboard_runs`` answers missing by recomputing — on a public,
+      unauthenticated GET, and on every page load for as long as the config
+      disagrees.
+    * ``_daily_models_status`` reports missing as **pending**, and a non-zero
+      pending count is what ``maybe_schedule_daily_leaderboard_refresh`` acts
+      on; ``refresh_daily_leaderboard`` then calls ``deploy_model_run`` for
+      **every** configured LLM entry. With ``LEADERBOARD_DAILY_AUTO_DEPLOY``
+      armed, one edit to ``leaderboard.json`` would buy a billable re-run of the
+      whole board from an anonymous request.
+
+    So a cache miss caused by a config change is not merely undesirable, it is
+    unbounded spend — which is why this cannot miss. It is also the policy
+    ``_warn_on_feed_drift`` already set for the identical problem one field
+    over: warn, never treat as missing, leave recomputing to an operator.
+    ``_warn_on_capital_drift`` is the matching signal, and issue #365's third
+    criterion asks for exactly that warning — a criterion that would be dead
+    code if a drifted row were refused instead of published.
+
+    Preference order: a row matching every recorded dimension, then a row that
+    never recorded one, then a row that recorded one and disagrees. With no
+    ``initial_capital`` or ``strategy_prompt`` passed, nothing is compared and
+    the first row for the window wins, exactly as this has always behaved.
+    """
+    wanted_capital = _finite_positive(initial_capital)
+    wanted_prompt = _wanted_prompt(strategy_prompt)
+    best: Optional[Dict[str, Any]] = None
+    best_rank = _CACHE_STALE + 1
     for run in db.get_runs_by_session(session_id) or []:
-        if (
+        if not (
             run.get("mode") == LEADERBOARD_MODE
             and run.get("start_date") == start_date
             and run.get("end_date") == end_date
             and run.get("llm_model") == strategy_id
         ):
-            return run
-    return None
+            continue
+        rank = _cache_match_rank(run, wanted_capital, wanted_prompt)
+        if rank < best_rank:
+            best, best_rank = run, rank
+            if rank == _CACHE_MATCH:
+                break  # nothing can beat it; stop scanning
+    return best, best_rank
+
+
+def _find_cached_run(
+    strategy_id: str,
+    start_date: str,
+    end_date: str,
+    session_id: str,
+    initial_capital: Optional[float] = None,
+    strategy_prompt: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """The cached run for one entry and window, or None. See ``_resolve_cached_run``.
+
+    Passing neither ``initial_capital`` nor ``strategy_prompt`` compares nothing
+    and returns the first row for the window, which is what this function has
+    always done.
+    """
+    return _resolve_cached_run(
+        strategy_id,
+        start_date,
+        end_date,
+        session_id,
+        initial_capital,
+        strategy_prompt,
+    )[0]
 
 
 def _symbols_for_config(config: Dict[str, Any]) -> List[str]:
@@ -910,9 +1121,19 @@ def ensure_leaderboard_runs(
         cached = (
             None
             if force_refresh
-            else _find_cached_run(strategy_id, start_date, end_date, session_id)
+            else _find_cached_run(
+                strategy_id,
+                start_date,
+                end_date,
+                session_id,
+                initial_capital,
+                strategy.get("strategy_prompt"),
+            )
         )
         if cached:
+            # A row that drifted from the config is still a HIT, deliberately:
+            # see `_resolve_cached_run`. `_warn_on_capital_drift` below is what
+            # reports it; recomputing is an operator action.
             cached_runs.append(cached)
             continue
         if not force_refresh and _is_skipped(session_id, start_date, end_date, strategy_id, skip_cache):
@@ -920,6 +1141,7 @@ def ensure_leaderboard_runs(
         missing.append(strategy)
 
     _warn_on_feed_drift(cached_runs, _configured_feed_or_none())
+    _warn_on_capital_drift(cached_runs, initial_capital)
 
     # Nothing left to compute — serve cached board without touching Alpaca.
     if not missing and not force_refresh:
@@ -960,7 +1182,12 @@ def ensure_leaderboard_runs(
         if not _auto_compute(strategy):
             continue  # deployed via deploy_model_run(), not on-demand
         existing = None if force_refresh else _find_cached_run(
-            strategy_id, start_date, end_date, session_id
+            strategy_id,
+            start_date,
+            end_date,
+            session_id,
+            initial_capital,
+            strategy.get("strategy_prompt"),
         )
         if existing and not force_refresh:
             continue
@@ -1206,6 +1433,52 @@ def _warn_on_feed_drift(runs: List[Dict[str, Any]], configured: Optional[str]) -
     )
 
 
+def _warn_on_capital_drift(
+    runs: List[Dict[str, Any]], configured: Optional[float]
+) -> None:
+    """Print when cached rows were run at seed capital the board no longer publishes.
+
+    The capital twin of ``_warn_on_feed_drift`` directly above, and deliberately
+    the same shape for the same reason: this is the established answer in this
+    module to "cached rows are not comparable". A warning, once per distinct
+    drift per process, never an auto-refresh — ``ensure_leaderboard_runs`` and
+    ``get_leaderboard`` both run on a public, unauthenticated GET, and
+    recomputing is an operator action (``POST /api/v1/leaderboard/refresh`` with
+    ``force=true``).
+
+    Why capital is a comparability problem and not a display one: a $10,000 run
+    buys whole shares in a coarser quantum than a $100,000 one and pays
+    per-trade costs against a smaller base, so it is a *different run* of the
+    same strategy, with different returns. Scaling the dollar levels hides that
+    and fixes nothing. A board holding both is ranking two things that were not
+    measured the same way (issue #365).
+    """
+    wanted = _finite_positive(configured)
+    if wanted is None:
+        return
+    stale = sorted(
+        {
+            seed
+            for run in runs
+            if (seed := _run_seed(run)) and abs(seed - wanted) > _SEED_MATCH_TOLERANCE
+        }
+    )
+    if not stale:
+        return
+    seen_key = (wanted, tuple(stale))
+    if seen_key in _warned_capital_drift:
+        return
+    _warned_capital_drift.add(seen_key)
+    rendered = ", ".join(f"${seed:,.2f}" for seed in stale)
+    print(
+        f"WARNING: leaderboard has cached runs seeded at {rendered} while the "
+        f"board publishes ${wanted:,.2f}. Curves seeded at different capital "
+        "are not comparable — a smaller account trades a coarser share quantum, "
+        "so the returns differ, not just the dollar levels. Force-refresh to "
+        "recompute, or align initial_capital in dashboard/config/leaderboard.json."
+    )
+
+
 def _llm_run_metadata(
     entry_id: str,
     entry: Dict[str, Any],
@@ -1285,8 +1558,25 @@ def deploy_model_run(
         available = [s.get("id") for s in config.get("strategies", [])]
         raise ValueError(f"Unknown leaderboard entry '{entry_id}'. Available: {available}")
 
-    existing = _find_cached_run(entry_id, start_date, end_date, session_id)
+    existing, existing_rank = _resolve_cached_run(
+        entry_id,
+        start_date,
+        end_date,
+        session_id,
+        initial_capital,
+        entry.get("strategy_prompt"),
+    )
     if existing and not force_refresh:
+        # A drifted row short-circuits here exactly like a matching one, and
+        # that is the point: this function is reached from
+        # `refresh_daily_leaderboard`, which loops over EVERY configured LLM
+        # entry, and that loop is reachable from a public unauthenticated GET
+        # whenever LEADERBOARD_DAILY_AUTO_DEPLOY is armed. Re-running on a
+        # config change would answer one edit to leaderboard.json with a
+        # billable re-run of the whole board. `force_refresh=True` is the
+        # operator's way to ask for it on purpose.
+        if existing_rank == _CACHE_STALE:
+            _warn_on_capital_drift([existing], initial_capital)
         return {
             "entry_id": entry_id,
             "run_id": existing["run_id"],
@@ -1414,6 +1704,153 @@ def _rank_entries(entries: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return entries
 
 
+def _scaled_level(value: Any, scale: float) -> Optional[float]:
+    """One stored dollar level, scaled — with *absent* preserved as absent.
+
+    A stored NULL means "no observation at this timestamp", which is a
+    different fact from "the account held $0". ``float(pt.get("equity") or 0)``
+    conflated them, and because ``chart_equity_curve`` prepends an open tick at
+    starting capital the series then read as a −100% loss. The damage is not
+    one bad marker: ``align_equity_curves`` puts every entry on one shared
+    axis, so a single −100% series sets the y-range and visually flattens every
+    honest curve on the board (issue #390).
+
+    A real ``0.0`` is still a real ``0.0`` and passes through — an account that
+    actually went to zero did lose 100%.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        num = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(num):
+        return None
+    return num * scale
+
+
+def _stored_seed(run: Dict[str, Any], equity_hourly: List[Dict[str, Any]]) -> Optional[float]:
+    """The seed the stored curve was actually run at, or None if unknowable.
+
+    Never falls back to the *config's* capital. That fallback was issue #365:
+    with ``initial_equity`` NULL it made ``scale`` exactly ``1.0``, so a curve
+    genuinely seeded at $100,000 was published unscaled and labelled $10,000 —
+    a wrong number that looked like a deliberate one. The curve's own first
+    observation is a fact about the run; the config is a fact about the board.
+    """
+    seed = _run_seed(run)
+    if seed is not None:
+        return seed
+    for point in equity_hourly:
+        seed = _finite_positive(point.get("equity"))
+        if seed is not None:
+            return seed
+    return None
+
+
+def _report_curve_integrity(
+    entry_id: str, run_id: str, scaled_hourly: List[Dict[str, Any]]
+) -> None:
+    """Make an *absent* curve distinguishable from a *broken* one in the log.
+
+    CLAUDE.md's fail-closed-is-not-fail-visible rule: a per-point warning cannot
+    report a total contract break, so the wholesale boundary — no points at all,
+    or every point unusable — logs ERROR, while a partial gap logs a single
+    aggregate WARNING naming the count rather than one line per point.
+    """
+    total = len(scaled_hourly)
+    if not total:
+        print(
+            f"ERROR: leaderboard entry '{entry_id}' (run {run_id}): the stored "
+            "run has no equity points at all — the board can draw only its "
+            "opening tick. A cached run with no curve is a broken write, not an "
+            "empty window."
+        )
+        return
+    missing = sum(1 for point in scaled_hourly if point.get("equity") is None)
+    if missing == total:
+        print(
+            f"ERROR: leaderboard entry '{entry_id}' (run {run_id}): all {total} "
+            "stored equity points are NULL or unparseable — this curve is "
+            "broken, not absent."
+        )
+    elif missing:
+        print(
+            f"WARNING: leaderboard entry '{entry_id}' (run {run_id}): {missing} "
+            f"of {total} equity points carry no value; the chart draws them as "
+            "gaps."
+        )
+
+
+def _warn_on_seed_mismatch(
+    entry_id: str, run_id: str, stored_initial: float, display_capital: float
+) -> None:
+    """Say out loud that a published row was rescaled from a seed nobody recorded.
+
+    Narrower than ``_warn_on_capital_drift``, and complementary: that one scans
+    the board for rows whose *recorded* seed disagrees with the config, so it is
+    structurally blind to a row with no recorded seed at all. This is the only
+    report such a row gets, and its seed came from the curve's own first point
+    rather than from anything the run wrote down.
+
+    One line per distinct mismatch, not per request, and never alongside the
+    board-level warning for the same row — this runs on a public GET, and an
+    alert channel has a credibility budget that every duplicate line spends.
+    """
+    key = (entry_id, stored_initial, display_capital)
+    if key in _warned_seed_mismatch:
+        return
+    _warned_seed_mismatch.add(key)
+    print(
+        f"WARNING: leaderboard entry '{entry_id}' (run {run_id}) was run at "
+        f"${stored_initial:,.2f} but the board publishes ${display_capital:,.2f}; "
+        "dollar levels are rescaled for display. Re-run the board at the "
+        "published seed to remove the shim (issue #194)."
+    )
+
+
+def _board_capital_base(
+    seeds: List[float], display_capital: float
+) -> Optional[float]:
+    """The one seed this board will publish, or None when there is nothing to publish.
+
+    **The defect is mixed capital, not capital that disagrees with the config.**
+    Twelve entries all seeded at $100,000 under a `$10,000` config are mutually
+    comparable — the board is internally consistent and merely mislabelled, and
+    refusing to publish it would turn a labelling problem into an outage on the
+    Competition Leaderboard, which is the site's acquisition hook. Twelve
+    entries across two seeds are *not* comparable at any label, because the
+    smaller account trades a coarser share quantum: that is the state that
+    corrupts a ranking, and the minority is what must not publish.
+
+    So: the largest group of mutually-equal seeds wins, and everything outside
+    it is dropped by the caller. Ties go to the group matching the config, then
+    to the first seen, so the choice is deterministic rather than dict-ordered.
+    **This can never return None for a non-empty board** — the winning group is
+    the largest, so it always has at least one member — which is the property
+    that makes a one-character config typo unable to empty the board.
+    """
+    groups: List[Tuple[float, int]] = []
+    for seed in seeds:
+        for index, (base, count) in enumerate(groups):
+            if abs(base - seed) <= _SEED_MATCH_TOLERANCE:
+                groups[index] = (base, count + 1)
+                break
+        else:
+            groups.append((seed, 1))
+    if not groups:
+        return None
+    best = max(
+        range(len(groups)),
+        key=lambda i: (
+            groups[i][1],
+            abs(groups[i][0] - display_capital) <= _SEED_MATCH_TOLERANCE,
+            -i,
+        ),
+    )
+    return groups[best][0]
+
+
 def get_leaderboard(
     force_refresh: bool = False,
     period: Optional[str] = "contest",
@@ -1427,29 +1864,101 @@ def get_leaderboard(
     strategy_by_id = {s["id"]: s for s in config.get("strategies", [])}
 
     entries: List[Dict[str, Any]] = []
+    board_runs: List[Dict[str, Any]] = []
     display_capital = float(config.get("initial_capital", INITIAL_CAPITAL))
 
+    # FIRST PASS: resolve every entry's run and the seed it was actually run at.
+    # Nothing can be scaled until the whole board is known, because the base to
+    # scale onto is a property of the board and not of any one row — see
+    # `_board_capital_base`.
+    resolved: List[Tuple[Dict[str, Any], Dict[str, Any], float, List[Dict[str, Any]]]] = []
     for strategy in config.get("strategies", []):
-        run = _find_cached_run(strategy["id"], start_date, end_date, session_id)
+        run = _find_cached_run(
+            strategy["id"],
+            start_date,
+            end_date,
+            session_id,
+            display_capital,
+            strategy.get("strategy_prompt"),
+        )
         if not run:
             continue
+        board_runs.append(run)
 
         equity_hourly = db.get_equity_curve(run["run_id"]) or []
-        stored_initial = float(
-            run.get("initial_equity") or config.get("initial_capital", INITIAL_CAPITAL)
-        )
-        # Display capital may differ from the stored seed run (e.g. $100k seed
-        # shown as $1k). Scale dollar levels; returns / Sharpe stay unchanged.
-        scale = (display_capital / stored_initial) if stored_initial else 1.0
+        stored_initial = _stored_seed(run, equity_hourly)
+        if stored_initial is None:
+            # A published leaderboard row is a claim, and with no recorded seed
+            # and no usable first point there is no honest number to make it
+            # with. Skipping costs one row; the old config fallback published a
+            # curve at an unverified scale, which costs the board's credibility.
+            print(
+                f"ERROR: leaderboard entry '{strategy['id']}' (run "
+                f"{run['run_id']}) records no seed capital and its curve has no "
+                "usable first point — omitted from the board rather than "
+                "published at a scale nobody verified (issue #365)."
+            )
+            continue
+        resolved.append((strategy, run, stored_initial, equity_hourly))
+
+    # Criterion 3 of issue #365: one board must not mix seed capital. This is
+    # the only seam that sees EVERY entry — `ensure_leaderboard_runs` skips the
+    # LLM entries before it looks anything up (they deploy manually), which is
+    # precisely the half the mixing lives in.
+    _warn_on_capital_drift(board_runs, display_capital)
+    capital_base = _board_capital_base(
+        [seed for _, _, seed, _ in resolved], display_capital
+    )
+
+    # SECOND PASS: publish the entries that share the board's one capital base.
+    for strategy, run, stored_initial, equity_hourly in resolved:
+        if capital_base is not None and (
+            abs(stored_initial - capital_base) > _SEED_MATCH_TOLERANCE
+        ):
+            # An outlier in a board that otherwise agrees. Ranking it against
+            # the rest would compare runs that were not measured the same way.
+            print(
+                f"WARNING: leaderboard entry '{strategy['id']}' (run "
+                f"{run['run_id']}) was run at ${stored_initial:,.2f} while the "
+                f"rest of this board was run at ${capital_base:,.2f} — omitted "
+                "rather than ranked against curves it is not comparable with "
+                "(issue #365). Force-refresh to re-run it at the board's seed."
+            )
+            continue
+        # SCALING IS A COMPATIBILITY SHIM, NOT A RE-RUN, and it is only honest
+        # for a scale-free strategy. Position sizing, whole-share/lot quanta and
+        # per-trade costs make a $10k run a genuinely *different* run from a
+        # $100k one rather than a scaled copy of it — a $10k account cannot buy
+        # the same basket in the same proportions, so its returns differ, not
+        # just its dollar levels. Returns / Sharpe below come off the stored run
+        # untouched, so the shim moves the dollar axis only. Re-running each
+        # entry at the published seed is the real fix (issue #194).
+        scale = display_capital / stored_initial
+        if (
+            _run_seed(run) is None
+            and abs(stored_initial - display_capital) > _SEED_MATCH_TOLERANCE
+        ):
+            # ONLY THE DERIVED CASE, and the narrowing is the point. A row
+            # that recorded its seed is already reported by
+            # `_warn_on_capital_drift` over the whole board above, and two lines
+            # for one condition is how a log stops being read: an alert channel
+            # has a credibility budget, and every duplicate line spends it, the
+            # same way a badge that cries wolf stops being looked at. This one
+            # covers what that warning structurally cannot see -- `_run_seed` is
+            # None here, so the board's own drift scan skips the row entirely.
+            _warn_on_seed_mismatch(
+                strategy["id"], run["run_id"], stored_initial, display_capital
+            )
         scaled_hourly = [
             {
                 **pt,
-                "equity": float(pt.get("equity") or 0) * scale,
-                "cash": float(pt.get("cash") or 0) * scale,
-                "positions_value": float(pt.get("positions_value") or 0) * scale,
+                "equity": _scaled_level(pt.get("equity"), scale),
+                "cash": _scaled_level(pt.get("cash"), scale),
+                "positions_value": _scaled_level(pt.get("positions_value"), scale),
             }
             for pt in equity_hourly
         ]
+        _report_curve_integrity(strategy["id"], run["run_id"], scaled_hourly)
         equity_curve = chart_equity_curve(
             scaled_hourly,
             initial_equity=display_capital,
@@ -1457,11 +1966,14 @@ def get_leaderboard(
         )
         strat = strategy_by_id.get(strategy["id"], strategy)
         is_model = strat.get("strategy") == "llm_agent" or strat.get("label") == "Model"
-        final_equity = run.get("final_equity")
-        if final_equity is None:
-            portfolio_value = display_capital
-        else:
-            portfolio_value = float(final_equity) * scale
+        # `= display_capital` here was the same defect as the two this change
+        # exists for: a run that recorded no final equity was published as an
+        # account that finished exactly level, which is a claim nobody made.
+        # `_rank_sort_key` already falls back to `cumulative_return` for a None,
+        # and both chart readers now render it as an em dash.
+        stored_final = run.get("final_equity")
+        scaled_final = _scaled_level(stored_final, scale)
+        portfolio_value = scaled_final
 
         entries.append(
             {

--- a/dashboard/backend/tests/test_frontend_chart_first_home.py
+++ b/dashboard/backend/tests/test_frontend_chart_first_home.py
@@ -197,6 +197,11 @@ def _harness() -> str:
             _extract(_LEADERBOARD_JS, "getTeamColor"),
             _extract(_LEADERBOARD_JS, "getSeriesStyle"),
             _extract(_LEADERBOARD_JS, "chartTimeKey"),
+            # `buildEquityCurvesFromEntries` calls this to reject an equity
+            # `Number.isFinite(Number(...))` would have accepted (`Number(null)`
+            # is 0). Omit it and the harness dies with a ReferenceError rather
+            # than testing anything.
+            _extract(_LEADERBOARD_JS, "finiteNumber"),
             # The real builder, so the gate is exercised against the actual
             # "silently drops curveless entries" behaviour rather than a stub
             # that would drop them the way the test author assumed.

--- a/dashboard/backend/tests/test_frontend_xss_guards.py
+++ b/dashboard/backend/tests/test_frontend_xss_guards.py
@@ -188,6 +188,11 @@ def _run_leaderboard_driver(js_body: str) -> dict:
             _extract_function(app_src, "escapeHtml"),
             _extract_function(src, "formatEntryBadge"),
             _extract_function(src, "formatLeaderboardNumber"),
+            # Both reached by the row/detail renderers: `portfolio_value` is
+            # `float | null` on the wire now, and the dash formatter is what
+            # keeps an absent value from rendering as `$0.00`.
+            _extract_function(src, "finiteNumber"),
+            _extract_function(src, "formatLeaderboardMoneyOrDash"),
             _extract_function(src, "renderLeaderboardRowHtml"),
             _extract_function(src, "renderLeaderboardDetailHtml"),
             "const entry = JSON.parse(process.argv[1]);",

--- a/dashboard/backend/tests/test_leaderboard_curve_integrity.py
+++ b/dashboard/backend/tests/test_leaderboard_curve_integrity.py
@@ -422,6 +422,50 @@ def test_the_scaling_shim_says_it_is_a_shim():
 
 
 # --------------------------------------------------------------------------
+# #365 criterion 2 — config and stored rows agree
+# --------------------------------------------------------------------------
+
+
+def test_the_config_capital_matches_what_the_committed_rows_were_run_at():
+    """The product decision on this branch, pinned against prod's own database.
+
+    ``dashboard/storage/data/backtest.db`` is not a fixture — on the free-tier
+    Render service it *is* the running database. Every contest row in it was
+    computed at $100,000, so aligning ``leaderboard.json`` makes those rows
+    correct as they stand and needs no re-run (#194, the re-run, is blocked on
+    LLM credits).
+
+    This is the only case in this file that depends on the alignment, and it
+    ships in the same commit as it, so dropping that commit drops this guard
+    with it. Everything else here is written against whatever the config says.
+    """
+    import sqlite3
+
+    from dashboard.backend.paths import DEFAULT_DB_PATH
+
+    config = lb_service.load_leaderboard_config()
+    conn = sqlite3.connect(f"file:{DEFAULT_DB_PATH}?immutable=1", uri=True)
+    try:
+        seeds = [
+            row[0]
+            for row in conn.execute(
+                "SELECT DISTINCT initial_equity FROM agent_runs WHERE mode = ?",
+                (lb_service.LEADERBOARD_MODE,),
+            )
+        ]
+    finally:
+        conn.close()
+
+    assert seeds, "the committed seed database has no leaderboard rows"
+    for seed in seeds:
+        assert seed == pytest.approx(config["initial_capital"], abs=0.01), (
+            f"a committed leaderboard row was run at {seed} while "
+            f"leaderboard.json publishes {config['initial_capital']} — the board "
+            "would mix capital bases"
+        )
+
+
+# --------------------------------------------------------------------------
 # #365 criterion 3 — warn on mixed capital, on the feed-drift pattern
 # --------------------------------------------------------------------------
 

--- a/dashboard/backend/tests/test_leaderboard_curve_integrity.py
+++ b/dashboard/backend/tests/test_leaderboard_curve_integrity.py
@@ -135,6 +135,7 @@ class _Board:
         equities,
         run_id=None,
         final_equity=None,
+        total_return=0.05,
         session_id=_SESSION,
     ):
         """One cached leaderboard run and its curve. ``equities`` may hold None."""
@@ -157,7 +158,7 @@ class _Board:
                 if final_equity is not None
                 else (finite[-1] if finite else None)
             ),
-            total_return=0.05,
+            total_return=total_return,
             sharpe_ratio=1.0,
             max_drawdown=-0.01,
             num_trades=1,
@@ -213,6 +214,8 @@ def board(tmp_path, monkeypatch):
     # drift would otherwise see no line at all.
     monkeypatch.setattr(lb_service, "_warned_seed_mismatch", set())
     monkeypatch.setattr(lb_service, "_warned_capital_drift", set())
+    monkeypatch.setattr(lb_service, "_warned_prompt_drift", set())
+    monkeypatch.setattr(lb_service, "_warned_curve_integrity", set())
     return _Board(test_db, monkeypatch)
 
 
@@ -960,12 +963,20 @@ def test_a_run_with_no_final_equity_publishes_null_not_starting_capital(board):
 
 
 def test_an_absent_portfolio_value_still_ranks(board):
-    """``_rank_sort_key`` falls back to ``cumulative_return`` for a None.
+    """Publishing null would be a regression if it made the entry unsortable.
 
-    Publishing null would be a regression if it made the entry unsortable.
+    ⚠ Asserting only that the ranks are ``[1, 2]`` is not a test: a total order
+    always produces those. **Which** entry got rank 1 is the whole question, and
+    the old ``pv = cumulative_return or 0`` fallback got it backwards — it
+    ranked a *fraction* (0.20) against its neighbour's *dollars* (105,000), so
+    the better run placed last precisely because its dollars were absent.
     """
     run_id = _seed_run(
-        board, "djia_index", initial_equity=_DISPLAY_CAPITAL, equities=[_DISPLAY_CAPITAL]
+        board,
+        "djia_index",
+        initial_equity=_DISPLAY_CAPITAL,
+        equities=[_DISPLAY_CAPITAL],
+        total_return=0.20,
     )
     board.set_final_equity(run_id, None)
     _seed_run(
@@ -973,11 +984,21 @@ def test_an_absent_portfolio_value_still_ranks(board):
         "spy_index",
         initial_equity=_DISPLAY_CAPITAL,
         equities=[_DISPLAY_CAPITAL, _DISPLAY_CAPITAL * 1.05],
+        final_equity=_DISPLAY_CAPITAL * 1.05,
+        total_return=0.05,
     )
 
     payload = lb_service.get_leaderboard()
+    by_id = {e["entry_id"]: e for e in payload["entries"]}
 
     assert [e["rank"] for e in payload["entries"]] == [1, 2]
+    assert by_id["djia_index"]["rank"] == 1, (
+        "a +20% run must outrank a +5% one; ranking its return against the "
+        "other's dollars buried it"
+    )
+    assert by_id["djia_index"]["portfolio_value"] is None, (
+        "the reconstruction is a sort key only — the wire value stays absent"
+    )
 
 
 def test_both_tables_render_an_absent_portfolio_value_as_a_dash():
@@ -1172,8 +1193,16 @@ def test_a_derived_seed_that_differs_from_the_board_is_reported(board, capsys):
 
     It scans rows for a *recorded* seed; this row has none, so its seed came
     from the curve's own first point and the board-level scan skips it.
+
+    ⚠ **The second entry is load-bearing.** A single-entry board makes
+    `_board_capital_base` return the derived seed itself, so the row passes the
+    majority filter for a reason that says nothing about the code under test —
+    and this case went green for a year against a build where the warning was
+    unreachable on every board that had more than one row. A recorded neighbour
+    at the published capital is the shape production actually has.
     """
     _seed_run(board, "djia_index", initial_equity=None, equities=[_OTHER_CAPITAL, _OTHER_CAPITAL * 1.05])
+    _seed_run(board, "spy_index", initial_equity=_DISPLAY_CAPITAL, equities=[_DISPLAY_CAPITAL])
 
     lb_service.get_leaderboard()
     lb_service.get_leaderboard()
@@ -1196,3 +1225,247 @@ def test_a_recorded_seed_is_not_reported_twice(board, capsys):
 
     assert "not comparable" in out
     assert "published seed" not in out
+
+
+# --------------------------------------------------------------------------
+# review follow-ups — the same absent-as-a-value defect, three more places
+# --------------------------------------------------------------------------
+
+
+def test_a_derived_seed_is_not_outvoted_by_the_recorded_majority(board, capsys):
+    """A derived seed is an estimate, and estimates do not get a vote.
+
+    ``_stored_seed`` falls back to the curve's own first equity point, which is
+    the equity at the **end** of the run's first hour — seed plus one hour of
+    P&L. Holding that to the board's base at a one-cent tolerance asks "was this
+    strategy exactly flat at the open?", not "was this run seeded differently",
+    and every derived row that moved at all answered no and vanished from a
+    public board. Publishing it through the scaling shim with a warning is the
+    outcome ``_warn_on_seed_mismatch`` was written for.
+    """
+    for entry_id in ("djia_index", "spy_index"):
+        _seed_run(board, entry_id, initial_equity=_DISPLAY_CAPITAL, equities=[_DISPLAY_CAPITAL])
+    # No recorded seed, and a curve whose first point is one good hour above it.
+    _seed_run(
+        board,
+        "buy_hold_djia",
+        initial_equity=None,
+        equities=[_DISPLAY_CAPITAL * 1.004, _DISPLAY_CAPITAL * 1.01],
+    )
+
+    payload = lb_service.get_leaderboard()
+    out = capsys.readouterr().out
+
+    assert {e["entry_id"] for e in payload["entries"]} == {
+        "djia_index",
+        "spy_index",
+        "buy_hold_djia",
+    }, "a row whose seed nobody recorded must not be dropped for having moved"
+    assert "buy_hold_djia" in out and "#194" in out, (
+        "and it is still reported, because its scale came off its own curve"
+    )
+
+
+def test_a_recorded_minority_is_still_dropped_when_a_derived_row_is_present(board, capsys):
+    """The narrowing must not weaken the check it narrows.
+
+    A *recorded* seed that disagrees is still two runs at two capitals, and the
+    derived row sitting beside it neither rescues it nor votes for it.
+    """
+    for entry_id in ("djia_index", "spy_index"):
+        _seed_run(board, entry_id, initial_equity=_DISPLAY_CAPITAL, equities=[_DISPLAY_CAPITAL])
+    _seed_run(board, "buy_hold_djia", initial_equity=_OTHER_CAPITAL, equities=[_OTHER_CAPITAL])
+    _seed_run(board, "equal_weight_djia", initial_equity=None, equities=[_OTHER_CAPITAL])
+
+    published = {e["entry_id"] for e in lb_service.get_leaderboard()["entries"]}
+
+    assert "buy_hold_djia" not in published, "a recorded outlier is still dropped"
+    assert published == {"djia_index", "spy_index", "equal_weight_djia"}
+
+
+def test_a_board_where_nobody_recorded_a_seed_publishes_every_row(board):
+    """``_board_capital_base`` returning None means "no votes", never "no board".
+
+    The old code could not reach this state — every row voted — so the guard has
+    to be pinned: an all-derived board (every row predating the column being
+    written) must degrade to publishing everything with the shim, not to empty.
+    """
+    for entry_id in ("djia_index", "spy_index", "buy_hold_djia"):
+        _seed_run(board, entry_id, initial_equity=None, equities=[_OTHER_CAPITAL])
+
+    payload = lb_service.get_leaderboard()
+
+    assert len(payload["entries"]) == 3
+
+
+def test_the_remediation_text_does_not_send_an_operator_to_empty_the_board(board, capsys):
+    """⚠ A half-refresh is worse than no refresh, and the old copy prescribed it.
+
+    ``ensure_leaderboard_runs`` recomputes only ``_auto_compute`` strategies, so
+    "force-refresh to recompute" moves the five baselines to the new seed and
+    strands the seven LLM entries at the old one. That does not align the board,
+    it *mixes* it — and the seven then outvote the five, dropping every baseline
+    and the chart's benchmarks with them.
+    """
+    _seed_run(board, "djia_index", initial_equity=_OTHER_CAPITAL, equities=[_OTHER_CAPITAL])
+
+    lb_service.get_leaderboard()
+    out = capsys.readouterr().out
+
+    assert "Force-refresh to recompute" not in out
+    assert "deploy_model_run" in out, (
+        "the LLM half needs naming, or the operator does half the job"
+    )
+
+
+def test_a_broken_curve_is_reported_once_per_process(board, capsys):
+    """Same credibility budget as the two warnings beside it.
+
+    This runs per entry on a public unauthenticated GET, so an undeduped line
+    is one ERROR per broken curve per page load, forever.
+    """
+    _seed_run(board, "djia_index", initial_equity=_DISPLAY_CAPITAL, equities=[None, None])
+
+    lb_service.get_leaderboard()
+    lb_service.get_leaderboard()
+    lines = [
+        ln
+        for ln in capsys.readouterr().out.splitlines()
+        if "djia_index" in ln and "broken, not absent" in ln
+    ]
+
+    assert len(lines) == 1, lines
+
+
+def test_a_drifted_baseline_does_not_inflate_the_model_drift_count(board):
+    """Every other number in that dict is counted over the LLM entries alone.
+
+    ``_cached_run_index`` ranks every run in the session and window, baselines
+    included, so ``len(drifted_ids)`` could report more of a population drifted
+    than the population has members.
+    """
+    config = lb_service.resolve_leaderboard_config("contest")
+    llm_id = lb_service.llm_leaderboard_entries(config)[0]["id"]
+    _seed_run(board, "djia_index", initial_equity=_OTHER_CAPITAL, equities=[_OTHER_CAPITAL])
+    _seed_run(board, llm_id, initial_equity=_OTHER_CAPITAL, equities=[_OTHER_CAPITAL])
+
+    status = lb_service._daily_models_status(config)
+
+    assert status["models_config_drift"] == 1, "the drifted baseline is not a model"
+    assert status["models_config_drift"] <= status["models_cached"] <= status["models_total"]
+
+
+def test_a_changed_instruction_is_reported_when_the_cached_curve_is_reused(
+    board, monkeypatch, capsys
+):
+    """Fail-closed is not fail-visible (CLAUDE.md).
+
+    Reusing the cached curve on a config edit is deliberate — the alternative is
+    answering one line of JSON with a billable redeploy of the whole board — but
+    ``_warn_on_capital_drift`` finds nothing when the disagreement is the prompt,
+    so "nobody changed the instruction" and "the instruction changed and is
+    being ignored" were byte-identical from outside.
+    """
+    entry_id = "claude_haiku_4_5"
+    run_id = _seed_run(board, entry_id, initial_equity=_DISPLAY_CAPITAL, equities=[_DISPLAY_CAPITAL])
+    board.set_metadata(run_id, {"strategy_prompt": "buy the dip"})
+    monkeypatch.setattr(
+        lb_service,
+        "resolve_leaderboard_config",
+        lambda period=None: {
+            "session_id": _SESSION,
+            "start_date": _START,
+            "end_date": _END,
+            "initial_capital": _DISPLAY_CAPITAL,
+            "period": "contest",
+            "strategies": [
+                {"id": entry_id, "strategy": "llm_agent", "strategy_prompt": "sell the rip"}
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        lb_service,
+        "get_strategy",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("a drifted prompt must not trigger a billable deploy")
+        ),
+    )
+
+    result = lb_service.deploy_model_run(entry_id)
+    out = capsys.readouterr().out
+
+    assert result["cached"] is True, "reuse is the intended behaviour"
+    assert "strategy_prompt" in out and entry_id in out, (
+        "and it must not be silent about what it reused"
+    )
+    assert "buy the dip" not in out and "sell the rip" not in out, (
+        "operator config can run to paragraphs; the line names the entry, not "
+        "the prompt"
+    )
+
+
+_SORT_HARNESS = (
+    _extract_function(_LEADERBOARD_JS, "finiteNumber"),
+    _extract_function(_LEADERBOARD_JS, "getFilteredLeaderboardEntries"),
+)
+
+
+def _sorted_ids(entries_js, field, direction):
+    return _run_node(
+        *_SORT_HARNESS,
+        f"let leaderboardPayload = {{ entries: {entries_js} }};",
+        f"let currentLeaderboardSort = '{field}';",
+        f"let currentLeaderboardSortDir = '{direction}';",
+        (
+            # Parenthesised, not two adjacent literals in the argument list:
+            # `py/implicit-string-concatenation-in-list` is a live alert class in
+            # this repo (PR #450 closed five of them) and an accidental
+            # concatenation reads as a missing comma.
+            "console.log(JSON.stringify("
+            "getFilteredLeaderboardEntries().map((e) => e.entry_id)));"
+        ),
+    )
+
+
+def test_the_value_sort_does_not_place_an_absent_value_at_the_top(board):
+    """`Number(v) || 0` was still in the comparator after the cell learned `—`.
+
+    Ascending, a run whose final equity nobody recorded scored $0 and sorted
+    *first* — the table's most prominent row, claiming a total loss nobody
+    measured.
+    """
+    entries = (
+        "[{entry_id:'has',portfolio_value:105000},"
+        "{entry_id:'absent',portfolio_value:null},"
+        "{entry_id:'low',portfolio_value:99000}]"
+    )
+
+    assert _sorted_ids(entries, "value", "asc") == ["low", "has", "absent"]
+
+
+def test_the_value_sort_keeps_an_absent_value_out_of_the_bottom_claim_too(board):
+    """Missing leaves the axis in BOTH directions.
+
+    Flipping it with the arrow is the same invented claim wearing the other
+    sign: descending, `|| 0` ranked an unrecorded run *above* every genuine
+    loss on the board.
+    """
+    entries = (
+        "[{entry_id:'up',cumulative_return:0.05},"
+        "{entry_id:'absent',cumulative_return:null},"
+        "{entry_id:'down',cumulative_return:-0.10}]"
+    )
+
+    assert _sorted_ids(entries, "return", "desc") == ["up", "down", "absent"]
+    assert _sorted_ids(entries, "return", "asc") == ["down", "up", "absent"]
+
+
+def test_a_real_zero_still_sorts_as_a_number(board):
+    """The point is never "treat 0 as missing" — an account can really be flat."""
+    entries = (
+        "[{entry_id:'up',cumulative_return:0.05},"
+        "{entry_id:'flat',cumulative_return:0},"
+        "{entry_id:'absent',cumulative_return:null}]"
+    )
+
+    assert _sorted_ids(entries, "return", "desc") == ["up", "flat", "absent"]

--- a/dashboard/backend/tests/test_leaderboard_curve_integrity.py
+++ b/dashboard/backend/tests/test_leaderboard_curve_integrity.py
@@ -1,0 +1,1154 @@
+"""Guards for issues #390 and #365 in ``get_leaderboard``.
+
+**#390 — a NULL equity published as a real $0.**
+``float(pt.get("equity") or 0)`` turned "nobody observed this hour" into "the
+account held nothing". ``chart_equity_curve`` prepends an open tick at starting
+capital, so the series read as a −100% loss, and ``align_equity_curves`` puts
+every entry on one shared axis — so a single such point sets the y-range and
+flattens every honest curve on the board. The fix is the wire format: the server
+emits ``null`` and each surface null-fills it the way it already null-fills a
+missing timestamp.
+
+**#365 — one board, two capital bases.** The twelve published contest curves in
+the committed seed database were all computed at **$100,000** (verified below,
+against the file itself). ``leaderboard.json`` was later changed to
+``initial_capital: 10000``, and because the cache key omitted seed capital the
+two halves of the board diverged: ``auto_compute`` baselines recompute at the
+new number while LLM entries stay cached at the old one. That is not a display
+problem — a $10k account buys whole shares in a coarser quantum and pays
+per-trade costs against a smaller base, so it is a *different run* of the same
+strategy. Rescaling the dollar levels hides the difference and repairs nothing.
+This branch aligns the config to $100,000, so the stored rows are correct as
+they stand and no re-run is needed (#194 is blocked on LLM credits).
+
+⚠ **Seed capital is a ranking key in the cache, never a filter, and the tests
+below pin that as a spend control.** A config change that made rows *miss* would
+not be quiet: ``ensure_leaderboard_runs`` answers a miss by recomputing on a
+public unauthenticated GET, and ``_daily_models_status`` reports one as
+*pending*, which is what ``maybe_schedule_daily_leaderboard_refresh`` acts on —
+``refresh_daily_leaderboard`` then calls ``deploy_model_run`` for every
+configured LLM entry. With ``LEADERBOARD_DAILY_AUTO_DEPLOY`` armed, one edit to
+``leaderboard.json`` would buy a billable re-run of the whole board from an
+anonymous request. ``_warn_on_capital_drift`` is the signal instead, following
+``_warn_on_feed_drift``, which set that policy for the identical problem one
+field over.
+
+The frontend cases run the real extracted functions under node, following
+test_frontend_leaderboard_hover.py.
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import dashboard.backend.database as db_module
+import dashboard.backend.domain.leaderboard.service as lb_service
+
+_FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
+_LEADERBOARD_JS = (_FRONTEND / "js" / "leaderboard.js").read_text(encoding="utf-8")
+_HOME_JS = (_FRONTEND / "home-page.js").read_text(encoding="utf-8")
+_APP_JS = (_FRONTEND / "app.js").read_text(encoding="utf-8")
+
+_SESSION = "leaderboard-contest"
+_START = "2026-04-15"
+_END = "2026-05-15"
+# Read from the config rather than hardcoded: the $100,000 alignment lands as its
+# own commit, and every case here must hold on both sides of it. A case that is
+# *about* the alignment lives with that commit, not here.
+_DISPLAY_CAPITAL = float(lb_service.load_leaderboard_config()["initial_capital"])
+# A seed no board publishes, for the drift cases.
+_OTHER_CAPITAL = _DISPLAY_CAPITAL / 10
+
+# Captured before the `board` fixture stubs it out, so the two cases that are
+# *about* the compute path can exercise the real one.
+_REAL_ENSURE_LEADERBOARD_RUNS = lb_service.ensure_leaderboard_runs
+
+
+# --------------------------------------------------------------------------
+# harness
+# --------------------------------------------------------------------------
+
+
+class _Board:
+    """A leaderboard database wired into the service, plus the two NULL shims.
+
+    ⚠ **A NULL cannot be written through the normal API today**, and that is
+    worth stating rather than working around silently:
+    ``equity_timeseries.equity`` and ``agent_runs.initial_equity`` are declared
+    ``NOT NULL`` in *both* backends (``database.py``, ``database_postgres.py``),
+    and the committed seed database — which *is* prod's database — holds no NULL
+    in either column today. So ``insert_equity_points`` raises rather than
+    storing the shape these defects mishandle.
+
+    That does not make the defects hypothetical, it makes the schema a *second*
+    layer that happens to hold:
+
+    * ``CREATE TABLE IF NOT EXISTS`` never tightens an existing table, so any
+      database created under a looser schema keeps it — and the committed seed
+      DB is itself proof that this drift happens: its ``equity_timeseries``
+      declares ``cash`` and ``positions_value`` **nullable** (the current
+      ``database.py`` declares both NOT NULL), and ``get_leaderboard`` scaled
+      those two columns through exactly the same ``or 0``.
+    * ``get_equity_curve`` is a plain row reader with no validation, so anything
+      the column can hold reaches the payload.
+
+    These shims therefore hand ``get_leaderboard`` the rows a looser database
+    would, at the seam it actually reads them through.
+    """
+
+    def __init__(self, test_db, monkeypatch):
+        self.db = test_db
+        self._curves = {}
+        self._seeds = {}
+        self._metadata = {}
+        self._finals = {}
+        real_curve = test_db.get_equity_curve
+        real_runs = test_db.get_runs_by_session
+
+        def get_equity_curve(run_id):
+            if run_id in self._curves:
+                return [dict(pt) for pt in self._curves[run_id]]
+            return real_curve(run_id)
+
+        def get_runs_by_session(session_id):
+            rows = real_runs(session_id)
+            for row in rows:
+                if row["run_id"] in self._seeds:
+                    row["initial_equity"] = self._seeds[row["run_id"]]
+                if row["run_id"] in self._metadata:
+                    row["metadata"] = self._metadata[row["run_id"]]
+                if row["run_id"] in self._finals:
+                    row["final_equity"] = self._finals[row["run_id"]]
+            return rows
+
+        monkeypatch.setattr(test_db, "get_equity_curve", get_equity_curve)
+        monkeypatch.setattr(test_db, "get_runs_by_session", get_runs_by_session)
+
+    def seed_run(
+        self,
+        strategy_id,
+        *,
+        initial_equity,
+        equities,
+        run_id=None,
+        final_equity=None,
+        session_id=_SESSION,
+    ):
+        """One cached leaderboard run and its curve. ``equities`` may hold None."""
+        run_id = run_id or (
+            f"lb_{strategy_id}_{_START.replace('-', '')}_{_END.replace('-', '')}"
+        )
+        finite = [e for e in equities if e is not None]
+        self.db.insert_run(
+            run_id=run_id,
+            session_id=session_id,
+            agent_name="Agentic Trading Lab",
+            mode="leaderboard",
+            start_date=_START,
+            end_date=_END,
+            # A placeholder when the case under test is "no seed recorded": the
+            # column is NOT NULL, so the NULL is applied on read (see above).
+            initial_equity=initial_equity if initial_equity is not None else 1.0,
+            final_equity=(
+                final_equity
+                if final_equity is not None
+                else (finite[-1] if finite else None)
+            ),
+            total_return=0.05,
+            sharpe_ratio=1.0,
+            max_drawdown=-0.01,
+            num_trades=1,
+            llm_model=strategy_id,
+        )
+        if initial_equity is None:
+            self._seeds[run_id] = None
+        self._curves[run_id] = [
+            {
+                "timestamp": f"2026-04-{15 + i:02d}T14:00:00+00:00",
+                "equity": equity,
+                "cash": equity,
+                "positions_value": 0 if equity is not None else None,
+                "daily_return": 0,
+            }
+            for i, equity in enumerate(equities)
+        ]
+        return run_id
+
+    def set_metadata(self, run_id, metadata):
+        """What ``_llm_run_metadata`` would have written for this run (PR #366)."""
+        self._metadata[run_id] = metadata
+
+    def set_final_equity(self, run_id, value):
+        """``agent_runs.final_equity`` is nullable in both backends."""
+        self._finals[run_id] = value
+
+
+@pytest.fixture
+def board(tmp_path, monkeypatch):
+    """An empty leaderboard database wired into the service.
+
+    ``ensure_leaderboard_runs`` is stubbed out for the same reason
+    test_leaderboard_api.py stubs it: unstubbed it reaches Alpaca for any
+    strategy it cannot find cached, which is all of them here.
+    """
+    test_db = db_module.BacktestDatabase(db_path=tmp_path / "leaderboard.db")
+    monkeypatch.setattr(db_module, "db", test_db)
+    monkeypatch.setattr(lb_service, "db", test_db)
+    monkeypatch.setattr(
+        lb_service,
+        "ensure_leaderboard_runs",
+        lambda force_refresh=False, period="contest", config=None: {
+            "session_id": _SESSION,
+            "start_date": _START,
+            "end_date": _END,
+            "period": "contest",
+            "created": 0,
+            "refreshed_at": "2026-09-11T00:00:00+00:00",
+        },
+    )
+    # One-shot warning state is module-level; a later test seeding the same
+    # drift would otherwise see no line at all.
+    monkeypatch.setattr(lb_service, "_warned_seed_mismatch", set())
+    monkeypatch.setattr(lb_service, "_warned_capital_drift", set())
+    return _Board(test_db, monkeypatch)
+
+
+def _seed_run(board, *args, **kwargs):
+    return board.seed_run(*args, **kwargs)
+
+
+def _entry(payload, entry_id):
+    return next((e for e in payload["entries"] if e["entry_id"] == entry_id), None)
+
+
+# --------------------------------------------------------------------------
+# #390 — a NULL equity is a gap, never a $0 account
+# --------------------------------------------------------------------------
+
+
+def test_a_null_equity_point_is_published_as_null_and_never_as_zero(board):
+    _seed_run(board, "djia_index", initial_equity=_DISPLAY_CAPITAL, equities=[_DISPLAY_CAPITAL, None, _DISPLAY_CAPITAL * 1.01])
+
+    entry = _entry(lb_service.get_leaderboard(), "djia_index")
+    equities = [pt["equity"] for pt in entry["equity_curve"]]
+
+    assert None in equities, (
+        "a stored NULL equity must survive to the wire as null; `or 0` published "
+        "an observation nobody made"
+    )
+    assert 0 not in equities and 0.0 not in equities
+
+
+def test_a_null_equity_point_does_not_drag_the_shared_axis(board):
+    """The damage is not one bad marker.
+
+    ``align_equity_curves`` puts every entry on one axis, so a single −100%
+    series sets the y-range and collapses the real board's spread into a sliver
+    at the top. The floor asserted here is deliberately crude: anything near
+    zero means a null became a dollar amount again.
+    """
+    _seed_run(board, "djia_index", initial_equity=_DISPLAY_CAPITAL, equities=[_DISPLAY_CAPITAL, None, _DISPLAY_CAPITAL * 1.01])
+    _seed_run(board, "spy_index", initial_equity=_DISPLAY_CAPITAL, equities=[_DISPLAY_CAPITAL, _DISPLAY_CAPITAL * 1.005, _DISPLAY_CAPITAL * 1.012])
+
+    payload = lb_service.get_leaderboard()
+    plotted = [
+        pt["equity"]
+        for entry in payload["entries"]
+        for pt in entry["equity_curve"]
+        if pt["equity"] is not None
+    ]
+
+    assert plotted, "the board published no plottable points at all"
+    assert min(plotted) > _DISPLAY_CAPITAL * 0.5, (
+        f"lowest plotted equity {min(plotted)} — a missing observation has been "
+        "rendered as a zero-dollar portfolio somewhere on the board"
+    )
+
+
+def test_cash_and_positions_value_are_nulled_too(board):
+    """Not defence in depth — the reachable half.
+
+    ``equity`` is ``NOT NULL`` in both backends, but the committed seed
+    database's own ``equity_timeseries`` declares ``cash`` and
+    ``positions_value`` **nullable** (``database.py`` declares them NOT NULL —
+    ``CREATE TABLE IF NOT EXISTS`` never tightened the existing table). Those
+    two columns went through exactly the same ``or 0``.
+    """
+    _seed_run(board, "djia_index", initial_equity=_DISPLAY_CAPITAL, equities=[_DISPLAY_CAPITAL, None])
+
+    curve = _entry(lb_service.get_leaderboard(), "djia_index")["equity_curve"]
+    gap = next(pt for pt in curve if pt["equity"] is None)
+
+    assert gap["cash"] is None
+    assert gap["positions_value"] is None
+
+
+def test_a_real_zero_equity_is_still_published(board):
+    """A blown account is not a missing observation and must not become a gap."""
+    _seed_run(board, "djia_index", initial_equity=_DISPLAY_CAPITAL, equities=[_DISPLAY_CAPITAL, 0, 0])
+
+    entry = _entry(lb_service.get_leaderboard(), "djia_index")
+    equities = [pt["equity"] for pt in entry["equity_curve"]]
+
+    assert 0.0 in equities
+    assert equities.count(None) == 0
+
+
+# --------------------------------------------------------------------------
+# #390 — absent must not be byte-identical to broken
+# --------------------------------------------------------------------------
+
+
+def test_a_wholly_null_curve_logs_an_error_at_the_wholesale_boundary(board, capsys):
+    _seed_run(board, "djia_index", initial_equity=_DISPLAY_CAPITAL, equities=[None, None, None])
+
+    lb_service.get_leaderboard()
+    out = capsys.readouterr().out
+
+    assert "ERROR" in out and "djia_index" in out
+    assert "broken, not absent" in out, (
+        "a contract break must be distinguishable in the log from an empty "
+        "window; a per-point warning cannot report a wholesale one"
+    )
+
+
+def test_a_curve_with_no_points_at_all_logs_an_error(board, capsys):
+    """A cached run with no curve is a broken write, not an empty window.
+
+    It publishes as a single opening tick at starting capital — a row that looks
+    like a flat, uneventful month.
+    """
+    _seed_run(board, "djia_index", initial_equity=_DISPLAY_CAPITAL, equities=[])
+
+    payload = lb_service.get_leaderboard()
+    out = capsys.readouterr().out
+
+    assert "ERROR" in out and "no equity points at all" in out
+    assert len(_entry(payload, "djia_index")["equity_curve"]) == 1
+
+
+def test_a_partial_gap_logs_one_aggregate_warning_not_one_line_per_point(board, capsys):
+    _seed_run(
+        board,
+        "djia_index",
+        initial_equity=_DISPLAY_CAPITAL,
+        equities=[_DISPLAY_CAPITAL, None, None, _DISPLAY_CAPITAL * 1.01],
+    )
+
+    lb_service.get_leaderboard()
+    lines = [ln for ln in capsys.readouterr().out.splitlines() if "djia_index" in ln]
+    gap_lines = [ln for ln in lines if "gaps" in ln]
+
+    assert len(gap_lines) == 1, gap_lines
+    assert "WARNING" in gap_lines[0] and "2 of 4" in gap_lines[0]
+
+
+# --------------------------------------------------------------------------
+# #365 — the seed comes from the run, never from the config
+# --------------------------------------------------------------------------
+
+
+def test_a_run_with_no_seed_and_no_usable_first_point_is_skipped_and_logged(board, capsys):
+    """A published row is a claim, and here there is no honest number to make it with.
+
+    The old fallback substituted the *config's* capital, which made ``scale``
+    exactly 1.0 — so the entry shipped at whatever scale the run happened to
+    have, labelled with the board's.
+    """
+    _seed_run(board, "djia_index", initial_equity=None, equities=[None, None])
+    _seed_run(board, "spy_index", initial_equity=_DISPLAY_CAPITAL, equities=[_DISPLAY_CAPITAL, _DISPLAY_CAPITAL * 1.01])
+
+    payload = lb_service.get_leaderboard()
+    out = capsys.readouterr().out
+
+    assert _entry(payload, "djia_index") is None, (
+        "an entry whose seed nobody recorded must not be published at an "
+        "unverified scale"
+    )
+    assert _entry(payload, "spy_index") is not None, "the rest of the board still ships"
+    assert "ERROR" in out and "djia_index" in out and "#365" in out
+
+
+def test_a_stored_zero_seed_does_not_collapse_to_config_capital(board, capsys):
+    """`run.get("initial_equity") or config[...]` — `0.0` is falsy.
+
+    The column is NOT NULL in both backends so the state cannot occur today, and
+    that is exactly why it had to be tightened while the line was open: nothing
+    else would ever have caught it. A zero seed is not a seed.
+    """
+    _seed_run(board, "djia_index", initial_equity=0.0, equities=[None, None])
+
+    payload = lb_service.get_leaderboard()
+
+    assert _entry(payload, "djia_index") is None
+    assert "ERROR" in capsys.readouterr().out
+
+
+def test_a_missing_seed_is_derived_from_the_curves_own_first_point(board):
+    """The curve is a fact about the run; the config is a fact about the board."""
+    _seed_run(
+        board,
+        "djia_index",
+        initial_equity=None,
+        equities=[_OTHER_CAPITAL, _OTHER_CAPITAL * 1.05],
+        final_equity=_OTHER_CAPITAL * 1.05,
+    )
+
+    entry = _entry(lb_service.get_leaderboard(), "djia_index")
+    equities = [pt["equity"] for pt in entry["equity_curve"] if pt["equity"] is not None]
+
+    assert max(equities) == pytest.approx(_DISPLAY_CAPITAL * 1.05), (
+        "a curve seeded at a tenth of the board must be rescaled from its own "
+        f"first point, not published unscaled: got {max(equities)}"
+    )
+    assert entry["initial_equity"] == pytest.approx(_DISPLAY_CAPITAL)
+
+
+def test_the_scaling_shim_says_it_is_a_shim():
+    """Scaling is only honest for a scale-free strategy.
+
+    Position sizing, whole-share quanta and per-trade costs make a $10k run a
+    genuinely different run from a $100k one. Nothing in the code stops a reader
+    treating the rescale as equivalence, so the comment has to.
+    """
+    source = Path(lb_service.__file__).read_text(encoding="utf-8")
+    marker = "SCALING IS A COMPATIBILITY SHIM, NOT A RE-RUN"
+    assert marker in source
+    note = source[source.index(marker) : source.index(marker) + 900]
+    assert "#194" in note, "the comment must point at the re-run that actually fixes it"
+
+
+# --------------------------------------------------------------------------
+# #365 criterion 3 — warn on mixed capital, on the feed-drift pattern
+# --------------------------------------------------------------------------
+
+
+def test_mixed_capital_within_one_board_is_warned_about(board, capsys):
+    _seed_run(board, "djia_index", initial_equity=_DISPLAY_CAPITAL, equities=[_DISPLAY_CAPITAL])
+    _seed_run(board, "spy_index", initial_equity=_OTHER_CAPITAL, equities=[_OTHER_CAPITAL])
+
+    lb_service.get_leaderboard()
+    # The board-level line specifically. The per-entry "not comparable with"
+    # line below it reports the drop, which is a different fact.
+    warnings = [
+        ln
+        for ln in capsys.readouterr().out.splitlines()
+        if "Curves seeded at different capital" in ln
+    ]
+
+    assert len(warnings) == 1, warnings
+    assert f"${_OTHER_CAPITAL:,.2f}" in warnings[0]
+    assert f"${_DISPLAY_CAPITAL:,.2f}" in warnings[0]
+
+
+def test_the_capital_warning_fires_once_per_process_like_the_feed_warning(board, capsys):
+    """This runs on the hot cached path of a public endpoint.
+
+    A line per page load buries itself, which is the reason ``_warn_on_feed_drift``
+    dedupes and the reason this one copies it.
+    """
+    _seed_run(board, "djia_index", initial_equity=_OTHER_CAPITAL, equities=[_OTHER_CAPITAL])
+
+    lb_service.get_leaderboard()
+    lb_service.get_leaderboard()
+    warnings = [
+        ln
+        for ln in capsys.readouterr().out.splitlines()
+        if "Curves seeded at different capital" in ln
+    ]
+
+    assert len(warnings) == 1, warnings
+
+
+def test_the_warning_sees_the_llm_entries_ensure_leaderboard_runs_cannot(board, capsys):
+    """`ensure_leaderboard_runs` skips every `auto_compute: false` entry before it
+    looks anything up, so its own `cached_runs` list is baselines only — and the
+    LLM half is exactly where the stale capital lives. `get_leaderboard` is the
+    only seam that sees the whole board.
+    """
+    _seed_run(board, "claude_haiku_4_5", initial_equity=_OTHER_CAPITAL, equities=[_OTHER_CAPITAL])
+
+    lb_service.get_leaderboard()
+    out = capsys.readouterr().out
+
+    assert "Curves seeded at different capital" in out
+
+
+# --------------------------------------------------------------------------
+# #365 criterion 1 — the key distinguishes seeds, and a drifted row is inert
+# --------------------------------------------------------------------------
+
+
+def test_the_run_id_is_seed_free_so_one_window_holds_exactly_one_row(board):
+    """The invariant that keeps a refresh from doubling the board.
+
+    Putting the seed in ``_run_id`` was tried and reverted: ``insert_run`` is
+    INSERT OR REPLACE on this id, and the twelve committed rows carry the
+    *seed-free* id — so a suffixed id would not replace them, it would insert
+    alongside them. The first force-refresh after such a change doubles every
+    entry and orphans twelve equity curves nothing prunes.
+    """
+    import inspect
+
+    assert lb_service._run_id("djia_index", _START, _END) == (
+        "lb_djia_index_20260415_20260515"
+    )
+    params = inspect.signature(lb_service._run_id).parameters
+    assert list(params) == ["strategy_id", "start_date", "end_date"], (
+        "a seed-dependent run id inserts beside the committed rows instead of "
+        "replacing them"
+    )
+
+
+def test_a_refresh_replaces_the_existing_row_rather_than_adding_one(board, monkeypatch):
+    """End to end, against the real writer, at a seed the stored row disagrees with.
+
+    The id must not vary with capital, so the second write lands on the first
+    row. Two rows for one window would be worse than the drift they record.
+    """
+
+    class _Strategy:
+        def num_trades(self):
+            return 0
+
+        def required_symbols(self):
+            return []
+
+        def run(self, bars, start_date, end_date, initial_capital):
+            return [
+                {
+                    "timestamp": f"{start_date}T14:00:00+00:00",
+                    "equity": initial_capital,
+                    "cash": initial_capital,
+                    "positions_value": 0,
+                }
+            ]
+
+    _seed_run(board, "djia_index", initial_equity=_OTHER_CAPITAL, equities=[_OTHER_CAPITAL])
+    monkeypatch.setattr(lb_service, "get_strategy", lambda entry: _Strategy())
+
+    _REAL_ENSURE_LEADERBOARD_RUNS(
+        force_refresh=True,
+        config={
+            "session_id": _SESSION,
+            "start_date": _START,
+            "end_date": _END,
+            "initial_capital": _DISPLAY_CAPITAL,
+            "period": "contest",
+            "strategies": [
+                {
+                    "id": "djia_index",
+                    "name": "Agentic Trading Lab",
+                    "strategy": "market_index",
+                }
+            ],
+        },
+    )
+
+    rows = [
+        run
+        for run in board.db.get_runs_by_session(_SESSION)
+        if run.get("llm_model") == "djia_index"
+    ]
+    assert len(rows) == 1, [r["run_id"] for r in rows]
+    assert rows[0]["initial_equity"] == pytest.approx(_DISPLAY_CAPITAL)
+
+
+def test_two_rows_for_one_window_are_ranked_not_guessed_between(board):
+    """Defensive, and honest about it.
+
+    The id invariant above means one window holds one row, so this state is not
+    reachable through the writers today. It is reachable through an imported or
+    hand-repaired database, and ``created_at DESC`` order is not a reason to
+    prefer one seed over another.
+    """
+    _seed_run(
+        board,
+        "djia_index",
+        initial_equity=_OTHER_CAPITAL,
+        equities=[_OTHER_CAPITAL],
+        run_id="lb_djia_index_20260415_20260515",
+    )
+    _seed_run(
+        board,
+        "djia_index",
+        initial_equity=_DISPLAY_CAPITAL,
+        equities=[_DISPLAY_CAPITAL],
+        run_id="lb_djia_index_20260415_20260515_imported",
+    )
+
+    at_other = lb_service._find_cached_run(
+        "djia_index", _START, _END, _SESSION, _OTHER_CAPITAL
+    )
+    at_board = lb_service._find_cached_run(
+        "djia_index", _START, _END, _SESSION, _DISPLAY_CAPITAL
+    )
+
+    assert at_other["initial_equity"] == pytest.approx(_OTHER_CAPITAL)
+    assert at_board["initial_equity"] == pytest.approx(_DISPLAY_CAPITAL)
+
+
+def test_a_drifted_row_is_still_a_cache_hit(board):
+    """THE SEED IS A RANKING KEY, NOT A FILTER — and that is a spend control.
+
+    Refusing the row would make it *missing*, and missing is what
+    ``ensure_leaderboard_runs`` answers by recomputing and what
+    ``_daily_models_status`` reports as pending. See the module docstring.
+    """
+    _seed_run(board, "djia_index", initial_equity=_OTHER_CAPITAL, equities=[_OTHER_CAPITAL])
+
+    run, rank = lb_service._resolve_cached_run(
+        "djia_index", _START, _END, _SESSION, _DISPLAY_CAPITAL
+    )
+
+    assert run is not None, "a drifted row must never read as a cache MISS"
+    assert rank == lb_service._CACHE_STALE
+
+
+def test_a_row_with_no_recorded_seed_is_a_cache_hit(board):
+    _seed_run(board, "spy_index", initial_equity=None, equities=[_DISPLAY_CAPITAL])
+
+    run, rank = lb_service._resolve_cached_run(
+        "spy_index", _START, _END, _SESSION, _DISPLAY_CAPITAL
+    )
+
+    assert run is not None
+    assert rank == lb_service._CACHE_UNRECORDED
+
+
+def test_a_float_wobble_in_a_stored_seed_is_the_same_seed(board):
+    """The committed board stores 100000.00000000003 for one entry."""
+    _seed_run(
+        board, "djia_index", initial_equity=_DISPLAY_CAPITAL + 3e-11, equities=[_DISPLAY_CAPITAL]
+    )
+
+    run, rank = lb_service._resolve_cached_run(
+        "djia_index", _START, _END, _SESSION, _DISPLAY_CAPITAL
+    )
+
+    assert run is not None
+    assert rank == lb_service._CACHE_MATCH
+
+
+def test_an_exact_seed_beats_an_unrecorded_one_which_beats_a_drifted_one(board):
+    for run_id, seed in (
+        ("lb_djia_index_20260415_20260515", _OTHER_CAPITAL),
+        ("lb_djia_index_20260415_20260515_x", None),
+        ("lb_djia_index_20260415_20260515_y", _DISPLAY_CAPITAL),
+    ):
+        _seed_run(
+            board,
+            "djia_index",
+            initial_equity=seed,
+            equities=[seed or _DISPLAY_CAPITAL / 2],
+            run_id=run_id,
+        )
+
+    run, rank = lb_service._resolve_cached_run(
+        "djia_index", _START, _END, _SESSION, _DISPLAY_CAPITAL
+    )
+    assert rank == lb_service._CACHE_MATCH
+    assert run["run_id"] == "lb_djia_index_20260415_20260515_y"
+
+
+def test_a_drifted_baseline_is_never_recomputed_on_a_public_get(board, monkeypatch):
+    """`ensure_leaderboard_runs` runs on every public GET of the board.
+
+    Treating a config change as "missing" would refetch Alpaca on every page
+    load for as long as the disagreement lasts — the failure
+    ``_warn_on_feed_drift`` was written to avoid, one field over.
+    """
+    _seed_run(board, "djia_index", initial_equity=_OTHER_CAPITAL, equities=[_OTHER_CAPITAL])
+
+    def _explode(*args, **kwargs):
+        raise AssertionError("a drifted row must not trigger a recompute")
+
+    monkeypatch.setattr(lb_service, "fetch_hourly_bars", _explode)
+    monkeypatch.setattr(lb_service, "get_strategy", _explode)
+
+    meta = _REAL_ENSURE_LEADERBOARD_RUNS(
+        config={
+            "session_id": _SESSION,
+            "start_date": _START,
+            "end_date": _END,
+            "initial_capital": _DISPLAY_CAPITAL,
+            "period": "contest",
+            "strategies": [{"id": "djia_index", "strategy": "market_index"}],
+        }
+    )
+
+    assert meta["cache_hit"] is True
+    assert meta["created"] == 0
+
+
+def test_a_drifted_model_is_never_redeployed_on_a_public_get(board, monkeypatch):
+    """The billable path: `get_leaderboard(period="daily")` ->
+    `maybe_schedule_daily_leaderboard_refresh` -> `refresh_daily_leaderboard`,
+    which calls `deploy_model_run` for EVERY configured LLM entry. It short
+    circuits only on a `_resolve_cached_run` hit, so a drifted row that read as
+    a miss would buy a real LLM run from an anonymous request.
+    """
+    _seed_run(board, "claude_haiku_4_5", initial_equity=_OTHER_CAPITAL, equities=[_OTHER_CAPITAL])
+
+    def _explode(*args, **kwargs):
+        raise AssertionError("a drifted row must not trigger a billable deploy")
+
+    monkeypatch.setattr(lb_service, "get_strategy", _explode)
+
+    result = lb_service.deploy_model_run("claude_haiku_4_5")
+
+    assert result["cached"] is True
+    assert result["run_id"] == "lb_claude_haiku_4_5_20260415_20260515"
+
+
+def test_a_drifted_model_is_counted_cached_not_pending(board, monkeypatch):
+    """`models_pending > 0` is the whole trigger for the deploy loop above."""
+    config = lb_service.resolve_leaderboard_config("contest")
+    entries = lb_service.llm_leaderboard_entries(config)
+    _seed_run(board, entries[0]["id"], initial_equity=_OTHER_CAPITAL, equities=[_OTHER_CAPITAL])
+
+    index, drifted = lb_service._cached_run_index(
+        _START, _END, _SESSION, _DISPLAY_CAPITAL
+    )
+
+    assert entries[0]["id"] in index, "drifted rows are cached, never missing"
+    assert entries[0]["id"] in drifted, "and they are still reported as drifted"
+
+
+def test_the_batched_index_agrees_with_the_scan(board):
+    """``_cached_run_index`` exists only to be ``_resolve_cached_run`` in one query.
+
+    Two predicates for one lookup is how the daily board's "models cached" count
+    and the board it then renders end up disagreeing.
+    """
+    _seed_run(
+        board,
+        "djia_index",
+        initial_equity=_OTHER_CAPITAL,
+        equities=[_OTHER_CAPITAL],
+        run_id="lb_djia_index_20260415_20260515",
+    )
+    _seed_run(
+        board,
+        "djia_index",
+        initial_equity=_DISPLAY_CAPITAL,
+        equities=[_DISPLAY_CAPITAL],
+        run_id="lb_djia_index_20260415_20260515_100000",
+    )
+    _seed_run(board, "spy_index", initial_equity=None, equities=[_DISPLAY_CAPITAL])
+
+    index, _ = lb_service._cached_run_index(_START, _END, _SESSION, _DISPLAY_CAPITAL)
+    for strategy_id in ("djia_index", "spy_index"):
+        scanned = lb_service._find_cached_run(
+            strategy_id, _START, _END, _SESSION, _DISPLAY_CAPITAL
+        )
+        assert index[strategy_id]["run_id"] == scanned["run_id"], strategy_id
+
+
+# --------------------------------------------------------------------------
+# #365 — strategy_prompt, the second key dimension (PR #366)
+# --------------------------------------------------------------------------
+
+
+def test_a_changed_instruction_does_not_silently_reuse_the_old_curve(board):
+    """The Open Track's competing variable rewrites the model's whole strategy.
+
+    Recorded in ``agent_runs.metadata`` since PR #366, and omitted from the key
+    until now — so editing an entry's instruction and redeploying returned the
+    cached row.
+    """
+    run_id = _seed_run(board, "claude_haiku_4_5", initial_equity=_DISPLAY_CAPITAL, equities=[_DISPLAY_CAPITAL])
+    board.set_metadata(run_id, {"strategy_prompt": "buy the dip"})
+
+    same = lb_service._resolve_cached_run(
+        "claude_haiku_4_5", _START, _END, _SESSION, _DISPLAY_CAPITAL, "buy the dip"
+    )
+    changed = lb_service._resolve_cached_run(
+        "claude_haiku_4_5", _START, _END, _SESSION, _DISPLAY_CAPITAL, "sell the rip"
+    )
+
+    assert same[1] == lb_service._CACHE_MATCH
+    assert changed[1] == lb_service._CACHE_STALE
+
+
+def test_an_unrecorded_instruction_is_unknown_and_not_a_mismatch(board):
+    """Every row in the committed seed database has ``metadata = NULL``.
+
+    Reading that as "this run used no prompt" would mark all twelve drifted the
+    moment any entry gains one.
+    """
+    _seed_run(board, "claude_haiku_4_5", initial_equity=_DISPLAY_CAPITAL, equities=[_DISPLAY_CAPITAL])
+
+    run, rank = lb_service._resolve_cached_run(
+        "claude_haiku_4_5", _START, _END, _SESSION, _DISPLAY_CAPITAL, "buy the dip"
+    )
+
+    assert run is not None
+    assert rank == lb_service._CACHE_UNRECORDED
+
+
+def test_a_prompt_the_config_does_not_set_is_not_compared(board):
+    """``_llm_run_metadata`` resolves the prompt off the strategy impl, not only
+    off ``leaderboard.json``, so a row can legitimately record one the config
+    does not name. Comparing one-sidedly would drop it off the board.
+    """
+    run_id = _seed_run(board, "claude_haiku_4_5", initial_equity=_DISPLAY_CAPITAL, equities=[_DISPLAY_CAPITAL])
+    board.set_metadata(run_id, {"strategy_prompt": "resolved from the impl"})
+
+    run, rank = lb_service._resolve_cached_run(
+        "claude_haiku_4_5", _START, _END, _SESSION, _DISPLAY_CAPITAL, None
+    )
+
+    assert run is not None
+    assert rank == lb_service._CACHE_MATCH
+
+
+# --------------------------------------------------------------------------
+# #365 — one capital base per board, and never an empty board
+# --------------------------------------------------------------------------
+
+
+def test_a_config_typo_cannot_empty_the_board(board, capsys):
+    """THE DEFECT IS MIXED CAPITAL, NOT CAPITAL THAT DISAGREES WITH CONFIG.
+
+    Entries that all share one seed are mutually comparable: the board is
+    internally consistent and merely mislabelled. Dropping every row because the
+    config names a third number turns a labelling problem into an outage on the
+    Competition Leaderboard, which CLAUDE.md calls the acquisition hook — from a
+    one-character edit.
+    """
+    for entry_id in ("djia_index", "spy_index", "buy_hold_djia"):
+        _seed_run(board, entry_id, initial_equity=_OTHER_CAPITAL, equities=[_OTHER_CAPITAL])
+
+    # A third value: neither the config's nor the stored rows'.
+    config = dict(lb_service.load_leaderboard_config())
+    config["initial_capital"] = _OTHER_CAPITAL * 5
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(lb_service, "load_leaderboard_config", lambda: config)
+        payload = lb_service.get_leaderboard()
+
+    assert len(payload["entries"]) == 3, "a config typo must not empty the board"
+    assert "Curves seeded at different capital" in capsys.readouterr().out
+
+
+def test_a_minority_seed_is_dropped_rather_than_ranked_against_the_rest(board, capsys):
+    """This is the state that actually corrupts a ranking.
+
+    A $10k run and a $100k run of the same strategy are different runs — the
+    smaller account buys whole shares in a coarser quantum — so ranking them
+    together compares two things that were not measured the same way. The
+    consistent majority publishes; the outlier does not.
+    """
+    for entry_id in ("djia_index", "spy_index"):
+        _seed_run(board, entry_id, initial_equity=_DISPLAY_CAPITAL, equities=[_DISPLAY_CAPITAL])
+    _seed_run(board, "buy_hold_djia", initial_equity=_OTHER_CAPITAL, equities=[_OTHER_CAPITAL])
+
+    payload = lb_service.get_leaderboard()
+    out = capsys.readouterr().out
+
+    assert {e["entry_id"] for e in payload["entries"]} == {"djia_index", "spy_index"}
+    assert "buy_hold_djia" in out and "not comparable with" in out
+
+
+def test_the_majority_wins_even_when_the_config_agrees_with_the_minority(board):
+    """The base is the board's, not the config's.
+
+    Publishing the config's seed here would keep one entry and drop two, which
+    is the empty-board failure in miniature — and it would rank nothing against
+    anything.
+    """
+    for entry_id in ("djia_index", "spy_index"):
+        _seed_run(board, entry_id, initial_equity=_OTHER_CAPITAL, equities=[_OTHER_CAPITAL])
+    _seed_run(board, "buy_hold_djia", initial_equity=_DISPLAY_CAPITAL, equities=[_DISPLAY_CAPITAL])
+
+    payload = lb_service.get_leaderboard()
+
+    assert {e["entry_id"] for e in payload["entries"]} == {"djia_index", "spy_index"}
+
+
+def test_a_tie_goes_to_the_seed_the_config_publishes(board):
+    """Deterministic, rather than whichever seed the DB happened to yield first."""
+    _seed_run(board, "djia_index", initial_equity=_DISPLAY_CAPITAL, equities=[_DISPLAY_CAPITAL])
+    _seed_run(board, "spy_index", initial_equity=_OTHER_CAPITAL, equities=[_OTHER_CAPITAL])
+
+    payload = lb_service.get_leaderboard()
+
+    assert [e["entry_id"] for e in payload["entries"]] == ["djia_index"]
+
+
+def test_the_seed_tolerance_is_not_exact_equality(board):
+    """``100000.00000000003`` is a real stored value, not a hypothetical.
+
+    An `==` here would split the committed board into two capital groups and
+    drop eleven entries as a "minority".
+    """
+    source = Path(lb_service.__file__).read_text(encoding="utf-8")
+    assert "_SEED_MATCH_TOLERANCE = 0.01" in source
+    assert "100000.00000000003" in source, (
+        "the comment naming the value that forces a tolerance must stay, or "
+        "someone will tighten this to `==`"
+    )
+
+
+# --------------------------------------------------------------------------
+# #365 — an unrecorded final equity is absent, not "finished level"
+# --------------------------------------------------------------------------
+
+
+def test_a_run_with_no_final_equity_publishes_null_not_starting_capital(board):
+    """``portfolio_value = display_capital`` was the same defect class.
+
+    A run that recorded no final equity was published as an account that ended
+    exactly level — a number nobody measured, in the column the board ranks on.
+    """
+    run_id = _seed_run(
+        board, "djia_index", initial_equity=_DISPLAY_CAPITAL, equities=[_DISPLAY_CAPITAL]
+    )
+    board.set_final_equity(run_id, None)
+
+    entry = _entry(lb_service.get_leaderboard(), "djia_index")
+
+    assert entry is not None, "the entry still publishes; only the value is absent"
+    assert entry["portfolio_value"] is None
+
+
+def test_an_absent_portfolio_value_still_ranks(board):
+    """``_rank_sort_key`` falls back to ``cumulative_return`` for a None.
+
+    Publishing null would be a regression if it made the entry unsortable.
+    """
+    run_id = _seed_run(
+        board, "djia_index", initial_equity=_DISPLAY_CAPITAL, equities=[_DISPLAY_CAPITAL]
+    )
+    board.set_final_equity(run_id, None)
+    _seed_run(
+        board,
+        "spy_index",
+        initial_equity=_DISPLAY_CAPITAL,
+        equities=[_DISPLAY_CAPITAL, _DISPLAY_CAPITAL * 1.05],
+    )
+
+    payload = lb_service.get_leaderboard()
+
+    assert [e["rank"] for e in payload["entries"]] == [1, 2]
+
+
+def test_both_tables_render_an_absent_portfolio_value_as_a_dash():
+    """`formatLeaderboardNumber(null)` is `0.00`, so the table printed `$0.00`.
+
+    Same conflation on the client as `or 0` was on the server, one column over.
+    """
+    body = _strip_comments(_LEADERBOARD_JS)
+    home = _strip_comments(_HOME_JS)
+
+    assert "formatLeaderboardMoneyOrDash(entry.portfolio_value)" in body
+    assert "$${formatLeaderboardNumber(entry.portfolio_value)}" not in body
+    # `Number(null)` is 0 and 0 is finite, so a bare `Number(value)` here never
+    # saw the shape the guard below it was written for.
+    home_fn = _extract_function(home, "homeFormatPortfolioValue")
+    assert "const n = Number(value);" not in home_fn
+    assert "Number.isFinite(n)" in home_fn
+
+
+# --------------------------------------------------------------------------
+# frontend — both readers of the changed wire format
+# --------------------------------------------------------------------------
+
+
+def _extract_function(source: str, name: str) -> str:
+    """The source of ``function <name>(...) { ... }``, brace-matched.
+
+    Extracted rather than restated so a rename or deletion fails these tests
+    instead of leaving them green against a copy that no longer ships.
+    """
+    start = source.index(f"function {name}(")
+    index = source.index("{", source.index(")", start))
+    depth = 0
+    while True:
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1]
+        index += 1
+
+
+def _run_node(*parts):
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is not available")
+    proc = subprocess.run(
+        [node, "-e", "\n".join(parts)], capture_output=True, text=True, timeout=30
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
+def _strip_comments(source: str) -> str:
+    """Whole-line comments only — an inline strip would eat the tail of any URL."""
+    import re
+
+    source = re.sub(r"/\*.*?\*/", "", source, flags=re.S)
+    return re.sub(r"(?m)^\s*//.*$", "", source)
+
+
+_CURVE_HARNESS = (
+    _extract_function(_LEADERBOARD_JS, "finiteNumber"),
+    _extract_function(_LEADERBOARD_JS, "chartTimeKey"),
+    _extract_function(_LEADERBOARD_JS, "buildEquityCurvesFromEntries"),
+    # Hoisted stub: the real one reaches a palette and module state this
+    # harness has no use for.
+    "function getSeriesStyle() { return { color: '#fff', dash: [], kind: 'model' }; }",
+)
+
+_TWO_ENTRIES = """
+const entries = [
+  { entry_id: 'a', model: 'A', initial_equity: 100000, equity_curve: [
+      { timestamp: '2026-04-15T14:00', equity: 100000 },
+      { timestamp: '2026-04-16T14:00', equity: %(bad)s },
+      { timestamp: '2026-04-17T14:00', equity: 101000 },
+  ]},
+  { entry_id: 'b', model: 'B', initial_equity: 100000, equity_curve: [
+      { timestamp: '2026-04-15T14:00', equity: 100000 },
+      { timestamp: '2026-04-16T14:00', equity: 100500 },
+      { timestamp: '2026-04-17T14:00', equity: 101200 },
+  ]},
+];
+const built = buildEquityCurvesFromEntries(entries);
+console.log(JSON.stringify({ a: built.curves.A, b: built.curves.B }));
+"""
+
+
+def test_app_chart_keeps_a_null_equity_null_instead_of_zeroing_it():
+    """`Number(pt.equity) || 0` was the client half of #390.
+
+    Null-filling the hour is what this function ALREADY does for a timestamp a
+    series does not carry, which is why the fix is to stop coercing rather than
+    to add a second rendering mode.
+    """
+    result = _run_node(*_CURVE_HARNESS, _TWO_ENTRIES % {"bad": "null"})
+
+    assert result["a"] == [100000, None, 101000], (
+        "the missing hour must stay null; zeroing it plots a -100% spike that "
+        "sets the y-range for every series on the shared axis"
+    )
+    assert result["b"] == [100000, 100500, 101200]
+
+
+@pytest.mark.parametrize("bad", ["null", "undefined", "''", "NaN", "'oops'"])
+def test_app_chart_treats_every_unparseable_equity_as_a_gap(bad):
+    """`Number.isFinite(Number(x))` alone would not do this: `Number(null)` is 0."""
+    result = _run_node(*_CURVE_HARNESS, _TWO_ENTRIES % {"bad": bad})
+
+    assert result["a"] == [100000, None, 101000], result["a"]
+
+
+def test_app_chart_still_plots_a_real_zero():
+    result = _run_node(*_CURVE_HARNESS, _TWO_ENTRIES % {"bad": "0"})
+
+    assert result["a"] == [100000, 0, 101000]
+
+
+def test_the_app_chart_reads_equity_through_the_landings_helper():
+    """One wire format, one definition of "is this a number".
+
+    ``finiteNumber`` is the landing's (``src/lib/leaderboard.ts``, PR #387),
+    ported under the same name: two readers of one payload answering that
+    question differently is how they drift.
+    """
+    body = _strip_comments(_LEADERBOARD_JS)
+    assert "function finiteNumber(value)" in body
+    assert "Number(pt.equity) || 0" not in body
+
+
+def test_the_chart_tooltip_does_not_print_a_missing_hour_as_zero_dollars():
+    """`(ds._raw && ds._raw[idx]) || 0` printed "$0.00" and "-100.00%"."""
+    body = _strip_comments(_LEADERBOARD_JS)
+    assert "finiteNumber(ds._raw ? ds._raw[idx] : null)" in body
+    assert "(ds._raw && ds._raw[idx]) || 0" not in body
+
+
+def test_the_marketplace_card_reads_a_null_equity_as_a_gap():
+    """app.js is the second reader of this payload, and its guard was inert.
+
+    `Number(point?.equity)` + `Number.isFinite` looks like a guard and is not:
+    `Number(null)` is 0 and 0 is finite, so the single most likely malformed
+    shape went straight through as a $0 account and drew the card's sparkline as
+    a collapse to −100%.
+    """
+    result = _run_node(
+        _extract_function(_APP_JS, "marketplaceIndexedPctSeries"),
+        _extract_function(_APP_JS, "marketplaceLinePath"),
+        """
+const series = marketplaceIndexedPctSeries([
+  { timestamp: 't0', equity: 100000 },
+  { timestamp: 't1', equity: null },
+  { timestamp: 't2', equity: 101000 },
+]);
+const path = marketplaceLinePath(series, (i) => i * 10, (p) => 100 - p);
+console.log(JSON.stringify({ pcts: series.map((p) => p.pct), path }));
+""",
+    )
+
+    assert result["pcts"][1] is None, (
+        "a missing observation must not become a -100% point on the card"
+    )
+    assert result["pcts"][0] == pytest.approx(0.0)
+    assert result["pcts"][2] == pytest.approx(1.0)
+    assert result["path"].count("M") == 2, (
+        f"the line must break at the gap rather than draw through it: {result['path']}"
+    )
+
+
+def test_the_marketplace_card_indexes_off_the_first_observed_point():
+    """A leading gap must not make the base null and every later pct NaN."""
+    result = _run_node(
+        _extract_function(_APP_JS, "marketplaceIndexedPctSeries"),
+        """
+const series = marketplaceIndexedPctSeries([
+  { timestamp: 't0', equity: null },
+  { timestamp: 't1', equity: 100000 },
+  { timestamp: 't2', equity: 101000 },
+]);
+console.log(JSON.stringify(series.map((p) => p.pct)));
+""",
+    )
+
+    assert result[0] is None
+    assert result[1] == pytest.approx(0.0)
+    assert result[2] == pytest.approx(1.0)
+
+
+def test_a_derived_seed_that_differs_from_the_board_is_reported(board, capsys):
+    """The one drift `_warn_on_capital_drift` cannot see.
+
+    It scans rows for a *recorded* seed; this row has none, so its seed came
+    from the curve's own first point and the board-level scan skips it.
+    """
+    _seed_run(board, "djia_index", initial_equity=None, equities=[_OTHER_CAPITAL, _OTHER_CAPITAL * 1.05])
+
+    lb_service.get_leaderboard()
+    lb_service.get_leaderboard()
+    lines = [
+        ln
+        for ln in capsys.readouterr().out.splitlines()
+        if "djia_index" in ln and "published seed" in ln
+    ]
+
+    assert len(lines) == 1, lines
+    assert "#194" in lines[0]
+
+
+def test_a_recorded_seed_is_not_reported_twice(board, capsys):
+    """One condition, one line. `_warn_on_capital_drift` owns the recorded case."""
+    _seed_run(board, "djia_index", initial_equity=_OTHER_CAPITAL, equities=[_OTHER_CAPITAL])
+
+    lb_service.get_leaderboard()
+    out = capsys.readouterr().out
+
+    assert "not comparable" in out
+    assert "published seed" not in out

--- a/dashboard/config/leaderboard.json
+++ b/dashboard/config/leaderboard.json
@@ -1,7 +1,7 @@
 {
   "session_id": "leaderboard-contest",
   "daily_session_id": "leaderboard-daily",
-  "initial_capital": 10000,
+  "initial_capital": 100000,
   "start_date": "2026-04-15",
   "end_date": "2026-05-15",
   "reference_start_date": "2026-03-15",

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -1530,7 +1530,7 @@
                     <h3 class="section-title">Live Trading Leaderboard</h3>
                     <p class="about-text">This board runs <strong>forward</strong>, in seasons of <strong>two weeks</strong>, Monday to Friday. &ldquo;Live&rdquo; describes the direction, not the money: this is <strong>simulated trading on real market data</strong> &mdash; no broker account, no real capital, and no order ever leaves this system.</p>
                     <p class="about-text">Each night after the 16:00 ET cash close, every entry is advanced one trading day: the model sees that day's real bars for the first time and its portfolio carries forward from where the previous day left it. Nobody &mdash; including us &mdash; knows what the next bar does when an entry locks, which is what separates this board from the fixed-window Competition one.</p>
-                    <p class="about-text">Seasons do not accumulate. Every season starts flat at $10,000, ranks only the days inside it, and ends. Entries do not carry over, so joining is a per-season decision.</p>
+                    <p class="about-text">Seasons do not accumulate. Every season starts flat at $100,000, ranks only the days inside it, and ends. Entries do not carry over, so joining is a per-season decision.</p>
                     <p class="about-text">If a night's advance fails, that day is <strong>marked as a gap</strong> and positions carry forward unchanged. It is never quietly re-run days later against a market that has already moved.</p>
                     <p class="about-text about-text-muted">We are in <strong>Season 0</strong>, the shakedown season: the engine that advances it is not deployed yet, so nothing on this tab is a standing. Until it ships, the board renders in preview and says so across the top. Season 1 is the first one that will count.</p>
                 </div>
@@ -1636,7 +1636,7 @@
                     <span class="season-next-advance" id="seasonNextAdvance">—</span>
                 </div>
                 <p class="season-reset-note">
-                    Every season starts flat at $10,000 and ranks only the days inside it.
+                    Every season starts flat at $100,000 and ranks only the days inside it.
                     Entries do not carry over &mdash; re-enter each season.
                 </p>
             </section>

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -2787,18 +2787,28 @@ function downsampleMarketplaceCurve(curve, maxPoints = 48) {
 }
 
 function marketplaceIndexedPctSeries(curve) {
-  // Cumulative return from the first equity point, in percent (0 = start).
+  // Cumulative return from the first OBSERVED equity point, in percent
+  // (0 = start). A point with no observation keeps its slot with `pct: null`
+  // so marketplaceLinePath can break the line there.
+  //
+  // `Number(point?.equity)` + `Number.isFinite` was NOT a guard against the
+  // shape that actually arrives: `Number(null)` is 0, and 0 is finite, so a
+  // stored NULL equity was read as a $0 account and drew this card's sparkline
+  // as a collapse to -100% (issue #390). Reject the empty shapes explicitly.
   if (!Array.isArray(curve) || curve.length < 2) return null;
-  const points = [];
-  for (const point of curve) {
-    const equity = Number(point?.equity);
-    if (!Number.isFinite(equity)) continue;
-    points.push({ t: point.timestamp, equity });
-  }
-  if (points.length < 2) return null;
-  const initial = points[0].equity;
+  const points = curve.map((point) => {
+    const raw = point == null ? null : point.equity;
+    const equity = (raw === null || raw === undefined || raw === '') ? NaN : Number(raw);
+    return { t: point?.timestamp, equity: Number.isFinite(equity) ? equity : null };
+  });
+  const observed = points.filter((point) => point.equity != null);
+  if (observed.length < 2) return null;
+  const initial = observed[0].equity;
   if (!initial) return null;
-  return points.map((point) => ({ t: point.t, pct: ((point.equity / initial) - 1) * 100 }));
+  return points.map((point) => ({
+    t: point.t,
+    pct: point.equity == null ? null : ((point.equity / initial) - 1) * 100,
+  }));
 }
 
 function formatMarketplaceMd(iso) {
@@ -2831,10 +2841,20 @@ function marketplaceNicePctTicks(min, max) {
 }
 
 function marketplaceLinePath(series, xOf, yOf) {
-  return series.map((point, i) => {
-    const cmd = i === 0 ? 'M' : 'L';
-    return `${cmd}${xOf(i).toFixed(1)},${yOf(point.pct).toFixed(1)}`;
-  }).join(' ');
+  // A null pct is a missing observation: lift the pen and start a new subpath,
+  // so the card shows a gap rather than bridging over hours nobody has data
+  // for. `M` therefore depends on the previous point, not on `i === 0`.
+  let penDown = false;
+  const parts = [];
+  series.forEach((point, i) => {
+    if (point.pct == null) {
+      penDown = false;
+      return;
+    }
+    parts.push(`${penDown ? 'L' : 'M'}${xOf(i).toFixed(1)},${yOf(point.pct).toFixed(1)}`);
+    penDown = true;
+  });
+  return parts.join(' ');
 }
 
 /** Agent vs DJIA comparison chart from real contest equity_curve points. */
@@ -2844,7 +2864,11 @@ function buildMarketplaceCompareChartHtml(agentCurve, benchmarkCurve, { positive
   const bench = marketplaceIndexedPctSeries(downsampleMarketplaceCurve(benchmarkCurve));
   const agentColor = positive ? '#4ade80' : '#f87171';
   const benchColor = '#94a3b8';
-  const pcts = agent.map((p) => p.pct).concat(bench ? bench.map((p) => p.pct) : []);
+  // Nulls are gaps, not data: including them would make Math.min/max NaN and
+  // poison every y coordinate on the card.
+  const pcts = agent.map((p) => p.pct)
+    .concat(bench ? bench.map((p) => p.pct) : [])
+    .filter((v) => v != null);
   const ticks = marketplaceNicePctTicks(Math.min(...pcts), Math.max(...pcts));
   const yMin = ticks[0];
   const yMax = ticks[ticks.length - 1];

--- a/dashboard/frontend/home-page.js
+++ b/dashboard/frontend/home-page.js
@@ -1786,7 +1786,13 @@ async function loadHomeLeaderboardModule() {
     }
 
     function homeFormatPortfolioValue(value) {
-        const n = Number(value);
+        // `Number(null)` is 0 and 0 is finite, so the guard below never saw the
+        // shape it was written for: a run with no recorded final equity
+        // rendered as `$0` rather than as no value. The server sends `null` for
+        // exactly that case.
+        const n = (value === null || value === undefined || value === '')
+            ? NaN
+            : Number(value);
         if (!Number.isFinite(n)) return '—';
         if (n >= 1000) {
             return `$${Math.round(n).toLocaleString('en-US')}`;

--- a/dashboard/frontend/home-page.js
+++ b/dashboard/frontend/home-page.js
@@ -1489,23 +1489,28 @@ function homeChartSeries(entries, build) {
             const raw = curves[label] || [];
             // Fractions, not dollars -- because of what the labels MEAN, not
             // for scale safety. The rank list beside this chart is its key and
-            // already renders percent (`homeFormatReturnPct`); and every dollar
-            // level here is a x0.1 rescale of a $100,000 backtest, since all 12
-            // published runs stored `initial_equity = 100000` while
-            // leaderboard.json declares `initial_capital: 10000`
-            // (service.py `scale = display_capital / stored_initial`). So a
-            // "$10,749" tick names an account that never existed, while
-            // `cumulative_return` comes off the stored run untouched by that
-            // rescale -- +7.49% is exactly what ran.
+            // already renders percent (`homeFormatReturnPct`), and percent is
+            // the number the stored run actually produced: `cumulative_return`
+            // comes off the row untouched by any display scaling.
+            //
+            // THE RESCALE THIS NOTE USED TO DESCRIBE IS GONE. It said every
+            // dollar level was a x0.1 rescale of a $100,000 backtest onto a
+            // $10,000 config base, so a "$10,749" tick named an account that
+            // never existed. leaderboard.json now declares
+            // `initial_capital: 100000`, which is what all 12 published runs
+            // were actually seeded at, so `scale` is 1.0 and the ticks are the
+            // run's own dollars. Kept as percent anyway: the rank list is this
+            // chart's key and renders percent, and nothing here should depend
+            // on a config value agreeing with the stored rows.
             //
             // Dividing per series rather than by one shared constant is
             // DEFENCE IN DEPTH on this function, not a live fix for issue #365:
             // get_leaderboard reports the same `display_capital` as every
-            // entry's `initial_equity`, so the bases agree today and a dollar
-            // axis would NOT draw a scale break. Do not re-derive that claim --
-            // it was measured and is false. #365's real damage is to the
-            // returns (a $10k re-run trades in a coarser share quantum), which
-            // no choice of y-axis can repair.
+            // entry's `initial_equity`, so the bases agree and a dollar axis
+            // would NOT draw a scale break. Do not re-derive that claim -- it
+            // was measured and is false. #365's real damage was to the returns
+            // (a $10k re-run trades in a coarser share quantum), which no
+            // choice of y-axis can repair.
             //
             // Same formula and same fallback order as
             // `transformLeaderboardChartData`'s 'cumulative' branch in

--- a/dashboard/frontend/js/leaderboard.js
+++ b/dashboard/frontend/js/leaderboard.js
@@ -1161,6 +1161,19 @@ function formatLeaderboardNumber(num) {
   return Number(num || 0).toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 }
 
+/** A dollar amount, or an em dash when there is no amount to render.
+ *
+ *  `formatLeaderboardNumber` answers `0.00` for null, undefined and '' -- fine
+ *  for a chart tick, wrong for a value that is simply absent. A run that
+ *  recorded no final equity used to reach the table as the board's starting
+ *  capital, i.e. an account that finished exactly level; the server now sends
+ *  `null`, and printing `$0.00` for it would be the same invention with a
+ *  different number. */
+function formatLeaderboardMoneyOrDash(value) {
+  const n = finiteNumber(value);
+  return Number.isFinite(n) ? `$${formatLeaderboardNumber(n)}` : '—';
+}
+
 function formatShortDate(isoDay) {
   if (!isoDay) return '';
   const d = new Date(String(isoDay).includes('T') ? isoDay : `${isoDay}T00:00:00`);
@@ -1183,6 +1196,24 @@ function formatChartTooltipLabel(ts) {
     });
   }
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+/** A finite number, or NaN for every shape that is not one.
+ *
+ *  Ported from the landing's `src/lib/leaderboard.ts` (PR #387) under the same
+ *  name and the same semantics, deliberately: both surfaces read the same
+ *  `equity_curve` payload, and "what counts as a number here" is not a question
+ *  two readers of one wire format get to answer differently.
+ *
+ *  The whole point is the first line. `Number.isFinite(Number(x))` is NOT this
+ *  function: `Number(null)` is 0 and 0 is finite, so the obvious guard passes
+ *  the single most likely malformed shape straight through -- and downstream,
+ *  a $0 account is a -100% return.
+ */
+function finiteNumber(value) {
+  if (value === null || value === undefined || value === '') return NaN;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : NaN;
 }
 
 /** Normalize equity timestamps to hour precision for shared-axis alignment. */
@@ -1209,7 +1240,23 @@ function buildEquityCurvesFromEntries(entries) {
     points.forEach((pt) => {
       const key = chartTimeKey(pt.timestamp);
       if (!key) return;
-      byTime[key] = Number(pt.equity) || 0;
+      // SKIPPED, NOT ZEROED. `Number(pt.equity) || 0` read every unparseable
+      // equity -- null, undefined, '', NaN -- as a $0 account, and the
+      // base-relative transforms downstream turn $0 into
+      // (0 - 10000) / 10000 = -100%. That does not misplace one marker: this
+      // chart shares ONE y-axis across every series, so a single -100% point
+      // sets the range and flattens the whole board's spread into a sliver
+      // (issue #390). The server now sends `null` for a stored NULL instead of
+      // 0; this is the client half of the same fix.
+      //
+      // Skipping rather than storing an explicit null: an unrecorded point is
+      // exactly a missing timestamp, which this function ALREADY represents --
+      // the map below fills `null` for any hour a series does not carry, and
+      // both charts null-fill from there. A REAL 0 still gets through and still
+      // reads -100%, which is what an account at zero actually did.
+      const value = finiteNumber(pt == null ? null : pt.equity);
+      if (!Number.isFinite(value)) return;
+      byTime[key] = value;
       timeSet.add(key);
     });
     perEntry.push({ entry, seriesLabel: entry.model || entry.team_name, byTime });
@@ -1320,7 +1367,7 @@ function renderLeaderboardRowHtml(entry) {
             <span class="team-badge">${escapeHtml(formatEntryBadge(entry.team_badge))}</span>
           </div>
         </td>
-        <td style="text-align: right; font-family: var(--font-mono);">$${formatLeaderboardNumber(entry.portfolio_value)}</td>
+        <td style="text-align: right; font-family: var(--font-mono);">${formatLeaderboardMoneyOrDash(entry.portfolio_value)}</td>
         <td style="text-align: right;" class="${retClass}">
           <span class="metric-value-text">${(ret * 100).toFixed(2)}%</span>
         </td>
@@ -1366,7 +1413,7 @@ function renderLeaderboardDetailHtml(entry, totalEntries) {
       </div>
       <div class="team-detail-row">
         <span class="team-detail-label">Value</span>
-        <span class="team-detail-value">$${formatLeaderboardNumber(entry.portfolio_value)}</span>
+        <span class="team-detail-value">${formatLeaderboardMoneyOrDash(entry.portfolio_value)}</span>
       </div>
       <div class="team-detail-row">
         <span class="team-detail-label">Return</span>
@@ -2103,6 +2150,9 @@ async function renderEquityCurvesChart() {
       fill: false,
       // Series use different hour grids (e.g. SPY :30 vs LLM :00). On a shared
       // axis that leaves many nulls; span across them so each curve still draws.
+      // An unrecorded point arrives as one more of those nulls and is bridged
+      // the same way -- #390's contract is that the server stops publishing it
+      // as a real $0, not that this chart grows a second rendering mode.
       spanGaps: true,
       hidden: hiddenSeries.has(label),
     });
@@ -2181,19 +2231,25 @@ async function renderEquityCurvesChart() {
             label(context) {
               const ds = context.dataset;
               const idx = context.dataIndex;
-              const equity = (ds._raw && ds._raw[idx]) || 0;
-              const ret = (equity - ds._initial) / (ds._initial || 1);
+              // `(ds._raw[idx]) || 0` printed "$0.00" and "-100.00%" for an
+              // hour with no observation -- the same conflation of absent with
+              // zero the series itself carried (issue #390). An em dash says
+              // "no data" and cannot be mistaken for a number.
+              const rawValue = finiteNumber(ds._raw ? ds._raw[idx] : null);
+              const equity = Number.isFinite(rawValue) ? rawValue : null;
+              const ret = equity == null ? null : (equity - ds._initial) / (ds._initial || 1);
               const entry = ds._entry || {};
               const lines = [
                 ds.label,
-                `Return: ${(ret * 100).toFixed(2)}%`,
-                `Value: $${formatLeaderboardNumber(equity)}`,
+                `Return: ${ret == null ? '—' : `${(ret * 100).toFixed(2)}%`}`,
+                `Value: ${equity == null ? '—' : `$${formatLeaderboardNumber(equity)}`}`,
                 `Rank: ${entry.rank ?? '—'} / ${leaderboardPayload?.total_entries || '—'}`,
               ];
 
               const benchDs = context.chart.data.datasets.find((d) => d.label === selectedBenchmarkLabel);
-              if (benchDs && benchDs.label !== ds.label && benchDs._raw && benchDs._raw[idx] != null) {
-                const benchRet = (benchDs._raw[idx] - benchDs._initial) / (benchDs._initial || 1);
+              const benchEquity = finiteNumber(benchDs && benchDs._raw ? benchDs._raw[idx] : null);
+              if (ret != null && benchDs && benchDs.label !== ds.label && Number.isFinite(benchEquity)) {
+                const benchRet = (benchEquity - benchDs._initial) / (benchDs._initial || 1);
                 const diff = (ret - benchRet) * 100;
                 const sign = diff >= 0 ? '+' : '';
                 lines.push(`vs ${shortName(selectedBenchmarkLabel)}: ${sign}${diff.toFixed(2)}%`);

--- a/dashboard/frontend/js/leaderboard.js
+++ b/dashboard/frontend/js/leaderboard.js
@@ -1316,29 +1316,46 @@ function getFilteredLeaderboardEntries() {
   // Left Rank stays the official portfolio-value rank; this only reorders rows.
   const entries = (leaderboardPayload?.entries || []).slice();
   const dir = currentLeaderboardSortDir === 'asc' ? 1 : -1;
-  const num = (v) => Number(v) || 0;
-  entries.sort((a, b) => {
-    let cmp = 0;
+  // `Number(v) || 0` used to live here, and it was the client half of the same
+  // defect this board just removed from the Value column's *rendering*: the
+  // server now sends `null` for a final equity nobody recorded, the cell draws
+  // an em dash -- and the comparator still scored it $0. Bottom of a descending
+  // sort, top of an ascending one: a run with no recorded value was presented as
+  // a total loss, in the column the board ranks on. (`Number(null)` is 0 and 0
+  // is finite, so the obvious `Number.isFinite(Number(x))` guard does not catch
+  // this either -- see `finiteNumber`.)
+  //
+  // Absent has no position on a numeric axis, so it leaves the axis: missing
+  // values sort to the END in BOTH directions, the way every spreadsheet
+  // handles a blank cell. Flipping them with the arrow would be the same
+  // invented claim wearing the other sign.
+  const sortKey = (entry) => {
     switch (currentLeaderboardSort) {
-      case 'rank':
-        cmp = num(a.rank) - num(b.rank);
-        break;
       case 'value':
-        cmp = num(a.portfolio_value) - num(b.portfolio_value);
-        break;
+        return finiteNumber(entry.portfolio_value);
       case 'return':
-        cmp = num(a.cumulative_return) - num(b.cumulative_return);
-        break;
+        return finiteNumber(entry.cumulative_return);
       case 'sharpe':
-        cmp = num(a.sharpe_ratio) - num(b.sharpe_ratio);
-        break;
-      case 'dd':
-        cmp = Math.abs(num(a.max_drawdown)) - Math.abs(num(b.max_drawdown));
-        break;
+        return finiteNumber(entry.sharpe_ratio);
+      case 'dd': {
+        const dd = finiteNumber(entry.max_drawdown);
+        return Number.isNaN(dd) ? NaN : Math.abs(dd);
+      }
+      case 'rank':
       default:
-        cmp = num(a.rank) - num(b.rank);
+        return finiteNumber(entry.rank);
     }
-    return cmp * dir;
+  };
+  entries.sort((a, b) => {
+    const x = sortKey(a);
+    const y = sortKey(b);
+    const xMissing = Number.isNaN(x);
+    const yMissing = Number.isNaN(y);
+    if (xMissing || yMissing) {
+      if (xMissing && yMissing) return 0;
+      return xMissing ? 1 : -1;
+    }
+    return (x - y) * dir;
   });
   return entries;
 }

--- a/dashboard/landing/src/components/home/storyline.ts
+++ b/dashboard/landing/src/components/home/storyline.ts
@@ -18,7 +18,14 @@ export const STORY_AGENT_NAME = "Alpha";
  *  board now sits four screens up, so naming a REAL roster model over the REAL
  *  contest window turned a fabricated `+14.2%` into a claim a visitor falsifies
  *  by scrolling: the board publishes that same model's actual return over that
- *  same window from that same $10,000 base.
+ *  same window.
+ *
+ *  The bases no longer coincide -- leaderboard.json publishes $100,000 and this
+ *  block is a user's own $10,000 backtest -- but do NOT treat that as the guard.
+ *  The falsifiable claim was always the RETURN, which is base-independent, and
+ *  a reader comparing two percentages does not check what each was seeded with.
+ *  This value is the demo user's setting, not a copy of the board's base, so it
+ *  stays at $10,000 and does not move when the board's does.
  *
  *  Breaking either half breaks the comparison; the window is the cheaper half,
  *  and both are broken here. Nothing else changed -- the numbers, the dollar

--- a/dashboard/landing/src/lib/leaderboard.ts
+++ b/dashboard/landing/src/lib/leaderboard.ts
@@ -14,7 +14,8 @@ export type LeaderboardEntry = {
   model: string;
   is_model: boolean;
   cumulative_return: number;
-  portfolio_value: number;
+  // `null` when the run recorded no final equity -- absent, not $0.
+  portfolio_value: number | null;
   initial_equity: number;
   equity_curve: EquityPoint[];
 };

--- a/dashboard/landing/src/lib/leaderboard.ts
+++ b/dashboard/landing/src/lib/leaderboard.ts
@@ -171,12 +171,17 @@ export function formatTooltipDate(isoStamp: string): string {
 }
 
 /** Fractions, not dollars, and not for scale safety -- because of what the
- *  labels MEAN. Every dollar level in this payload is a x0.1 rescale of a
- *  $100,000 backtest onto the config's $10,000 display base (leaderboard
- *  service.py), so a `$10,749` tick names an account that never existed, while
- *  the percent is exactly what ran. The old hero was allowed a dollar axis only
- *  because its curves were fabricated with a clean base of 1000; live data
- *  removes that premise. */
+ *  labels MEAN. The percent is exactly what ran: `cumulative_return` comes off
+ *  the stored row untouched by any display scaling.
+ *
+ *  THE RESCALE THIS NOTE USED TO DESCRIBE IS GONE. It said every dollar level
+ *  was a x0.1 rescale of a $100,000 backtest onto the config's $10,000 display
+ *  base, so a `$10,749` tick named an account that never existed.
+ *  leaderboard.json now declares `initial_capital: 100000` -- what all 12
+ *  published runs were actually seeded at -- so `scale` is 1.0. Kept as percent
+ *  anyway: the old hero was allowed a dollar axis only because its curves were
+ *  fabricated with a clean base of 1000, and live data removes that premise
+ *  whatever the base happens to be. */
 export function buildBoardData(payload: {
   entries?: LeaderboardEntry[];
   window?: { label?: string };


### PR DESCRIPTION
Reviewed and approved. Carries a product decision: the public board's headline dollar figures move 10x (commit `cd9ef340`, separable — verified droppable).

Closes #390. Closes #365. Links #194 (board re-run — no longer a prerequisite).

Two commits, deliberately separable:

| | |
|---|---|
| `057303e` **fix** | the defects. Verified green on its own. |
| `cd9ef34` **chore** | the $100k alignment, its guard test, and every piece of copy that states the base. **Verified: revert this one commit and the suite is green (4486 passed).** |

## ⚠ Product decision (second commit only): the board publishes $100,000

`leaderboard.json` `initial_capital: 10000` → `100000`. **Rankings, returns and Sharpe are identical** — only displayed dollar levels move (`+7.49%` reads `$107,494` instead of `$10,749`).

Verified against `dashboard/storage/data/backtest.db` (read-only, `immutable=1`), which on the free-tier Render service *is* prod's database:

| | |
|---|---|
| `initial_equity`, all 12 contest rows | **100000.0** (one `100000.00000000003`) |
| first stored curve point, all 12 | **exactly 100000.0** |
| NULLs in `initial_equity` / `equity` | **zero** |
| `agent_runs.metadata` | **NULL on all 12** |

Today the board is *accidentally* consistent — `scale = 0.1` normalises all twelve. The fragmentation #365 describes happens on **the next baseline refresh**, when the five `auto_compute` entries recompute at $10k while the seven LLM entries stay cached at $100k. Aligning removes the disagreement rather than managing it, and needs no re-run — which matters because #194 is blocked on LLM credits.

That commit also carries the copy that states the base independently: the Live Trading Leaderboard's two "every season starts flat at $10,000" lines in `app.html` (the live board reuses the contest config, so that *is* `initial_capital`), and the `home-page.js` / landing comments explaining their percent axis by a ×0.1 rescale that no longer happens. **Swept and deliberately left alone:** the $10k account ledger (`DEFAULT_PORTFOLIO_EQUITY`, portfolio panel, mock rows), the landing storyline's `$10,000` (a demo *user's* backtest, not the board's base), and the `|| 10000` last-resort chart fallbacks, which never fire and are pinned as an equivalence pair. The landing build output in `dashboard/frontend/assets/` needs no rebuild — its three `$10,000`/`$10k` strings are all the storyline demo.

## #390 — the column in the title is the one that cannot be null

⚠ Read this before the diff, or the fix looks misdirected. `equity` is `REAL NOT NULL` in **both** backends and in the committed DB, so a NULL `equity` is not reachable today. The committed DB's own `equity_timeseries` declares `cash REAL` and `positions_value REAL` — **nullable** — while `database.py:175-176` declares both `NOT NULL`. `CREATE TABLE IF NOT EXISTS` never tightened the existing table. So the reachable half of #390 is the two columns the issue title does not name, and this is a concrete instance of **schema drift being the risk, not the declared schema**.

All four of `equity`, `cash`, `positions_value` and `portfolio_value` are now `float | null`. The surfaces already null-fill a missing timestamp, so the client work is only the sites that **destroyed** the null:

- `js/leaderboard.js` — `Number(pt.equity) || 0`, the tooltip's `|| 0`, and `formatLeaderboardNumber(entry.portfolio_value)` which printed `$0.00`. All now go through `finiteNumber`, ported from the landing's `src/lib/leaderboard.ts` (PR #387) under the same name.
- `app.js` — `marketplaceIndexedPctSeries`'s guard was **inert**: `Number(null)` is `0` and `0` is finite, so a NULL drew the card's sparkline as a collapse to −100%.
- `home-page.js` — `homeFormatPortfolioValue`'s `Number.isFinite` guard, inert for the same reason.

Also fixed: `portfolio_value = display_capital` when `final_equity` was NULL published an account as finishing exactly level, in the column the board ranks on. And a stored `0.0` seed took the `or` branch, being falsy — now an explicit `is None` plus a finite/positive guard.

Absent and broken are no longer byte-identical: no points at all, or every point unusable → `ERROR`; a partial gap → one aggregate `WARNING` naming the count.

## #365 — one board, one capital base

The defect is **mixed** capital, not capital that disagrees with config. A $10k run and a $100k run of one strategy are different runs — the smaller account buys whole shares in a coarser quantum — so ranking them together compares things that were not measured the same way. Rescaling hides that and repairs nothing.

`_board_capital_base` picks the largest group of mutually-equal seeds; outliers are dropped with a line each. The rule is **relative, so it can never empty the board**: entries that agree with each other are internally consistent and merely mislabelled, and a config naming a third value still renders every row plus a loud warning.

## The cache key is a ranking key, never a filter — a spend control

Seed capital and `strategy_prompt` (PR #366, merged) join the lookup, ranked: recorded-and-matching → never-recorded → recorded-and-different. A row is always returned if one exists.

A filter would make a config change a **cache miss**, and a miss is not quiet:

- `ensure_leaderboard_runs` answers one by recomputing, on a public unauthenticated GET, on every page load while the config disagrees.
- `_daily_models_status` reports one as **pending** → `maybe_schedule_daily_leaderboard_refresh` → `refresh_daily_leaderboard`, which calls `deploy_model_run` for **every** configured LLM entry (it loops the roster; it never consults `pending_entry_ids`). With `LEADERBOARD_DAILY_AUTO_DEPLOY` armed, one config edit buys a billable re-run of the board from an anonymous request.

Pinned at all four seams. `_warn_on_capital_drift` is the signal instead, modelled on `_warn_on_feed_drift`, which set exactly this policy for the identical problem one field over.

**`_run_id` stays seed-free.** A seeded id was tried and reverted: the twelve committed rows carry seed-free ids, so a suffixed id does not replace them, it **inserts alongside** — the first force-refresh would double every entry and orphan twelve curves nothing prunes. One window holds exactly one row, pinned end-to-end.

## Notes

- `dashboard/backend/tests/test_leaderboard_curve_integrity.py`, **50 cases** (+1 in the chore commit), written against whatever the config says so they hold on both sides of the split. Suite green: **4487 passed, 163 skipped**.
- Two existing node harnesses gain the helpers their extracted functions now call (`test_frontend_chart_first_home.py`, `test_frontend_xss_guards.py`).
- `_SEED_MATCH_TOLERANCE = 0.01` is load-bearing: `100000.00000000003` is a real stored value, and `==` would split the committed board into two capital groups. Pinned by `test_the_seed_tolerance_is_not_exact_equality`.
- No user-facing doc under `docs/source/lab/` goes stale — its capital references are all per-agent Allocated Capital, not the board's base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PdsVmuCNd8iaC2Sff5B8jZ
