### PR TITLE
feat: add admin user groups and source analytics

### DIFF
--- a/dashboard/backend/api/routers/admin_analytics.py
+++ b/dashboard/backend/api/routers/admin_analytics.py
@@ -25,6 +25,7 @@ from dashboard.backend.domain.analytics.service import (
 )
 from dashboard.backend.domain.analytics.value_queries import (
     CommercialAnalyticsResponse,
+    GroupAnalyticsResponse,
     LifecycleAnalyticsResponse,
     MAX_VALUE_RANGE_DAYS,
     OperationalAnalyticsResponse,
@@ -34,6 +35,7 @@ from dashboard.backend.domain.analytics.value_queries import (
     ValueAnalyticsQueryService,
     ValueUserProfile,
 )
+from dashboard.backend.domain.user_groups import parse_user_group
 
 
 router = APIRouter(
@@ -214,6 +216,7 @@ def _value_user_filters(request: Request) -> tuple[UserValueFilters, int, int]:
             "lifecycle_segment",
             "operational_state",
             "commercial_tier",
+            "user_group",
             "activated",
             "last_meaningful_activity_from",
             "last_meaningful_activity_to",
@@ -235,6 +238,12 @@ def _value_user_filters(request: Request) -> tuple[UserValueFilters, int, int]:
     tier = values.get("commercial_tier")
     if tier is not None and tier not in _COMMERCIAL_TIERS:
         _invalid_query()
+    user_group = values.get("user_group")
+    if user_group is not None:
+        try:
+            user_group = parse_user_group(user_group)
+        except ValueError:
+            _invalid_query()
     legacy_status = values.get("status")
     if legacy_status is not None and legacy_status not in _USER_STATES:
         _invalid_query()
@@ -257,6 +266,7 @@ def _value_user_filters(request: Request) -> tuple[UserValueFilters, int, int]:
             lifecycle_segment=lifecycle_segment,
             operational_state=operational_state,
             commercial_tier=tier,
+            user_group=user_group,
             activated=(
                 _parse_bool(values["activated"]) if "activated" in values else None
             ),
@@ -483,6 +493,32 @@ def get_operational(
             billing_mode=billing_mode,
             provider_id=provider_id,
             model_id=model_id,
+        )
+    except Exception as exc:
+        _raise_service_error(exc)
+
+
+@router.get("/groups", response_model=GroupAnalyticsResponse)
+def get_groups(
+    request: Request,
+    service: ValueAnalyticsQueryService = Depends(get_value_analytics_query_service),
+):
+    start, end, include_internal, values = _value_range(
+        request,
+        additional={"user_group"},
+    )
+    selected_group = values.get("user_group")
+    if selected_group is not None:
+        try:
+            selected_group = parse_user_group(selected_group)
+        except ValueError:
+            _invalid_query()
+    try:
+        return service.get_groups(
+            start=start,
+            end=end,
+            include_internal=include_internal,
+            user_group=selected_group,
         )
     except Exception as exc:
         _raise_service_error(exc)

--- a/dashboard/backend/api/routers/admin_credits.py
+++ b/dashboard/backend/api/routers/admin_credits.py
@@ -223,6 +223,11 @@ def list_grant_users(
                 "email": identity["email"],
                 "display_name": identity["display_name"],
                 "role": identity["role"],
+                # Account Management is the canonical editor for this
+                # admin-only dimension. Keep the stable stored value alongside
+                # the identity fields so the frontend can render one select
+                # without a second users lookup.
+                "user_group": identity.get("user_group", "unknown"),
                 "balance": balance,
             }
         )

--- a/dashboard/backend/api/routers/admin_users.py
+++ b/dashboard/backend/api/routers/admin_users.py
@@ -18,6 +18,7 @@ from dashboard.backend.api.rate_limit import (
     client_ip,
     rate_limited_error,
 )
+from dashboard.backend.domain.user_groups import UserGroup
 from dashboard.backend.session_tokens import secrets_equal
 from dashboard.backend.users import (
     MAX_CONCURRENT_BACKTESTS_CAP,
@@ -91,6 +92,7 @@ _BOOTSTRAP_REFUSAL = "Invalid bootstrap secret"
 
 class AdminUserPatch(BaseModel):
     role: Optional[Literal["user", "admin"]] = None
+    user_group: Optional[UserGroup] = None
     # ge=0, not ge=1: a floor equal to the default quota is not a control. An
     # admin watching a fresh account burn LLM budget could only lower it to the
     # value that account already had; 0 is "suspended" and needs no new field
@@ -241,6 +243,7 @@ def patch_user(
         )
     if (
         payload.role is None
+        and payload.user_group is None
         and payload.max_concurrent_backtests is None
         and payload.credits is None
     ):
@@ -259,6 +262,13 @@ def patch_user(
                 detail="Cannot demote yourself; ask another admin",
             )
 
+    # Read the current admin projection before the atomic write. The projection
+    # is already the tolerant/coerced boundary for legacy malformed values, so
+    # the audit line below records the value an operator actually sees rather
+    # than whatever untrusted raw text happens to be in the database.
+    previous = users_module.user_store.get_user_admin(user_id)
+    previous_group = previous.get("user_group") if previous else None
+
     # One store call, one transaction. Applying the role and the entitlements
     # as two separate writes meant a failure on the second left the first
     # committed behind a 500, so the console kept showing a row the database no
@@ -267,6 +277,7 @@ def patch_user(
         updated = users_module.user_store.apply_admin_patch(
             user_id,
             role=payload.role,
+            user_group=payload.user_group,
             max_concurrent_backtests=payload.max_concurrent_backtests,
             credits=payload.credits,
             updated_by_admin_id=admin["id"],
@@ -280,6 +291,8 @@ def patch_user(
                 status_code=400,
                 detail="Cannot demote the last admin account",
             ) from exc
+        if code == "invalid_user_group":
+            raise HTTPException(status_code=422, detail="Invalid user group") from exc
         # invalid_role / invalid_* range errors are unreachable from this
         # route — the Pydantic model's Literal and Field bounds reject those
         # requests as 422 before the store runs — so they re-raise as the
@@ -293,6 +306,8 @@ def patch_user(
         "user_patched",
         actor=int(admin["id"]),
         target=int(user_id),
+        old_group=previous_group,
+        new_group=updated["user_group"],
         role=payload.role,
         max_concurrent_backtests=payload.max_concurrent_backtests,
         credits=payload.credits,

--- a/dashboard/backend/domain/analytics/value_queries.py
+++ b/dashboard/backend/domain/analytics/value_queries.py
@@ -31,6 +31,13 @@ from .value_repository import (
     UserValueSnapshot,
     ValueAnalyticsStore,
 )
+from dashboard.backend.domain.user_groups import (
+    USER_GROUPS,
+    USER_GROUP_LABELS,
+    UserGroup,
+    coerce_user_group,
+    parse_user_group,
+)
 
 
 UTC = timezone.utc
@@ -269,6 +276,32 @@ class OperationalAnalyticsResponse(BaseModel):
     availability: SectionAvailability
 
 
+class UserGroupSummary(BaseModel):
+    """Display-safe value metrics for one canonical account-source group."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    group: UserGroup
+    label: str
+    users: int = Field(ge=0)
+    successful_run_users: int = Field(ge=0)
+    repeat_users: int = Field(ge=0)
+    total_runs: int = Field(ge=0)
+    atl_cost_micro_usd: int = Field(ge=0)
+    paid_users: int = Field(ge=0)
+
+
+class GroupAnalyticsResponse(BaseModel):
+    """Fixed-order, admin-only source summary for the selected UTC period."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    as_of: datetime
+    groups: Sequence[UserGroupSummary]
+    selected_user_group: UserGroup | None = None
+    availability: SectionAvailability
+
+
 class UserValueFilters(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
@@ -276,6 +309,7 @@ class UserValueFilters(BaseModel):
     lifecycle_segment: LifecycleSegment | None = None
     operational_state: OperationalState | None = None
     commercial_tier: CommercialTier | None = None
+    user_group: UserGroup | None = None
     activated: bool | None = None
     last_meaningful_activity_from: datetime | None = None
     last_meaningful_activity_to: datetime | None = None
@@ -407,6 +441,38 @@ def _all_users(user_store: Any) -> list[dict[str, Any]]:
         if len(page) < 500:
             return rows
         offset += len(page)
+
+
+def _event_utc(value: object) -> datetime:
+    """Normalize an event timestamp without trusting a naive stored value."""
+
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() is None:
+            return value.replace(tzinfo=UTC)
+        return value.astimezone(UTC)
+    return _parse_timestamp(value)
+
+
+def _safe_cost_micro_usd(event: object) -> int:
+    """Read only the bounded platform-cost field used by the summary.
+
+    Server analytics events are validated on write, but this endpoint also
+    reads legacy rows. A malformed or negative value must not make an admin
+    summary fail or turn into a negative cost.
+    """
+
+    if (
+        getattr(event, "event_name", None) != "model_usage_recorded"
+        or getattr(event, "billing_mode", None) != "platform_credits"
+    ):
+        return 0
+    properties = getattr(event, "properties", {})
+    if not isinstance(properties, dict):
+        return 0
+    value = properties.get("cost_micro_usd")
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return 0
+    return value
 
 
 class ValueAnalyticsQueryService:
@@ -1021,6 +1087,169 @@ class ValueAnalyticsQueryService:
             ),
         )
 
+    def get_groups(
+        self,
+        start: date,
+        end: date,
+        include_internal: bool = False,
+        user_group: UserGroup | None = None,
+        now: datetime | None = None,
+    ) -> GroupAnalyticsResponse:
+        """Build the fixed-order source summary for one UTC date window.
+
+        The account row is the source of truth for group membership. Event and
+        Credits reads are deliberately batched and independently guarded so a
+        missing projection leaves six honest rows with partial availability,
+        rather than dropping the whole summary.
+        """
+
+        start, end = _validate_dates(start, end)
+        current_time = _utc(now or datetime.now(UTC), "now")
+        selected_group = (
+            parse_user_group(user_group) if user_group is not None else None
+        )
+
+        # Keep the row shape stable even if the account projection is
+        # temporarily unavailable. The endpoint can then expose an explicit
+        # unavailable state without leaking a storage exception.
+        users_available = True
+        try:
+            all_users = self._eligible_users(include_internal=include_internal)
+        except Exception:
+            all_users = []
+            users_available = False
+
+        group_by_user: dict[int, UserGroup] = {}
+        user_rows: list[dict[str, Any]] = []
+        for user in all_users:
+            try:
+                user_id = positive_user_id(user["id"])
+            except (KeyError, TypeError, ValueError):
+                # A malformed legacy account must not crash an admin report.
+                users_available = False
+                continue
+            group_by_user[user_id] = coerce_user_group(user.get("user_group"))
+            user_rows.append(user)
+
+        if selected_group is not None:
+            user_rows = [
+                user
+                for user in user_rows
+                if group_by_user.get(int(user["id"])) == selected_group
+            ]
+        user_ids = {int(user["id"]) for user in user_rows}
+
+        users_by_group: Counter[UserGroup] = Counter(
+            group_by_user[user_id] for user_id in user_ids
+        )
+        requested_by_group: Counter[UserGroup] = Counter()
+        successful_users_by_group: dict[UserGroup, set[int]] = defaultdict(set)
+        completion_days_by_group: dict[
+            UserGroup, dict[int, set[date]]
+        ] = defaultdict(lambda: defaultdict(set))
+        cost_by_group: Counter[UserGroup] = Counter()
+        events_available = True
+        events: Sequence[Any] = ()
+        period_start = _day_start(start)
+        period_end = _day_start(end)
+        try:
+            list_metric_events = getattr(self.query_store, "list_metric_events", None)
+            if callable(list_metric_events):
+                events = list_metric_events(
+                    start=period_start,
+                    end=period_end,
+                    include_internal=include_internal,
+                )
+            else:
+                # Small synthetic stores used by older callers expose only
+                # the rollup reader. It is still display-safe; account
+                # eligibility above remains the authoritative filter.
+                events = self.query_store.rollups.list_events(
+                    start=period_start,
+                    end=period_end,
+                    include_internal=True,
+                )
+        except Exception:
+            events_available = False
+
+        for event in events:
+            try:
+                event_user_id = positive_user_id(getattr(event, "user_id"))
+                if event_user_id not in user_ids:
+                    continue
+                occurred_at = _event_utc(getattr(event, "occurred_at"))
+                if not (period_start <= occurred_at < period_end):
+                    continue
+                group = group_by_user[event_user_id]
+                event_name = getattr(event, "event_name", None)
+            except (AttributeError, TypeError, ValueError, KeyError):
+                # Ignore malformed legacy event rows while preserving a valid
+                # summary for the rest of the period.
+                events_available = False
+                continue
+            if event_name == "backtest_requested":
+                requested_by_group[group] += 1
+            elif event_name == "backtest_completed":
+                successful_users_by_group[group].add(event_user_id)
+                completion_days_by_group[group][event_user_id].add(
+                    occurred_at.date()
+                )
+            elif event_name == "model_usage_recorded":
+                cost_by_group[group] += _safe_cost_micro_usd(event)
+
+        commercial_available = True
+        commercial: dict[int, CommercialValueFact] = {}
+        try:
+            commercial = self._commercial(user_rows, start=start, end=end)
+            if user_ids and not user_ids.issubset(commercial):
+                commercial_available = False
+        except Exception:
+            commercial_available = False
+
+        paid_by_group: Counter[UserGroup] = Counter()
+        for user_id, fact in commercial.items():
+            if user_id not in user_ids:
+                continue
+            if fact.lifetime_net_purchased_micro > 0:
+                paid_by_group[group_by_user[user_id]] += 1
+
+        rows: list[UserGroupSummary] = []
+        for group in USER_GROUPS:
+            successful_users = successful_users_by_group[group]
+            repeat_users = sum(
+                len(days) >= 2
+                for days in completion_days_by_group[group].values()
+            )
+            rows.append(
+                UserGroupSummary(
+                    group=group,
+                    label=USER_GROUP_LABELS[group],
+                    users=int(users_by_group[group]),
+                    successful_run_users=len(successful_users),
+                    repeat_users=repeat_users,
+                    total_runs=int(requested_by_group[group]),
+                    atl_cost_micro_usd=int(cost_by_group[group]),
+                    paid_users=int(paid_by_group[group]),
+                )
+            )
+
+        if not users_available:
+            availability = SectionAvailability(available=False, status="unavailable")
+        else:
+            complete = events_available and commercial_available
+            availability = SectionAvailability(
+                available=True,
+                status="ready" if complete else "partial",
+                coverage_start=start,
+                coverage_end=end - timedelta(days=1),
+            )
+        return GroupAnalyticsResponse(
+            as_of=current_time,
+            groups=rows,
+            selected_user_group=selected_group,
+            availability=availability,
+        )
+
     def list_users(
         self,
         *,
@@ -1050,6 +1279,9 @@ class ValueAnalyticsQueryService:
             snapshot = current.get(user_id)
             fact = commercial.get(user_id)
             if snapshot is None or fact is None:
+                continue
+            user_group = coerce_user_group(user.get("user_group"))
+            if filters.user_group is not None and user_group != filters.user_group:
                 continue
             group = _priority_group(snapshot)
             if filters.priority and group == "none":
@@ -1162,6 +1394,7 @@ __all__ = [
     "BalanceTotals",
     "CommercialAnalyticsResponse",
     "CommercialPeriodSummary",
+    "GroupAnalyticsResponse",
     "LifecycleAnalyticsResponse",
     "LifecycleHeadline",
     "LifecycleMovementPoint",
@@ -1172,6 +1405,7 @@ __all__ = [
     "RetentionCell",
     "RetentionCohort",
     "SectionAvailability",
+    "UserGroupSummary",
     "UserValueFilters",
     "ValueAnalyticsQueryService",
     "ValueUserListItem",

--- a/dashboard/backend/domain/user_groups.py
+++ b/dashboard/backend/domain/user_groups.py
@@ -1,0 +1,61 @@
+"""Canonical user-source groups used by admin account and analytics views."""
+
+from typing import Literal, Mapping, cast
+
+UserGroup = Literal[
+    "internal",
+    "invited",
+    "organic",
+    "competition",
+    "partner",
+    "unknown",
+]
+
+USER_GROUPS: tuple[UserGroup, ...] = (
+    "internal",
+    "invited",
+    "organic",
+    "competition",
+    "partner",
+    "unknown",
+)
+
+USER_GROUP_LABELS: Mapping[UserGroup, str] = {
+    "internal": "Internal",
+    "invited": "Invited",
+    "organic": "Organic",
+    "competition": "Competition",
+    "partner": "Partner",
+    "unknown": "Unknown",
+}
+
+
+def parse_user_group(value: object) -> UserGroup:
+    """Validate and normalize a user-supplied group value.
+
+    This is the strict write path: only strings naming one of the canonical
+    groups are accepted. Callers can map the stable ``invalid_user_group``
+    error to their API validation response.
+    """
+
+    if not isinstance(value, str):
+        raise ValueError("invalid_user_group")
+    normalized = value.strip().lower()
+    if normalized not in USER_GROUPS:
+        raise ValueError("invalid_user_group")
+    return cast(UserGroup, normalized)
+
+
+def coerce_user_group(value: object) -> UserGroup:
+    """Read a stored value defensively, defaulting malformed data to unknown."""
+
+    try:
+        return parse_user_group(value)
+    except ValueError:
+        return "unknown"
+
+
+def user_group_label(value: UserGroup) -> str:
+    """Return the canonical English display label for a group."""
+
+    return USER_GROUP_LABELS[value]

--- a/dashboard/backend/tests/domain/analytics/test_value_queries.py
+++ b/dashboard/backend/tests/domain/analytics/test_value_queries.py
@@ -29,12 +29,13 @@ UTC = timezone.utc
 NOW = datetime(2026, 9, 3, 12, 0, tzinfo=UTC)
 
 
-def _user(user_id: int) -> dict[str, object]:
+def _user(user_id: int, user_group: str = "unknown") -> dict[str, object]:
     return {
         "id": user_id,
         "display_name": f"Value User {user_id}",
         "email": f"value-{user_id}@example.test",
         "created_at": (NOW - timedelta(days=90)).isoformat(),
+        "user_group": user_group,
     }
 
 
@@ -249,11 +250,13 @@ def _service(
     commercial=None,
     daily=(),
     events=(),
+    user_groups=None,
     rollups=(),
     excluded=(),
     legacy_availability=None,
 ):
     facts = commercial or {user_id: _commercial(user_id) for user_id in snapshots}
+    group_values = dict(user_groups or {})
     value_store = FakeValueStore(
         snapshots=snapshots,
         commercial=facts,
@@ -262,12 +265,36 @@ def _service(
     legacy_service = FakeLegacyService(legacy_availability)
     service = ValueAnalyticsQueryService(
         store=FakeBaseStore(excluded),
-        user_store=FakeUserStore([_user(user_id) for user_id in snapshots]),
+        user_store=FakeUserStore(
+            [_user(user_id, group_values.get(user_id, "unknown")) for user_id in snapshots]
+        ),
         value_store=value_store,
         query_store=FakeQueryStore(events=events, rollups=rollups),
         legacy_service=legacy_service,
     )
     return service, value_store, legacy_service
+
+
+def _metric_event(
+    user_id: int,
+    event_name: str,
+    occurred_at: str | datetime,
+    *,
+    billing_mode: str | None = None,
+    properties: dict[str, object] | None = None,
+):
+    at = (
+        datetime.fromisoformat(occurred_at)
+        if isinstance(occurred_at, str)
+        else occurred_at
+    )
+    return SimpleNamespace(
+        user_id=user_id,
+        event_name=event_name,
+        occurred_at=at,
+        billing_mode=billing_mode,
+        properties=properties or {},
+    )
 
 
 def _activity(user_id: int, occurred_at: datetime):
@@ -470,6 +497,101 @@ def test_user_list_uses_injected_utc_day_for_commercial_window():
             datetime(2026, 9, 4, tzinfo=UTC),
         )
     ]
+
+
+def test_group_summary_has_six_rows_zeroes_and_fixed_order():
+    service, _value_store, _legacy = _service(
+        snapshots={1: _snapshot(1)},
+        user_groups={1: "organic"},
+        events=[
+            _metric_event(
+                1,
+                "backtest_requested",
+                "2026-09-01T01:00:00+00:00",
+            ),
+            _metric_event(
+                1,
+                "backtest_completed",
+                "2026-09-01T02:00:00+00:00",
+            ),
+            _metric_event(
+                1,
+                "backtest_completed",
+                "2026-09-03T02:00:00+00:00",
+            ),
+        ],
+    )
+
+    result = service.get_groups(
+        date(2026, 9, 1), date(2026, 9, 4), now=NOW
+    )
+
+    assert [row.group for row in result.groups] == [
+        "internal",
+        "invited",
+        "organic",
+        "competition",
+        "partner",
+        "unknown",
+    ]
+    organic = result.groups[2]
+    assert organic.users == 1
+    assert organic.successful_run_users == 1
+    assert organic.repeat_users == 1
+    assert organic.total_runs == 1
+    assert result.groups[0].users == 0
+    assert result.availability.status == "ready"
+
+
+def test_group_summary_cost_excludes_byok_and_paid_uses_lifetime_credits():
+    service, _value_store, _legacy = _service(
+        snapshots={1: _snapshot(1), 2: _snapshot(2)},
+        user_groups={1: "partner", 2: "organic"},
+        commercial={
+            1: _commercial(1, 5_000_000),
+            2: _commercial(2, 0),
+        },
+        events=[
+            _metric_event(
+                1,
+                "model_usage_recorded",
+                "2026-09-01T01:00:00+00:00",
+                billing_mode="platform_credits",
+                properties={"cost_micro_usd": 1234},
+            ),
+            _metric_event(
+                1,
+                "model_usage_recorded",
+                "2026-09-01T02:00:00+00:00",
+                billing_mode="byok",
+                properties={"cost_micro_usd": 9999},
+            ),
+        ],
+    )
+
+    result = service.get_groups(
+        date(2026, 9, 1), date(2026, 9, 2), now=NOW
+    )
+
+    partner = next(row for row in result.groups if row.group == "partner")
+    organic = next(row for row in result.groups if row.group == "organic")
+    assert partner.atl_cost_micro_usd == 1234
+    assert partner.paid_users == 1
+    assert organic.atl_cost_micro_usd == 0
+    assert organic.paid_users == 0
+
+
+def test_user_group_filter_applies_to_priority_users():
+    service, _value_store, _legacy = _service(
+        snapshots={1: _snapshot(1, operational="blocked"), 2: _snapshot(2)},
+        user_groups={1: "partner", 2: "organic"},
+    )
+
+    filters = UserValueFilters(user_group="partner", priority=True)
+    page = service.list_users(filters=filters, limit=25, offset=0, now=NOW)
+
+    assert filters.user_group == "partner"
+    assert [item.user_id for item in page.items] == [1]
 
 
 def test_commercial_response_keeps_revenue_usage_grants_cost_and_balances_separate():

--- a/dashboard/backend/tests/test_admin_analytics_api.py
+++ b/dashboard/backend/tests/test_admin_analytics_api.py
@@ -38,12 +38,16 @@ from dashboard.backend.domain.analytics.states import (
 )
 from dashboard.backend.domain.analytics.value_queries import (
     CommercialAnalyticsResponse,
+    GroupAnalyticsResponse,
     LifecycleAnalyticsResponse,
     OperationalAnalyticsResponse,
     PaginatedValueUsers,
     RetentionAnalyticsResponse,
+    SectionAvailability,
+    UserGroupSummary,
     ValueUserProfile,
 )
+from dashboard.backend.domain.user_groups import USER_GROUP_LABELS, USER_GROUPS
 from dashboard.backend.users import UserStore
 
 
@@ -76,6 +80,33 @@ class FixtureValueQueryService:
     def get_operational(self, **kwargs):
         self.calls.append(("operational", kwargs))
         return _contract("operational.json", OperationalAnalyticsResponse)
+
+    def get_groups(self, **kwargs):
+        self.calls.append(("groups", kwargs))
+        selected = kwargs.get("user_group")
+        return GroupAnalyticsResponse(
+            as_of=NOW,
+            groups=[
+                UserGroupSummary(
+                    group=group,
+                    label=USER_GROUP_LABELS[group],
+                    users=(1 if selected in {None, group} and group == "unknown" else 0),
+                    successful_run_users=0,
+                    repeat_users=0,
+                    total_runs=0,
+                    atl_cost_micro_usd=0,
+                    paid_users=0,
+                )
+                for group in USER_GROUPS
+            ],
+            selected_user_group=selected,
+            availability=SectionAvailability(
+                available=True,
+                status="ready",
+                coverage_start=date(2026, 8, 1),
+                coverage_end=date(2026, 8, 30),
+            ),
+        )
 
     def list_users(self, **kwargs):
         self.calls.append(("users", kwargs))
@@ -481,6 +512,7 @@ def test_non_admin_cannot_query_any_admin_analytics_route(admin_analytics_api):
         ("/api/admin/analytics/retention", {}),
         ("/api/admin/analytics/commercial", {}),
         ("/api/admin/analytics/operational", {}),
+        ("/api/admin/analytics/groups", {}),
         ("/api/admin/analytics/users", {}),
         (f"/api/admin/analytics/users/{subject_id}", {}),
         (
@@ -537,6 +569,49 @@ def test_admin_value_sections_have_independent_contracts(
         assert call["provider_id"] == "provider_synthetic"
         assert call["model_id"] == "model-synthetic-v1"
         assert call["billing_mode"] == "platform_credits"
+
+
+def test_group_endpoint_propagates_filter_and_always_returns_six_rows(
+    admin_analytics_api,
+):
+    api = admin_analytics_api
+    response = api["client"].get(
+        "/api/admin/analytics/groups",
+        params={
+            "from": "2026-08-01",
+            "to": "2026-08-31",
+            "user_group": "organic",
+            "include_internal": "false",
+        },
+        headers=api["admin_headers"],
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert len(body["groups"]) == 6
+    assert [row["group"] for row in body["groups"]] == list(USER_GROUPS)
+    assert body["selected_user_group"] == "organic"
+    name, call = api["value_query_service"].calls[-1]
+    assert name == "groups"
+    assert call["start"] == date(2026, 8, 1)
+    assert call["end"] == date(2026, 9, 1)
+    assert call["include_internal"] is False
+    assert call["user_group"] == "organic"
+
+
+def test_group_endpoint_rejects_unknown_group(admin_analytics_api):
+    response = admin_analytics_api["client"].get(
+        "/api/admin/analytics/groups",
+        params={
+            "from": "2026-09-01",
+            "to": "2026-09-03",
+            "user_group": "friends",
+        },
+        headers=admin_analytics_api["admin_headers"],
+    )
+
+    assert response.status_code == 422
+    assert response.json() == {"detail": "Invalid Analytics query."}
 
 
 @pytest.mark.parametrize("movement_range", ["5d", "1w", "1m", "1y"])
@@ -636,6 +711,7 @@ def test_admin_user_list_accepts_documented_filters(admin_analytics_api):
             "lifecycle_segment": "core",
             "operational_state": "healthy",
             "commercial_tier": "invested",
+            "user_group": "partner",
             "activated": "true",
             "last_meaningful_activity_from": (today - timedelta(days=1)).isoformat(),
             "last_meaningful_activity_to": today.isoformat(),
@@ -657,6 +733,7 @@ def test_admin_user_list_accepts_documented_filters(admin_analytics_api):
     assert filters.lifecycle_segment == "core"
     assert filters.operational_state == "healthy"
     assert filters.commercial_tier == "invested"
+    assert filters.user_group == "partner"
     assert filters.activated is True
     assert filters.legacy_status == "active"
 

--- a/dashboard/backend/tests/test_admin_analytics_value_frontend.py
+++ b/dashboard/backend/tests/test_admin_analytics_value_frontend.py
@@ -32,9 +32,49 @@ def test_value_client_uses_independent_endpoints():
         "/commercial",
         "/operational",
         "/users",
+        "/groups",
     ):
         assert endpoint in source
     assert "Promise.allSettled" in source
+
+
+def test_analytics_has_group_filter_and_summary_contract():
+    assert 'id="adminValueGroup"' in APP_HTML
+    assert 'id="adminAnalyticsGroupSummary"' in APP_HTML
+    assert 'id="adminAnalyticsGroupTable"' in APP_HTML
+    assert 'id="adminAnalyticsGroupBody"' in APP_HTML
+    source = value_source()
+    assert "/api/admin/analytics/groups" in source
+    assert "analyticsGroup" in source
+    assert "renderGroups" in source
+    for label in (
+        "Internal", "Invited", "Organic", "Competition", "Partner", "Unknown"
+    ):
+        assert label in APP_HTML or label in source
+
+
+def test_group_summary_has_fixed_order_bars_and_accessible_fallback():
+    source = value_source()
+    for group in ("internal", "invited", "organic", "competition", "partner", "unknown"):
+        assert group in source
+    assert "USER_GROUPS.map" in source
+    assert "Math.max(1" in source
+    assert "admin-group-bar-fill" in source
+    assert "aria-hidden" in source
+    assert 'aria-describedby="adminAnalyticsGroupSummaryFallback"' in APP_HTML
+    assert 'id="adminAnalyticsGroupSummaryFallback"' in APP_HTML
+
+
+def test_group_filter_preserves_include_internal_and_updates_priority_users():
+    source = value_source()
+    range_body = strip_comments(fn_body("function rangeParams(", source))
+    user_body = strip_comments(fn_body("function userParams(", source))
+    assert "include_internal" in range_body
+    assert "user_group" in range_body
+    assert "include_internal" in user_body
+    assert "user_group" in user_body
+    assert "state.userFilters.group" in source
+    assert "applyUserFilters({" in source
 
 
 def test_deep_sections_fetch_only_on_first_open():

--- a/dashboard/backend/tests/test_admin_credits_api.py
+++ b/dashboard/backend/tests/test_admin_credits_api.py
@@ -191,6 +191,7 @@ def test_admin_user_search_composes_identity_with_bucket_projection(
             "email": "needle@example.com",
             "display_name": "needle",
             "role": "user",
+            "user_group": "unknown",
             "balance": {
                 "grant_committed_micro": 0,
                 "purchased_committed_micro": 0,

--- a/dashboard/backend/tests/test_admin_credits_frontend.py
+++ b/dashboard/backend/tests/test_admin_credits_frontend.py
@@ -116,6 +116,7 @@ def test_account_management_has_one_group_editor():
     assert "method: 'PATCH'" in ADMIN_JS
     assert "/api/admin/users/${Number(user.id)}" in ADMIN_JS
     assert "JSON.stringify({ user_group: nextGroup })" in ADMIN_JS
+    assert "state.usersRequestSeq += 1" in ADMIN_JS
     assert "groupSelect.disabled = true" in ADMIN_JS
     assert "groupSelect.disabled = false" in ADMIN_JS
     assert "user.user_group = savedGroup" in ADMIN_JS

--- a/dashboard/backend/tests/test_admin_credits_frontend.py
+++ b/dashboard/backend/tests/test_admin_credits_frontend.py
@@ -105,6 +105,29 @@ def test_admin_grant_console_has_responsive_operation_and_audit_styles():
     assert "@media (max-width: 600px)" in STYLES
 
 
+def test_account_management_has_one_group_editor():
+    admin_start = APP_HTML.index('id="adminView"')
+    admin_end = APP_HTML.index('id="adminLegacyUsersPanel"', admin_start)
+    account_management = APP_HTML[admin_start:admin_end]
+    assert '<th scope="col">Group</th>' in account_management
+    assert 'colspan="9"' in account_management
+    assert "admin-credits-group-select" in ADMIN_JS
+    assert "mutateUserGroup" in ADMIN_JS
+    assert "method: 'PATCH'" in ADMIN_JS
+    assert "/api/admin/users/${Number(user.id)}" in ADMIN_JS
+    assert "JSON.stringify({ user_group: nextGroup })" in ADMIN_JS
+    assert "groupSelect.disabled = true" in ADMIN_JS
+    assert "groupSelect.disabled = false" in ADMIN_JS
+    assert "user.user_group = savedGroup" in ADMIN_JS
+    assert "admin-credits-group-error" in ADMIN_JS
+    labels = ("Internal", "Invited", "Organic", "Competition", "Partner", "Unknown")
+    positions = [ADMIN_JS.index(label) for label in labels]
+    assert positions == sorted(positions)
+    assert ".admin-credits-group-select" in STYLES
+    assert ".admin-credits-users-table {" in STYLES
+    assert "overflow-x: auto" in STYLES
+
+
 def test_admin_tabs_default_to_analytics_and_are_url_backed():
     assert "DEFAULT_TAB = 'analytics'" in ADMIN_TABS_JS
     assert "adminTab" in ADMIN_TABS_JS

--- a/dashboard/backend/tests/test_admin_users.py
+++ b/dashboard/backend/tests/test_admin_users.py
@@ -335,6 +335,60 @@ def test_admin_patch_entitlements_and_role(isolated_auth):
     assert body["entitlements"]["credits"] == 50
 
 
+def test_admin_can_patch_group_and_public_me_does_not_expose_it(
+    isolated_auth, capsys
+):
+    client, store = isolated_auth
+    admin = _signup(client, "group-admin@example.com")
+    target = _signup(client, "group-target@example.com")
+    _promote(store, admin["id"])
+    client.post(
+        "/api/auth/login",
+        json={"email": "group-admin@example.com", "password": "SecurePass1!"},
+    )
+
+    response = client.patch(
+        "/api/admin/users/" + str(target["id"]),
+        json={"user_group": "organic"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["user"]["user_group"] == "organic"
+    audit = capsys.readouterr().out
+    assert "old_group=unknown" in audit
+    assert "new_group=organic" in audit
+    assert f"actor={admin['id']}" in audit
+    assert f"target={target['id']}" in audit
+    assert "group-target@example.com" not in audit
+    assert "user_group" not in client.get("/api/auth/me").json()["user"]
+
+
+def test_admin_group_patch_rejects_null_and_unknown_value(isolated_auth):
+    client, store = isolated_auth
+    admin = _signup(client, "group-validation@example.com")
+    _promote(store, admin["id"])
+    target = _signup(client, "group-invalid@example.com")
+    client.post(
+        "/api/auth/login",
+        json={
+            "email": "group-validation@example.com",
+            "password": "SecurePass1!",
+        },
+    )
+
+    null_response = client.patch(
+        "/api/admin/users/" + str(target["id"]),
+        json={"user_group": None},
+    )
+    assert null_response.status_code == 400, null_response.text
+
+    invalid_response = client.patch(
+        "/api/admin/users/" + str(target["id"]),
+        json={"user_group": "friends"},
+    )
+    assert invalid_response.status_code == 422, invalid_response.text
+
+
 def test_backtest_slot_respects_entitlement(monkeypatch, tmp_path):
     """The dashboard runner's per-owner slots read the same entitlement.
 

--- a/dashboard/backend/tests/test_store_twin_parity.py
+++ b/dashboard/backend/tests/test_store_twin_parity.py
@@ -916,6 +916,36 @@ def test_postgres_twin_repeats_every_sqlite_lazy_migration(
     )
 
 
+def test_user_store_twins_explicitly_migrate_user_group():
+    """Pin the account-group migration in both source-level twin guards.
+
+    The generic schema checks above catch drift, but this focused assertion
+    keeps the admin-only dimension's deployed-table migration visible in the
+    parity suite's failure output and prevents a future refactor from hiding
+    it behind a dynamically assembled SQL fragment.
+    """
+    sqlite_source = _module_source_path("dashboard.backend.users").read_text(
+        encoding="utf-8"
+    )
+    postgres_source = _module_source_path(
+        "dashboard.backend.users_postgres"
+    ).read_text(encoding="utf-8")
+
+    sqlite_schema = _parse_ddl(sqlite_source)
+    postgres_schema = _parse_ddl(postgres_source)
+
+    assert "user_group" in sqlite_schema.declared["users"]
+    assert "user_group" in postgres_schema.declared["users"]
+    assert "user_group" in sqlite_schema.migrated["users"]
+    assert "user_group" in postgres_schema.migrated["users"]
+
+    folded_postgres = re.sub(r"\s+", " ", postgres_source)
+    assert (
+        "ALTER TABLE users ADD COLUMN IF NOT EXISTS user_group "
+        "TEXT NOT NULL DEFAULT 'unknown'"
+    ) in folded_postgres
+
+
 def test_credits_postgres_migrates_every_column_added_by_sqlite_rebuild():
     """Credits rebuilds its ledger instead of using SQLite ADD COLUMN statements.
 

--- a/dashboard/backend/tests/test_user_group_store.py
+++ b/dashboard/backend/tests/test_user_group_store.py
@@ -1,0 +1,136 @@
+"""SQLite persistence contract for the admin-only user-group dimension."""
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from dashboard.backend.users import MAX_CREDITS_CAP, UserStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> UserStore:
+    return UserStore(db_path=tmp_path / "users.db")
+
+
+def _column(store: UserStore, name: str) -> dict:
+    conn = store._get_connection()
+    try:
+        rows = conn.execute("PRAGMA table_info(users)").fetchall()
+    finally:
+        conn.close()
+    return dict(next(row for row in rows if row["name"] == name))
+
+
+def test_fresh_users_table_declares_required_unknown_group(store: UserStore):
+    column = _column(store, "user_group")
+
+    assert column["notnull"] == 1
+    assert column["dflt_value"] == "'unknown'"
+
+
+def test_existing_users_table_gets_unknown_group_column(tmp_path: Path):
+    path = tmp_path / "legacy.db"
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT, display_name TEXT, "
+        "password_hash TEXT, role TEXT, created_at TEXT)"
+    )
+    conn.execute(
+        "INSERT INTO users VALUES (1, 'legacy@example.test', 'Legacy', 'hash', "
+        "'user', '2026-01-01T00:00:00+00:00')"
+    )
+    conn.commit()
+    conn.close()
+
+    migrated = UserStore(db_path=path)
+
+    assert migrated.get_user_admin(1)["user_group"] == "unknown"
+    column = _column(migrated, "user_group")
+    assert column["notnull"] == 1
+    assert column["dflt_value"] == "'unknown'"
+
+
+def test_new_users_default_to_unknown_only_in_admin_projection(store: UserStore):
+    created = store.create_user("group@example.test", "Group", "SecurePass1!")
+
+    assert "user_group" not in created
+    assert store.get_user_admin(created["id"])["user_group"] == "unknown"
+    assert store.list_users_admin()[0]["user_group"] == "unknown"
+
+
+def test_store_patch_updates_group_and_entitlements_atomically(store: UserStore):
+    user = store.create_user("atomic@example.test", "Atomic", "SecurePass1!")
+
+    updated = store.apply_admin_patch(
+        user["id"],
+        role="admin",
+        user_group=" ORGANIC ",
+        credits=7,
+        max_concurrent_backtests=2,
+    )
+
+    assert updated["role"] == "admin"
+    assert updated["user_group"] == "organic"
+    assert updated["entitlements"]["credits"] == 7
+    assert updated["entitlements"]["max_concurrent_backtests"] == 2
+    assert store.get_user_admin(user["id"])["user_group"] == "organic"
+
+
+def test_invalid_or_omitted_group_cannot_overwrite_stored_group(store: UserStore):
+    user = store.create_user("preserve@example.test", "Preserve", "SecurePass1!")
+    store.apply_admin_patch(user["id"], user_group="partner")
+
+    with pytest.raises(ValueError, match="invalid_user_group"):
+        store.apply_admin_patch(user["id"], user_group="friends")
+
+    unchanged = store.apply_admin_patch(user["id"], credits=9)
+    assert unchanged["user_group"] == "partner"
+
+
+def test_failed_multi_field_patch_rolls_group_back(store: UserStore):
+    user = store.create_user("rollback@example.test", "Rollback", "SecurePass1!")
+    store.apply_admin_patch(user["id"], user_group="invited")
+
+    with pytest.raises(ValueError, match="invalid_credits"):
+        store.apply_admin_patch(
+            user["id"],
+            user_group="competition",
+            credits=MAX_CREDITS_CAP + 1,
+        )
+
+    assert store.get_user_admin(user["id"])["user_group"] == "invited"
+
+
+def test_malformed_stored_group_is_coerced_in_admin_projection(store: UserStore):
+    user = store.create_user("malformed@example.test", "Malformed", "SecurePass1!")
+    conn = store._get_connection()
+    conn.execute(
+        "UPDATE users SET user_group = ? WHERE id = ?",
+        ("legacy-source", user["id"]),
+    )
+    conn.commit()
+    conn.close()
+
+    assert store.get_user_admin(user["id"])["user_group"] == "unknown"
+
+
+def test_auth_me_does_not_expose_admin_only_group(store: UserStore, monkeypatch):
+    from fastapi.testclient import TestClient
+
+    from dashboard.backend import users as users_module
+    from dashboard.backend.app import app
+
+    user = store.create_user("private@example.test", "Private", "SecurePass1!")
+    store.apply_admin_patch(user["id"], user_group="internal")
+    token = store.create_session(user["id"])
+    monkeypatch.setattr(users_module, "user_store", store)
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/api/auth/me",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200, response.text
+    assert "user_group" not in response.json()["user"]

--- a/dashboard/backend/tests/test_user_groups.py
+++ b/dashboard/backend/tests/test_user_groups.py
@@ -1,0 +1,50 @@
+"""Contract tests for the canonical admin user-group taxonomy."""
+
+import pytest
+
+from dashboard.backend.domain.user_groups import (
+    USER_GROUPS,
+    USER_GROUP_LABELS,
+    coerce_user_group,
+    parse_user_group,
+    user_group_label,
+)
+
+
+def test_groups_have_fixed_product_order_and_labels():
+    assert USER_GROUPS == (
+        "internal",
+        "invited",
+        "organic",
+        "competition",
+        "partner",
+        "unknown",
+    )
+    assert [USER_GROUP_LABELS[group] for group in USER_GROUPS] == [
+        "Internal",
+        "Invited",
+        "Organic",
+        "Competition",
+        "Partner",
+        "Unknown",
+    ]
+
+
+@pytest.mark.parametrize("value", ["internal", " ORGANIC ", "competition"])
+def test_parse_user_group_normalizes_supported_values(value):
+    assert parse_user_group(value) in USER_GROUPS
+
+
+@pytest.mark.parametrize("value", [None, "", "not-a-group", 3, True])
+def test_parse_user_group_rejects_invalid_writes(value):
+    with pytest.raises(ValueError, match="invalid_user_group"):
+        parse_user_group(value)
+
+
+@pytest.mark.parametrize("value", [None, "", "old-acquisition-value", object()])
+def test_coerce_user_group_defaults_bad_stored_values_to_unknown(value):
+    assert coerce_user_group(value) == "unknown"
+
+
+def test_user_group_label_uses_canonical_display_label():
+    assert user_group_label("organic") == "Organic"

--- a/dashboard/backend/tests/test_users_postgres.py
+++ b/dashboard/backend/tests/test_users_postgres.py
@@ -19,6 +19,7 @@ CodeQL's py/import-and-import-from flags it.
 
 import os
 from datetime import timedelta
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
@@ -407,6 +408,14 @@ def test_avatar_column_lazy_migration_postgres():
             assert cur.fetchone() is not None
 
 
+def test_users_postgres_repeats_sqlite_user_group_migration():
+    """The deployed users table must gain the group column lazily too."""
+    source = Path(__file__).resolve().parents[1] / "users_postgres.py"
+    sql = source.read_text(encoding="utf-8")
+    assert "ADD COLUMN IF NOT EXISTS user_group" in sql
+    assert "user_group TEXT NOT NULL DEFAULT 'unknown'" in sql
+
+
 @pg_only
 def test_update_display_name_postgres(temp_postgres_store):
     user = temp_postgres_store.create_user("pgname@example.com", "PG Name", "securepass1")
@@ -629,6 +638,34 @@ def test_apply_admin_patch_atomic_postgres(temp_postgres_store):
     # Last-admin guard, serialized by the advisory lock.
     with pytest.raises(ValueError, match="last_admin"):
         store.apply_admin_patch(admin["id"], role="user")
+
+
+@pg_only
+def test_user_group_default_and_atomic_patch_postgres(temp_postgres_store):
+    store = temp_postgres_store
+    user = store.create_user(
+        "pg-group@example.test", "PG Group", "securepass1"
+    )
+
+    assert store.get_user_admin(user["id"])["user_group"] == "unknown"
+
+    updated = store.apply_admin_patch(
+        user["id"], user_group="competition", credits=11
+    )
+
+    assert updated["user_group"] == "competition"
+    assert updated["entitlements"]["credits"] == 11
+    assert store.list_users_admin()[0]["user_group"] == "competition"
+
+    # The group is admin-only; public signup/session projections stay unchanged.
+    assert "user_group" not in user
+    token = store.create_session(user["id"])
+    session_user = store.get_user_for_token(token)
+    assert session_user is not None
+    assert "user_group" in session_user  # raw store row, not an API projection
+    from dashboard.backend.users import public_user
+
+    assert "user_group" not in public_user(session_user)
 
 
 @pg_only

--- a/dashboard/backend/users.py
+++ b/dashboard/backend/users.py
@@ -23,6 +23,7 @@ import bcrypt
 
 from dashboard.backend.database import DB_PATH
 from dashboard.backend.db_url import describe_database_url
+from dashboard.backend.domain.user_groups import coerce_user_group, parse_user_group
 from dashboard.backend.session_tokens import (
     absolute_expiry,
     hash_session_token,
@@ -428,17 +429,18 @@ def public_user_with_entitlements(
     row: sqlite3.Row | Dict[str, Any],
     entitlements: Dict[str, Any],
 ) -> Dict[str, Any]:
-    """Admin projection: the public user plus entitlements, minus ``avatar``.
+    """Admin projection: the public user plus group and entitlements, minus ``avatar``.
 
     Avatars are data: URIs bounded at 200_000 chars each on write
-    (``api/auth.py``). The admin console renders emails, names, roles and two
-    numbers — never the image — so carrying them would make a 100-row page tens
-    of megabytes of response body on a free-tier box for nothing. Callers that
+    (``api/auth.py``). The admin console renders emails, names, roles, one group
+    and two numbers — never the image — so carrying it would make a 100-row page
+    tens of megabytes of response body on a free-tier box for nothing. Callers that
     merge this into a stored user (``saveAdminUserRole``) spread it over the
     existing object, so an absent key leaves the cached avatar intact.
     """
     payload = public_user(row)
     payload.pop("avatar", None)
+    payload["user_group"] = coerce_user_group(dict(row).get("user_group"))
     payload["entitlements"] = entitlements
     return payload
 
@@ -703,6 +705,7 @@ class UserStore:
                 display_name TEXT NOT NULL,
                 password_hash TEXT NOT NULL,
                 role TEXT NOT NULL DEFAULT 'user',
+                user_group TEXT NOT NULL DEFAULT 'unknown',
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )
             """
@@ -750,6 +753,10 @@ class UserStore:
             )
         if "avatar" not in columns:
             cursor.execute("ALTER TABLE users ADD COLUMN avatar TEXT")
+        if "user_group" not in columns:
+            cursor.execute(
+                "ALTER TABLE users ADD COLUMN user_group TEXT NOT NULL DEFAULT 'unknown'"
+            )
         cursor.execute(
             """
             CREATE UNIQUE INDEX IF NOT EXISTS idx_users_discord_user_id
@@ -1717,11 +1724,12 @@ class UserStore:
         user_id: int,
         *,
         role: Optional[str] = None,
+        user_group: Optional[str] = None,
         max_concurrent_backtests: Optional[int] = None,
         credits: Optional[int] = None,
         updated_by_admin_id: Optional[int] = None,
     ) -> Optional[Dict[str, Any]]:
-        """Role and entitlements for one user, in a single transaction.
+        """Role, group, and entitlements for one user, in one transaction.
 
         ``PATCH /api/admin/users/{id}`` advertises one atomic change. Doing it
         as a role write then ``set_entitlements`` meant a failure on the
@@ -1733,6 +1741,9 @@ class UserStore:
             normalized_role = (role or "").strip().lower()
             if normalized_role not in VALID_ROLES:
                 raise ValueError("invalid_role")
+        normalized_group = (
+            parse_user_group(user_group) if user_group is not None else None
+        )
         next_max, next_credits = validate_entitlement_patch(
             max_concurrent_backtests, credits
         )
@@ -1756,6 +1767,11 @@ class UserStore:
                 cursor.execute(
                     "UPDATE users SET role = ? WHERE id = ?",
                     (normalized_role, int(user_id)),
+                )
+            if normalized_group is not None:
+                cursor.execute(
+                    "UPDATE users SET user_group = ? WHERE id = ?",
+                    (normalized_group, int(user_id)),
                 )
             if touches_entitlements:
                 cursor.execute(ENTITLEMENTS_UPSERT_SQLITE, entitlements_upsert_params(

--- a/dashboard/backend/users_postgres.py
+++ b/dashboard/backend/users_postgres.py
@@ -46,6 +46,7 @@ from dashboard.backend.users import (
     hash_password,
     is_expired,
     parse_stored_timestamp,
+    parse_user_group,
     public_entitlements,
     public_user,
     public_user_with_entitlements,
@@ -94,6 +95,7 @@ class PostgresUserStore:
                         display_name TEXT NOT NULL,
                         password_hash TEXT NOT NULL,
                         role TEXT NOT NULL DEFAULT 'user',
+                        user_group TEXT NOT NULL DEFAULT 'unknown',
                         created_at TEXT NOT NULL,
                         discord_user_id TEXT,
                         avatar TEXT
@@ -111,6 +113,12 @@ class PostgresUserStore:
                     """
                     ALTER TABLE users
                     ADD COLUMN IF NOT EXISTS avatar TEXT
+                    """
+                )
+                cur.execute(
+                    """
+                    ALTER TABLE users
+                    ADD COLUMN IF NOT EXISTS user_group TEXT NOT NULL DEFAULT 'unknown'
                     """
                 )
                 cur.execute(
@@ -929,6 +937,7 @@ class PostgresUserStore:
         user_id: int,
         *,
         role: Optional[str] = None,
+        user_group: Optional[str] = None,
         max_concurrent_backtests: Optional[int] = None,
         credits: Optional[int] = None,
         updated_by_admin_id: Optional[int] = None,
@@ -939,6 +948,9 @@ class PostgresUserStore:
             normalized_role = (role or "").strip().lower()
             if normalized_role not in VALID_ROLES:
                 raise ValueError("invalid_role")
+        normalized_group = (
+            parse_user_group(user_group) if user_group is not None else None
+        )
         next_max, next_credits = validate_entitlement_patch(
             max_concurrent_backtests, credits
         )
@@ -965,6 +977,12 @@ class PostgresUserStore:
                         cur.execute(
                             "UPDATE users SET role = %s WHERE id = %s RETURNING *",
                             (normalized_role, int(user_id)),
+                        )
+                        user_row = cur.fetchone()
+                    if normalized_group is not None:
+                        cur.execute(
+                            "UPDATE users SET user_group = %s WHERE id = %s RETURNING *",
+                            (normalized_group, int(user_id)),
                         )
                         user_row = cur.fetchone()
                     if touches_entitlements:

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -2159,9 +2159,10 @@
                         </div>
                     </header>
 
-                    <form id="adminAnalyticsValueFilters" class="admin-value-filters" aria-label="User value date filters">
+                    <form id="adminAnalyticsValueFilters" class="admin-value-filters" aria-label="User value filters">
                         <label for="adminValueStart"><span>From</span><input id="adminValueStart" name="from" type="date" autocomplete="off" required></label>
                         <label for="adminValueEnd"><span>To</span><input id="adminValueEnd" name="to" type="date" autocomplete="off" required></label>
+                        <label for="adminValueGroup"><span>User group</span><select id="adminValueGroup" name="user_group" class="filter-select" autocomplete="off"><option value="">All user groups</option><option value="internal">Internal</option><option value="invited">Invited</option><option value="organic">Organic</option><option value="competition">Competition</option><option value="partner">Partner</option><option value="unknown">Unknown</option></select></label>
                         <label class="admin-value-check" for="adminValueInternal"><input id="adminValueInternal" name="include_internal" type="checkbox"><span>Include internal accounts</span></label>
                         <button class="auth-btn auth-btn-secondary" type="submit">Apply range</button>
                         <p id="adminValueFilterError" class="auth-error" role="alert" tabindex="-1" hidden></p>
@@ -2175,6 +2176,24 @@
                     </div>
                     <p id="adminValuePrimaryStatus" class="credits-status" role="status" aria-live="polite"></p>
                     <p id="adminValuePrimaryError" class="auth-error" role="alert" hidden></p>
+
+                    <section id="adminAnalyticsGroupSummary" class="admin-value-card admin-value-group-summary" aria-labelledby="adminAnalyticsGroupSummaryTitle" aria-busy="true">
+                        <div class="admin-value-section-head">
+                            <div><p class="credits-section-kicker">Where users come from</p><h4 id="adminAnalyticsGroupSummaryTitle">Group summary</h4></div>
+                            <span id="adminAnalyticsGroupSummaryStatus" class="admin-value-coverage" data-admin-value-status role="status" aria-live="polite">Loading group summary…</span>
+                        </div>
+                        <p id="adminAnalyticsGroupSummaryError" class="auth-error" role="alert" hidden></p>
+                        <div class="admin-value-table-wrap">
+                            <table id="adminAnalyticsGroupTable" class="admin-value-group-table" aria-describedby="adminAnalyticsGroupSummaryFallback">
+                                <caption class="sr-only">Users and value signals by user group</caption>
+                                <thead>
+                                    <tr><th scope="col">Group</th><th scope="col">Users</th><th scope="col">Successful run users</th><th scope="col">Repeat users</th><th scope="col">Total runs</th><th scope="col">ATL cost</th><th scope="col">Paid users</th></tr>
+                                </thead>
+                                <tbody id="adminAnalyticsGroupBody"></tbody>
+                            </table>
+                        </div>
+                        <p id="adminAnalyticsGroupSummaryFallback" class="admin-value-empty" hidden></p>
+                    </section>
 
                     <div class="admin-value-primary-grid">
                         <section class="admin-value-card" aria-labelledby="adminLifecycleDistributionTitle">

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -2483,8 +2483,8 @@
                 </form>
                 <div class="admin-credits-table-wrap">
                     <table class="admin-credits-users-table" aria-label="Grant Credits user allocation">
-                        <thead><tr><th scope="col">Account</th><th scope="col">Role</th><th scope="col">Status</th><th scope="col">Grant</th><th scope="col">Purchased</th><th scope="col">Total</th><th scope="col">Amount</th><th scope="col"><span class="sr-only">Actions</span></th></tr></thead>
-                        <tbody id="adminCreditsUsersBody"><tr><td colspan="8" class="admin-empty">Search for an account to allocate Grant Credits.</td></tr></tbody>
+                        <thead><tr><th scope="col">Account</th><th scope="col">Group</th><th scope="col">Role</th><th scope="col">Status</th><th scope="col">Grant</th><th scope="col">Purchased</th><th scope="col">Total</th><th scope="col">Amount</th><th scope="col"><span class="sr-only">Actions</span></th></tr></thead>
+                        <tbody id="adminCreditsUsersBody"><tr><td colspan="9" class="admin-empty">Search for an account to allocate Grant Credits.</td></tr></tbody>
                     </table>
                 </div>
                 <div class="admin-credits-pager" aria-label="Account pages">

--- a/dashboard/frontend/js/admin-analytics-value.js
+++ b/dashboard/frontend/js/admin-analytics-value.js
@@ -12,6 +12,24 @@
     commercial: '/api/admin/analytics/commercial',
     operational: '/api/admin/analytics/operational',
     users: '/api/admin/analytics/users',
+    groups: '/api/admin/analytics/groups',
+  });
+  const USER_GROUPS = ['internal', 'invited', 'organic', 'competition', 'partner', 'unknown'];
+  const USER_GROUP_LABELS = Object.freeze({
+    internal: 'Internal',
+    invited: 'Invited',
+    organic: 'Organic',
+    competition: 'Competition',
+    partner: 'Partner',
+    unknown: 'Unknown',
+  });
+  const USER_GROUP_COLORS = Object.freeze({
+    internal: '#a78bfa',
+    invited: '#38bdf8',
+    organic: '#2dd4bf',
+    competition: '#fbbf24',
+    partner: '#fb7185',
+    unknown: '#94a3b8',
   });
   const LIFECYCLE_SEGMENTS = ['new', 'onboarding', 'growing', 'core', 'at_risk', 'dormant'];
   const LIFECYCLE_LABELS = Object.freeze({
@@ -64,6 +82,7 @@
     lifecycle: 'analyticsLifecycle',
     operational: 'analyticsOperational',
     commercial: 'analyticsCommercial',
+    group: 'analyticsGroup',
     user: 'analyticsUser',
     profile: 'analyticsProfile',
     movementRange: 'analyticsMovementRange',
@@ -81,6 +100,7 @@
       lifecycle: '',
       operational: '',
       commercial: '',
+      group: '',
       query: '',
     },
     openDisclosures: new Set(),
@@ -90,6 +110,7 @@
       retention: { loaded: false, data: null, error: null, stale: false },
       commercial: { loaded: false, data: null, error: null, stale: false },
       operational: { loaded: false, data: null, error: null, stale: false },
+      groups: { loaded: false, data: null, error: null, stale: false },
     },
     movementChart: null,
     evidenceUser: null,
@@ -170,9 +191,11 @@
     const lifecycle = params.get(URL_KEYS.lifecycle) || '';
     const operational = params.get(URL_KEYS.operational) || '';
     const commercial = params.get(URL_KEYS.commercial) || '';
+    const group = params.get(URL_KEYS.group) || '';
     state.userFilters.lifecycle = LIFECYCLE_SEGMENTS.includes(lifecycle) ? lifecycle : '';
     state.userFilters.operational = Object.hasOwn(OPERATIONAL_LABELS, operational) ? operational : '';
     state.userFilters.commercial = Object.hasOwn(COMMERCIAL_LABELS, commercial) ? commercial : '';
+    state.userFilters.group = USER_GROUPS.includes(group) ? group : '';
     state.userFilters.query = params.get('analyticsUserQuery') || '';
     state.openDisclosures = new Set(
       String(params.get('analyticsPanel') || '')
@@ -195,6 +218,7 @@
     setOrDelete(url.searchParams, URL_KEYS.lifecycle, state.userFilters.lifecycle);
     setOrDelete(url.searchParams, URL_KEYS.operational, state.userFilters.operational);
     setOrDelete(url.searchParams, URL_KEYS.commercial, state.userFilters.commercial);
+    setOrDelete(url.searchParams, URL_KEYS.group, state.userFilters.group);
     setOrDelete(url.searchParams, 'analyticsUserQuery', state.userFilters.query);
     url.searchParams.set(URL_KEYS.movementRange, state.movementRange);
     setOrDelete(url.searchParams, 'analyticsPanel', [...state.openDisclosures].sort().join(','));
@@ -209,6 +233,7 @@
     element('adminPriorityLifecycle').value = state.userFilters.lifecycle;
     element('adminPriorityOperational').value = state.userFilters.operational;
     element('adminPriorityCommercial').value = state.userFilters.commercial;
+    element('adminValueGroup').value = state.userFilters.group;
     document.querySelectorAll('[data-movement-range]').forEach((button) => {
       const selected = button.dataset.movementRange === state.movementRange;
       button.setAttribute('aria-checked', selected ? 'true' : 'false');
@@ -216,12 +241,16 @@
     });
   }
 
-  function rangeParams() {
-    return new URLSearchParams({
+  function rangeParams({ includeGroup = false } = {}) {
+    const params = new URLSearchParams({
       from: state.range.start,
       to: state.range.end,
       include_internal: state.includeInternal ? 'true' : 'false',
     });
+    if (includeGroup && state.userFilters.group) {
+      params.set('user_group', state.userFilters.group);
+    }
+    return params;
   }
 
   function userParams() {
@@ -235,6 +264,7 @@
     if (state.userFilters.lifecycle) params.set('lifecycle_segment', state.userFilters.lifecycle);
     if (state.userFilters.operational) params.set('operational_state', state.userFilters.operational);
     if (state.userFilters.commercial) params.set('commercial_tier', state.userFilters.commercial);
+    if (state.userFilters.group) params.set('user_group', state.userFilters.group);
     return params;
   }
 
@@ -427,6 +457,157 @@
     renderLifecycleMovement(payload);
     const incomplete = availabilityIncomplete(payload.availability);
     element('adminValuePrimaryStatus').textContent = incomplete ? 'Incomplete data · available sections remain current.' : '';
+  }
+
+  function groupCount(value) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed >= 0 ? Math.round(parsed) : 0;
+  }
+
+  function groupSummaryStatus(payload, rows, { stale = false } = {}) {
+    if (stale) return 'Showing the last successful response; refresh failed.';
+    const availability = payload?.availability;
+    if (!availability || availability.available === false || availability.status === 'unavailable') {
+      return SECTION_UNAVAILABLE;
+    }
+    if (availabilityIncomplete(availability)) {
+      return 'Partial data · some event or billing signals may be incomplete.';
+    }
+    const totalUsers = rows.reduce((total, row) => total + row.users, 0);
+    if (!totalUsers) {
+      const selected = payload?.selected_user_group;
+      return selected && USER_GROUP_LABELS[selected]
+        ? `No ${USER_GROUP_LABELS[selected]} users in this range.`
+        : 'No user accounts in this range.';
+    }
+    const timestamp = payload?.as_of ? new Date(payload.as_of) : null;
+    if (timestamp && Number.isFinite(timestamp.getTime())) {
+      return `Updated ${new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(timestamp)}`;
+    }
+    return '';
+  }
+
+  function setGroupSummaryLoading(loading) {
+    const summary = element('adminAnalyticsGroupSummary');
+    const status = element('adminAnalyticsGroupSummaryStatus');
+    if (summary) summary.setAttribute('aria-busy', loading ? 'true' : 'false');
+    if (status && loading) {
+      status.textContent = state.sections.groups.data
+        ? 'Refreshing group summary…'
+        : 'Loading group summary…';
+    }
+  }
+
+  function renderGroups(payload, { stale = false } = {}) {
+    const summary = element('adminAnalyticsGroupSummary');
+    const table = element('adminAnalyticsGroupTable');
+    const body = element('adminAnalyticsGroupBody');
+    const fallback = element('adminAnalyticsGroupSummaryFallback');
+    const error = element('adminAnalyticsGroupSummaryError');
+    if (!body) return;
+
+    const sourceRows = Array.isArray(payload?.groups) ? payload.groups : [];
+    const rowsByGroup = new Map(
+      sourceRows
+        .filter((row) => USER_GROUPS.includes(row?.group))
+        .map((row) => [row.group, row])
+    );
+    const rows = USER_GROUPS.map((group) => {
+      const source = rowsByGroup.get(group) || {};
+      return {
+        group,
+        label: USER_GROUP_LABELS[group],
+        users: groupCount(source.users),
+        successful_run_users: groupCount(source.successful_run_users),
+        repeat_users: groupCount(source.repeat_users),
+        total_runs: groupCount(source.total_runs),
+        atl_cost_micro_usd: groupCount(source.atl_cost_micro_usd),
+        paid_users: groupCount(source.paid_users),
+      };
+    });
+    const hasRows = Array.isArray(payload?.groups);
+    const maxUsers = Math.max(1, ...rows.map((row) => row.users));
+    clear(body);
+
+    if (!hasRows) {
+      if (table) table.setAttribute('aria-busy', 'false');
+      if (summary) summary.setAttribute('aria-busy', 'false');
+      if (fallback) {
+        fallback.textContent = stale
+          ? 'The latest group summary could not be loaded.'
+          : SECTION_UNAVAILABLE;
+        fallback.hidden = false;
+      }
+      if (error) {
+        error.textContent = stale ? SECTION_UNAVAILABLE : '';
+        error.hidden = !stale;
+      }
+      const status = element('adminAnalyticsGroupSummaryStatus');
+      if (status) status.textContent = stale ? groupSummaryStatus(payload, rows, { stale }) : SECTION_UNAVAILABLE;
+      return;
+    }
+
+    rows.forEach((row) => {
+      const tableRow = document.createElement('tr');
+      tableRow.dataset.userGroup = row.group;
+
+      const groupCell = node('th', 'admin-group-name', row.label);
+      groupCell.scope = 'row';
+      const swatch = node('span', 'admin-group-swatch');
+      swatch.style.setProperty('--admin-group-color', USER_GROUP_COLORS[row.group]);
+      swatch.setAttribute('aria-hidden', 'true');
+      groupCell.prepend(swatch);
+      tableRow.appendChild(groupCell);
+
+      const usersCell = node('td', 'admin-group-users-cell');
+      const usersMetric = node('div', 'admin-group-users-metric');
+      const bar = node('span', 'admin-group-bar');
+      const track = node('span', 'admin-group-bar-track');
+      const fill = node('span', 'admin-group-bar-fill');
+      const width = Math.round((row.users / maxUsers) * 100);
+      fill.style.setProperty('--admin-group-bar-width', `${width}%`);
+      fill.style.setProperty('--admin-group-color', USER_GROUP_COLORS[row.group]);
+      track.appendChild(fill);
+      bar.appendChild(track);
+      bar.setAttribute('aria-hidden', 'true');
+      usersMetric.appendChild(bar);
+      usersMetric.appendChild(node('span', 'admin-group-number', number(row.users)));
+      usersCell.appendChild(usersMetric);
+      usersCell.setAttribute('aria-label', `${row.label}: ${number(row.users)} users`);
+      tableRow.appendChild(usersCell);
+
+      [
+        ['successful_run_users', 'Successful run users'],
+        ['repeat_users', 'Repeat users'],
+        ['total_runs', 'Total runs'],
+        ['atl_cost_micro_usd', 'ATL cost'],
+        ['paid_users', 'Paid users'],
+      ].forEach(([field, label]) => {
+        const value = field === 'atl_cost_micro_usd'
+          ? dollarsFromMicro(row[field])
+          : number(row[field]);
+        const cell = node('td', 'admin-group-number', value);
+        cell.setAttribute('aria-label', `${label}: ${value}`);
+        tableRow.appendChild(cell);
+      });
+      body.appendChild(tableRow);
+    });
+
+    if (table) table.setAttribute('aria-busy', 'false');
+    if (summary) summary.setAttribute('aria-busy', 'false');
+    if (fallback) {
+      fallback.textContent = '';
+      fallback.hidden = true;
+    }
+    if (error) {
+      const unavailable = !payload?.availability
+        || payload.availability.available === false
+        || payload.availability.status === 'unavailable';
+      error.textContent = unavailable && !stale ? SECTION_UNAVAILABLE : '';
+      error.hidden = !unavailable || stale;
+    }
+    const status = element('adminAnalyticsGroupSummaryStatus');
+    if (status) status.textContent = groupSummaryStatus(payload, rows, { stale });
   }
 
   function badge(kind, value, labels, rules) {
@@ -747,6 +928,11 @@
     return request(`${API_ENDPOINTS.users}?${userParams()}`);
   }
 
+  function fetchGroups() {
+    const params = rangeParams({ includeGroup: true });
+    return request(`${API_ENDPOINTS.groups}?${params}`);
+  }
+
   async function applySettledSection(name, result) {
     const section = state.sections[name];
     if (result.status === 'fulfilled') {
@@ -755,20 +941,28 @@
       section.error = null;
       section.stale = false;
       if (name === 'lifecycle') renderLifecycle(result.value);
+      else if (name === 'groups') renderGroups(result.value);
       else renderUsers(result.value);
       return;
     }
     if (await handleAccessLost(result.reason)) return;
     section.error = SECTION_UNAVAILABLE;
     section.stale = Boolean(section.data);
-    const target = name === 'lifecycle' ? element('adminValuePrimaryError') : element('adminPriorityError');
+    if (section.stale) {
+      if (name === 'lifecycle') renderLifecycle(section.data);
+      else if (name === 'groups') renderGroups(section.data, { stale: true });
+      else renderUsers(section.data);
+    } else if (name === 'groups') {
+      renderGroups(null);
+    }
+    const target = name === 'lifecycle'
+      ? element('adminValuePrimaryError')
+      : name === 'groups'
+        ? element('adminAnalyticsGroupSummaryError')
+        : element('adminPriorityError');
     if (target) {
       target.textContent = SECTION_UNAVAILABLE;
       target.hidden = false;
-    }
-    if (section.stale) {
-      if (name === 'lifecycle') renderLifecycle(section.data);
-      else renderUsers(section.data);
     }
   }
 
@@ -776,13 +970,16 @@
     const requestSeq = ++state.requestSeq;
     element('adminAnalyticsHeadline').setAttribute('aria-busy', 'true');
     element('adminPriorityUsers').setAttribute('aria-busy', 'true');
+    setGroupSummaryLoading(true);
     element('adminValuePrimaryError').hidden = true;
     element('adminPriorityError').hidden = true;
+    element('adminAnalyticsGroupSummaryError').hidden = true;
     element('adminValuePrimaryStatus').textContent = 'Refreshing user value analytics…';
-    const results = await Promise.allSettled([fetchLifecycle(), fetchPriorityUsers()]);
+    const results = await Promise.allSettled([fetchLifecycle(), fetchPriorityUsers(), fetchGroups()]);
     if (requestSeq !== state.requestSeq) return;
     await applySettledSection('lifecycle', results[0]);
     await applySettledSection('users', results[1]);
+    await applySettledSection('groups', results[2]);
     element('adminValuePrimaryStatus').textContent = state.sections.lifecycle.stale
       ? 'Showing the last successful response; refresh failed.'
       : element('adminValuePrimaryStatus').textContent.replace('Refreshing user value analytics…', '');
@@ -809,9 +1006,14 @@
       button.setAttribute('aria-pressed', button.dataset.lifecycle === state.userFilters.lifecycle ? 'true' : 'false');
     });
     state.sections.users.loaded = false;
-    fetchPriorityUsers()
-      .then((payload) => applySettledSection('users', { status: 'fulfilled', value: payload }))
-      .catch((error) => applySettledSection('users', { status: 'rejected', reason: error }));
+    state.sections.groups.loaded = false;
+    const groupError = element('adminAnalyticsGroupSummaryError');
+    if (groupError) groupError.hidden = true;
+    setGroupSummaryLoading(true);
+    Promise.allSettled([fetchPriorityUsers(), fetchGroups()]).then(async ([users, groups]) => {
+      await applySettledSection('users', users);
+      await applySettledSection('groups', groups);
+    });
   }
 
   function validateRange(start, end) {
@@ -890,6 +1092,8 @@
         validateRange(start, end);
         state.range = { start, end };
         state.includeInternal = element('adminValueInternal').checked;
+        const selectedGroup = element('adminValueGroup').value;
+        state.userFilters.group = USER_GROUPS.includes(selectedGroup) ? selectedGroup : '';
         error.hidden = true;
         writeUrlState();
         refresh();
@@ -898,6 +1102,12 @@
         error.hidden = false;
         error.focus();
       }
+    });
+    element('adminValueGroup')?.addEventListener('change', (event) => {
+      const selectedGroup = event.currentTarget.value;
+      applyUserFilters({
+        group: USER_GROUPS.includes(selectedGroup) ? selectedGroup : '',
+      });
     });
     element('adminAnalyticsValueRefresh')?.addEventListener('click', refresh);
     element('adminPriorityFilters')?.addEventListener('submit', (event) => {
@@ -966,7 +1176,11 @@
     // the overview blank for the rest of the page session.
     const requested = params.get(URL_KEYS.profile) || params.get(URL_KEYS.user) || '';
     const profileRequested = /^\d+$/.test(requested);
-    if (!profileRequested && (!state.sections.lifecycle.loaded || !state.sections.users.loaded)) refreshPrimary();
+    if (!profileRequested && (
+      !state.sections.lifecycle.loaded
+      || !state.sections.users.loaded
+      || !state.sections.groups.loaded
+    )) refreshPrimary();
   }
 
   function syncAuth(user) {

--- a/dashboard/frontend/js/admin-credits.js
+++ b/dashboard/frontend/js/admin-credits.js
@@ -352,6 +352,11 @@
       return;
     }
 
+    // Invalidate any list request that was already in flight. Without this,
+    // a slower pre-save response can arrive after the PATCH and re-render the
+    // row from its stale `Unknown` snapshot, making a successful save look
+    // like it was lost until the next refresh.
+    state.usersRequestSeq += 1;
     groupSelect.disabled = true;
     try {
       setStatus(`Updating group for ${subject}…`, 'pending');
@@ -359,6 +364,10 @@
         method: 'PATCH',
         body: JSON.stringify({ user_group: nextGroup }),
       });
+      // A refresh may have started while the PATCH was in flight. Its
+      // response was built before this mutation committed, so invalidate it
+      // before publishing the server-confirmed row below.
+      state.usersRequestSeq += 1;
       const updatedUser = data?.user || {};
       if (!Object.prototype.hasOwnProperty.call(updatedUser, 'user_group')) {
         throw new Error('Group update response was incomplete.');
@@ -370,6 +379,9 @@
       setGroupError(groupSelect);
       setStatus(`${subject} is now in ${userGroupLabel(savedGroup)}.`, 'success');
     } catch (error) {
+      // Also discard a concurrent list response on failure; it may otherwise
+      // repaint the select after we restore the value from before the save.
+      state.usersRequestSeq += 1;
       groupSelect.value = previousGroup;
       setGroupError(groupSelect, error.message || 'Group update failed.');
       if (!handleAccessLost(error)) setStatus(error.message || 'Group update failed.', 'error');

--- a/dashboard/frontend/js/admin-credits.js
+++ b/dashboard/frontend/js/admin-credits.js
@@ -4,6 +4,14 @@
 
   const { formatCredits, formatCreditsMicro } = window.CreditFormat;
   const ADMIN_CREDITS_USERS_PAGE_SIZE = 25;
+  const USER_GROUP_OPTIONS = Object.freeze([
+    ['internal', 'Internal'],
+    ['invited', 'Invited'],
+    ['organic', 'Organic'],
+    ['competition', 'Competition'],
+    ['partner', 'Partner'],
+    ['unknown', 'Unknown'],
+  ]);
 
   const state = {
     initialized: false,
@@ -165,6 +173,47 @@
     return user.display_name || user.email || `User #${user.id}`;
   }
 
+  function normalizeUserGroup(value) {
+    const normalized = String(value || '').trim().toLowerCase();
+    return USER_GROUP_OPTIONS.some(([optionValue]) => optionValue === normalized)
+      ? normalized
+      : 'unknown';
+  }
+
+  function userGroupLabel(value) {
+    const normalized = normalizeUserGroup(value);
+    return USER_GROUP_OPTIONS.find(([optionValue]) => optionValue === normalized)?.[1] || 'Unknown';
+  }
+
+  function renderUserGroup(user) {
+    const select = document.createElement('select');
+    select.className = 'admin-credits-group-select';
+    select.setAttribute('aria-label', `Group for ${userName(user)}`);
+    const currentGroup = normalizeUserGroup(user.user_group);
+    USER_GROUP_OPTIONS.forEach(([optionValue, label]) => {
+      const option = document.createElement('option');
+      option.value = optionValue;
+      option.textContent = label;
+      option.selected = optionValue === currentGroup;
+      select.appendChild(option);
+    });
+    select.addEventListener('change', () => mutateUserGroup(user, select));
+    return select;
+  }
+
+  function groupErrorNode(groupSelect) {
+    return groupSelect?.closest('.admin-credits-group')?.querySelector('.admin-credits-group-error') || null;
+  }
+
+  function setGroupError(groupSelect, message = '') {
+    const errorNode = groupErrorNode(groupSelect);
+    if (!errorNode) return;
+    errorNode.textContent = message;
+    errorNode.hidden = !message;
+    if (message) groupSelect.setAttribute('aria-invalid', 'true');
+    else groupSelect.removeAttribute('aria-invalid');
+  }
+
   function renderUsersPager() {
     const range = element('adminCreditsUsersRange');
     const previous = element('adminCreditsUsersPrevBtn');
@@ -192,7 +241,7 @@
     if (!state.users.length) {
       const row = document.createElement('tr');
       const cell = textNode('td', 'admin-empty', 'No matching accounts.');
-      cell.colSpan = 8;
+      cell.colSpan = 9;
       row.appendChild(cell);
       body.appendChild(row);
       return;
@@ -205,6 +254,15 @@
       account.className = 'admin-credits-account';
       account.appendChild(textNode('strong', '', userName(user)));
       account.appendChild(textNode('span', '', user.email || `User #${user.id}`));
+      const groupCell = document.createElement('td');
+      groupCell.className = 'admin-credits-group';
+      const groupSelect = renderUserGroup(user);
+      const groupError = textNode('span', 'admin-credits-group-error', '');
+      groupError.id = `admin-credits-group-error-${Number(user.id)}`;
+      groupError.hidden = true;
+      groupError.setAttribute('role', 'alert');
+      groupSelect.setAttribute('aria-describedby', groupError.id);
+      groupCell.append(groupSelect, groupError);
       const roleCell = document.createElement('td');
       roleCell.className = 'admin-credits-role';
       const role = user.role === 'admin' ? 'admin' : 'user';
@@ -271,6 +329,7 @@
 
       row.append(
         account,
+        groupCell,
         roleCell,
         statusCell,
         textNode('td', 'admin-credits-number', formatCredits(balance.display_grant_credits)),
@@ -281,6 +340,42 @@
       );
       body.appendChild(row);
     });
+  }
+
+  async function mutateUserGroup(user, groupSelect) {
+    const previousGroup = normalizeUserGroup(user.user_group);
+    const nextGroup = normalizeUserGroup(groupSelect.value);
+    const subject = userName(user);
+    setGroupError(groupSelect);
+    if (nextGroup === previousGroup) {
+      groupSelect.value = previousGroup;
+      return;
+    }
+
+    groupSelect.disabled = true;
+    try {
+      setStatus(`Updating group for ${subject}…`, 'pending');
+      const data = await request(`/api/admin/users/${Number(user.id)}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ user_group: nextGroup }),
+      });
+      const updatedUser = data?.user || {};
+      if (!Object.prototype.hasOwnProperty.call(updatedUser, 'user_group')) {
+        throw new Error('Group update response was incomplete.');
+      }
+      const savedGroup = normalizeUserGroup(updatedUser.user_group);
+      Object.assign(user, updatedUser);
+      user.user_group = savedGroup;
+      groupSelect.value = savedGroup;
+      setGroupError(groupSelect);
+      setStatus(`${subject} is now in ${userGroupLabel(savedGroup)}.`, 'success');
+    } catch (error) {
+      groupSelect.value = previousGroup;
+      setGroupError(groupSelect, error.message || 'Group update failed.');
+      if (!handleAccessLost(error)) setStatus(error.message || 'Group update failed.', 'error');
+    } finally {
+      groupSelect.disabled = false;
+    }
   }
 
   async function reinstateUser(user) {

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -2824,7 +2824,7 @@ a.header-brand:hover .title-section h1 {
 
 .admin-value-filters {
     display: grid;
-    grid-template-columns: repeat(2, minmax(145px, 185px)) minmax(220px, 1fr) auto;
+    grid-template-columns: repeat(2, minmax(145px, 185px)) minmax(155px, 1fr) minmax(220px, 1fr) auto;
     align-items: end;
     gap: 10px;
     padding: 13px 14px;
@@ -2845,6 +2845,7 @@ a.header-brand:hover .title-section h1 {
 }
 
 .admin-value-filters input,
+.admin-value-filters select,
 .admin-priority-filters input,
 .admin-priority-filters select,
 .admin-operational-filters input,
@@ -3291,6 +3292,99 @@ a.header-brand:hover .title-section h1 {
     text-transform: uppercase;
 }
 
+.admin-value-group-summary {
+    display: grid;
+    gap: 12px;
+}
+
+.admin-value-group-table {
+    width: 100%;
+    min-width: 900px;
+    border-collapse: collapse;
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+}
+
+.admin-value-group-table th,
+.admin-value-group-table td {
+    padding: 10px 10px;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.13);
+    color: var(--text-secondary);
+    text-align: left;
+    white-space: nowrap;
+}
+
+.admin-value-group-table thead th {
+    color: var(--text-muted);
+    font-size: 10px;
+    text-transform: uppercase;
+}
+
+.admin-value-group-table thead th:not(:first-child),
+.admin-value-group-table td:not(:first-child) {
+    text-align: right;
+}
+
+.admin-value-group-table tbody tr:last-child th,
+.admin-value-group-table tbody tr:last-child td {
+    border-bottom: 0;
+}
+
+.admin-value-group-table .admin-group-name {
+    min-width: 118px;
+    color: var(--text-primary);
+    font-weight: 600;
+}
+
+.admin-group-swatch {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    margin-right: 8px;
+    border-radius: 50%;
+    background: var(--admin-group-color, #94a3b8);
+    vertical-align: middle;
+}
+
+.admin-group-users-cell {
+    min-width: 245px;
+}
+
+.admin-group-users-metric {
+    display: grid;
+    grid-template-columns: minmax(120px, 1fr) auto;
+    align-items: center;
+    gap: 10px;
+}
+
+.admin-group-bar {
+    display: block;
+    min-width: 120px;
+}
+
+.admin-group-bar-track {
+    display: block;
+    height: 8px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: rgba(148, 163, 184, 0.13);
+}
+
+.admin-group-bar-fill {
+    display: block;
+    width: var(--admin-group-bar-width, 0%);
+    height: 100%;
+    border-radius: inherit;
+    background: var(--admin-group-color, #94a3b8);
+    transition: width 180ms ease;
+}
+
+.admin-group-number {
+    color: var(--text-primary) !important;
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+}
+
 .admin-operational-filters {
     grid-template-columns: repeat(3, minmax(150px, 1fr)) auto;
     margin-bottom: 12px;
@@ -3415,7 +3509,8 @@ a.header-brand:hover .title-section h1 {
 }
 
 @media (prefers-reduced-motion: reduce) {
-    .admin-value-disclosure-toggle svg {
+    .admin-value-disclosure-toggle svg,
+    .admin-group-bar-fill {
         transition: none;
     }
 }

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -14420,6 +14420,10 @@ table.sr-only {
     font-size: 12px;
 }
 
+.admin-credits-users-table {
+    min-width: 900px;
+}
+
 .admin-credits-users-table th,
 .admin-credits-users-table td,
 .admin-credits-activity-table th,
@@ -14501,6 +14505,45 @@ table.sr-only {
     color: var(--text-primary);
     font: inherit;
     font-size: 12px;
+}
+
+.admin-credits-group {
+    white-space: nowrap;
+}
+
+.admin-credits-group-select {
+    width: 132px;
+    min-width: 118px;
+    max-width: 160px;
+    padding: 6px 8px;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    font: inherit;
+    font-size: 12px;
+}
+
+.admin-credits-role-select:focus,
+.admin-credits-group-select:focus {
+    outline: none;
+    border-color: var(--info-color);
+    box-shadow: 0 0 0 2px rgba(0, 191, 255, 0.12);
+}
+
+.admin-credits-group-select:disabled {
+    cursor: wait;
+    opacity: 0.62;
+}
+
+.admin-credits-group-error {
+    display: block;
+    max-width: 160px;
+    margin-top: 4px;
+    color: var(--danger-color);
+    font-size: 10px;
+    line-height: 1.35;
+    white-space: normal;
 }
 
 .admin-credits-number,

--- a/docs/superpowers/plans/2026-09-13-admin-user-groups.md
+++ b/docs/superpowers/plans/2026-09-13-admin-user-groups.md
@@ -1,0 +1,697 @@
+# Admin User Groups and Source Analysis Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (- [ ]) syntax for tracking.
+
+**Goal:** Add one canonical, admin-editable user-source group to every account and expose a six-row, filterable source analysis in Admin Analytics without changing billing, lifecycle, operational-state, or legacy acquisition semantics.
+
+**Architecture:** Keep the source classification on the canonical users account row as a validated user_group value. Both SQLite and PostgreSQL stores expose the same admin projection and atomic patch method; the existing Admin Credits Account Management table is the one editing surface. Analytics reuses the existing batched user, event, run, and Credits readers to build a fixed-order group summary, while the vanilla frontend keeps the selected group in URL-backed state and renders a compact accessible table with proportional bars.
+
+**Tech Stack:** Python 3, FastAPI, Pydantic v2, SQLite, PostgreSQL/psycopg, pytest, vanilla JavaScript, semantic HTML/CSS, and the existing Chart.js-loaded ATL admin shell.
+
+**Spec:** docs/superpowers/specs/2026-09-13-admin-user-groups-design.md
+
+## Global Constraints
+
+- The only stored values are internal, invited, organic, competition, partner, and unknown, in that order; all labels and UI copy remain English.
+- unknown is the default for new and historical accounts. Do not infer a new group from old acquisition source or cohort values.
+- user_group is independent from Paid status, lifecycle segment, operational state, and legacy acquisition fields.
+- include_internal keeps its current Analytics exclusion meaning; selecting Internal must not silently toggle it.
+- Only the admin projection exposes the group. Public signup, login, /api/auth/me, and ordinary session payloads must not expose this admin-only field.
+- PATCH /api/admin/users/{user_id} remains the single atomic mutation for role, entitlements, and group. Omitted fields remain unchanged; explicit null and unsupported values are rejected.
+- Group Summary always returns six rows, including zero rows, in fixed taxonomy order. Each row contains Users, Successful run users, Repeat users, Total runs, ATL cost, and Paid users.
+- Successful run users means at least one backtest_completed event in the selected UTC period. Repeat users means successful completions on at least two different UTC dates. Total runs counts one backtest_requested event per run attempt. Paid users use lifetime settled purchases minus settled refunds from the Credits ledger. ATL cost includes settled platform model cost only and excludes BYOK usage.
+- Analytics endpoints remain admin-only, display-safe, batched, and independently available. Never return prompts, provider bodies, secrets, raw User-Agent values, full IPs, or credential material.
+- Additive lazy migrations must work on existing SQLite and PostgreSQL deployments. Do not edit or commit any database file or production fixture.
+- The canonical Account Management table gets the only Group editor; the hidden legacy Users table does not receive a second editor.
+- Use native controls, proportional bars, and accessible text-table fallbacks. Do not use emoji as icons and do not introduce a second analytics architecture.
+- Tests use synthetic stores and temporary databases only. Never print or stage API keys, database URLs with credentials, dashboard/storage/data/backtest.db, dashboard/storage/backtest.db, .superpowers/, work/, or generated mockups.
+- Before deployment, local API/browser smoke and CI are required. A Vercel Preview cannot prove API persistence because its /api rewrite targets the current production backend. Do not report production completion until the real Render API and a real admin session have been verified.
+
+## File Map
+
+- dashboard/backend/domain/user_groups.py: single taxonomy, labels, strict write parsing, and tolerant read coercion.
+- dashboard/backend/users.py: SQLite users.user_group schema/migration, account creation default, admin projection, and atomic store patch.
+- dashboard/backend/users_postgres.py: PostgreSQL schema/migration, creation/default projection, and twin atomic patch.
+- dashboard/backend/api/routers/admin_users.py: Pydantic request contract, HTTP validation, atomic patch wiring, and audit line.
+- dashboard/backend/api/routers/admin_credits.py: pass the canonical group through the Account Management list response.
+- dashboard/backend/domain/analytics/value_queries.py: group-aware filter model, fixed-order summary model, and batched aggregation.
+- dashboard/backend/api/routers/admin_analytics.py: query-string validation and GET /api/admin/analytics/groups.
+- dashboard/frontend/app.html: Account Management Group column/control and Analytics Group Summary/filter markup.
+- dashboard/frontend/js/admin-credits.js: Account Management select rendering, save flow, and inline error recovery.
+- dashboard/frontend/js/admin-analytics-value.js: URL state, group filter requests, summary rendering, and partial-availability handling.
+- dashboard/frontend/styles.css: table, select, proportional-bar, overflow, and ATL-theme states.
+- Focused tests: dashboard/backend/tests/test_user_groups.py, test_user_group_store.py, test_admin_users.py, test_admin_credits_api.py, test_admin_credits_frontend.py, domain/analytics/test_value_queries.py, test_admin_analytics_api.py, test_admin_analytics_value_frontend.py, test_users_postgres.py, and test_store_twin_parity.py.
+
+---
+
+### Task 1: Define the six-value group contract
+
+**Files:**
+- Create: dashboard/backend/domain/user_groups.py
+- Create: dashboard/backend/tests/test_user_groups.py
+
+**Interfaces:**
+- Produce UserGroup = Literal["internal", "invited", "organic", "competition", "partner", "unknown"].
+- Produce USER_GROUPS: tuple[UserGroup, ...], USER_GROUP_LABELS, parse_user_group(value: object) -> UserGroup, coerce_user_group(value: object) -> UserGroup, and user_group_label(value: UserGroup) -> str.
+- parse_user_group strips and lowercases a string and raises ValueError("invalid_user_group") for None, blank, non-string, or unsupported values. coerce_user_group returns unknown for missing or malformed stored data.
+
+- [ ] **Step 1: Write the failing taxonomy and parser tests.**
+
+    import pytest
+    from dashboard.backend.domain.user_groups import (
+        USER_GROUPS, USER_GROUP_LABELS, coerce_user_group, parse_user_group
+    )
+
+    def test_groups_have_fixed_product_order_and_labels():
+        assert USER_GROUPS == (
+            "internal", "invited", "organic", "competition", "partner", "unknown"
+        )
+        assert [USER_GROUP_LABELS[group] for group in USER_GROUPS] == [
+            "Internal", "Invited", "Organic", "Competition", "Partner", "Unknown"
+        ]
+
+    @pytest.mark.parametrize("value", ["internal", " ORGANIC ", "competition"])
+    def test_parse_user_group_normalizes_supported_values(value):
+        assert parse_user_group(value) in USER_GROUPS
+
+    @pytest.mark.parametrize("value", [None, "", "not-a-group", 3, True])
+    def test_parse_user_group_rejects_invalid_writes(value):
+        with pytest.raises(ValueError, match="invalid_user_group"):
+            parse_user_group(value)
+
+    @pytest.mark.parametrize("value", [None, "", "old-acquisition-value", object()])
+    def test_coerce_user_group_defaults_bad_stored_values_to_unknown(value):
+        assert coerce_user_group(value) == "unknown"
+
+- [ ] **Step 2: Run the focused test and verify the new module is missing.**
+
+Run: pytest -q dashboard/backend/tests/test_user_groups.py
+
+Expected: collection fails because dashboard.backend.domain.user_groups does not exist.
+
+- [ ] **Step 3: Implement the constants and two explicit read/write paths.**
+
+    from typing import Literal, Mapping, cast
+
+    UserGroup = Literal[
+        "internal", "invited", "organic", "competition", "partner", "unknown"
+    ]
+    USER_GROUPS = (
+        "internal", "invited", "organic", "competition", "partner", "unknown"
+    )
+    USER_GROUP_LABELS = {
+        "internal": "Internal", "invited": "Invited", "organic": "Organic",
+        "competition": "Competition", "partner": "Partner", "unknown": "Unknown",
+    }
+
+    def parse_user_group(value: object) -> UserGroup:
+        if not isinstance(value, str):
+            raise ValueError("invalid_user_group")
+        normalized = value.strip().lower()
+        if normalized not in USER_GROUPS:
+            raise ValueError("invalid_user_group")
+        return cast(UserGroup, normalized)
+
+    def coerce_user_group(value: object) -> UserGroup:
+        try:
+            return parse_user_group(value)
+        except ValueError:
+            return "unknown"
+
+    def user_group_label(value: UserGroup) -> str:
+        return USER_GROUP_LABELS[value]
+
+- [ ] **Step 4: Run the tests and commit the standalone contract.**
+
+Run: pytest -q dashboard/backend/tests/test_user_groups.py
+
+Expected: PASS.
+
+    git add dashboard/backend/domain/user_groups.py dashboard/backend/tests/test_user_groups.py
+    git commit -m "feat: define admin user group taxonomy"
+
+### Task 2: Add SQLite persistence and admin projections
+
+**Files:**
+- Modify: dashboard/backend/users.py
+- Create: dashboard/backend/tests/test_user_group_store.py
+
+**Interfaces:**
+- UserStore._init_schema() declares users.user_group TEXT NOT NULL DEFAULT 'unknown' and lazily adds the same column to old databases.
+- UserStore.create_user() creates unknown explicitly or through the schema default.
+- UserStore.apply_admin_patch(..., user_group: str | None = None, ...) validates a supplied group, leaves an omitted group unchanged, updates it inside the existing BEGIN IMMEDIATE transaction, and returns it in the admin projection.
+- public_user() remains the public projection without user_group; public_user_with_entitlements() and admin_user_rows_to_payloads() include a coerced group.
+
+- [ ] **Step 1: Write migration, default, projection, and atomic-update tests.**
+
+Create a store fixture in the new test file before the cases:
+
+    @pytest.fixture
+    def store(tmp_path):
+        return UserStore(db_path=tmp_path / "users.db")
+
+    import sqlite3
+    from pathlib import Path
+    import pytest
+    from dashboard.backend.users import UserStore
+
+    def test_existing_users_table_gets_unknown_group_column(tmp_path: Path):
+        path = tmp_path / "legacy.db"
+        conn = sqlite3.connect(path)
+        conn.execute(
+            "CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT, display_name TEXT, "
+            "password_hash TEXT, role TEXT, created_at TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO users VALUES (1, 'legacy@example.test', 'Legacy', 'hash', "
+            "'user', '2026-01-01T00:00:00+00:00')"
+        )
+        conn.commit()
+        conn.close()
+        store = UserStore(db_path=path)
+        assert store.get_user_admin(1)["user_group"] == "unknown"
+
+    def test_new_users_default_to_unknown_and_store_patch_is_atomic(store):
+        user = store.create_user("group@example.test", "Group", "SecurePass1!")
+        assert store.get_user_admin(user["id"])["user_group"] == "unknown"
+        updated = store.apply_admin_patch(
+            user["id"], user_group="organic", credits=7, max_concurrent_backtests=2
+        )
+        assert updated["user_group"] == "organic"
+        assert updated["entitlements"]["credits"] == 7
+        assert store.get_user_admin(user["id"])["user_group"] == "organic"
+
+    def test_store_rejects_invalid_group_and_omitted_group_preserves_value(store):
+        user = store.create_user("preserve@example.test", "Preserve", "SecurePass1!")
+        store.apply_admin_patch(user["id"], user_group="partner")
+        with pytest.raises(ValueError, match="invalid_user_group"):
+            store.apply_admin_patch(user["id"], user_group="friends")
+        assert store.apply_admin_patch(user["id"], credits=9)["user_group"] == "partner"
+
+- [ ] **Step 2: Run the tests and verify the column/projection are absent.**
+
+Run: pytest -q dashboard/backend/tests/test_user_group_store.py
+
+Expected: FAIL because users.user_group, the patch parameter, and admin projection field do not yet exist.
+
+- [ ] **Step 3: Add the additive SQLite migration and shared projection handling.**
+
+Keep the existing PRAGMA table_info(users) pattern and add:
+
+    if "user_group" not in columns:
+        cursor.execute(
+            "ALTER TABLE users ADD COLUMN user_group TEXT NOT NULL DEFAULT 'unknown'"
+        )
+
+Import parse_user_group and coerce_user_group. Add user_group to the admin projection only:
+
+    payload = public_user(row)
+    payload.pop("avatar", None)
+    payload["user_group"] = coerce_user_group(dict(row).get("user_group"))
+    payload["entitlements"] = entitlements
+
+Extend apply_admin_patch with user_group: Optional[str] = None, call parse_user_group only when supplied, execute UPDATE users SET user_group = ? WHERE id = ? inside the existing transaction, then read the row back before commit. Do not add the field to public_user().
+
+- [ ] **Step 4: Run SQLite store and existing admin-store tests.**
+
+Run: pytest -q dashboard/backend/tests/test_user_group_store.py dashboard/backend/tests/test_admin_users.py::test_apply_role_and_list_admin dashboard/backend/tests/test_store_twin_parity.py
+
+Expected: the new SQLite tests pass; twin-parity may remain red until Task 3 adds the PostgreSQL twin.
+
+- [ ] **Step 5: Commit the SQLite implementation.**
+
+    git add dashboard/backend/users.py dashboard/backend/tests/test_user_group_store.py
+    git commit -m "feat: persist admin user groups in sqlite"
+
+### Task 3: Mirror the store contract in PostgreSQL
+
+**Files:**
+- Modify: dashboard/backend/users_postgres.py
+- Modify: dashboard/backend/tests/test_users_postgres.py
+- Modify: dashboard/backend/tests/test_store_twin_parity.py
+
+**Interfaces:**
+- PostgresUserStore exposes the same public methods and signatures as UserStore, including apply_admin_patch(..., user_group: str | None = None, ...).
+- Fresh and existing PostgreSQL users tables contain user_group TEXT NOT NULL DEFAULT 'unknown'; the existing-table path uses ALTER TABLE users ADD COLUMN IF NOT EXISTS user_group TEXT NOT NULL DEFAULT 'unknown'.
+- PostgreSQL admin list/get/create/patch payloads match SQLite exactly for user_group and continue omitting it from public session payloads.
+
+- [ ] **Step 1: Add twin tests before changing PostgreSQL code.**
+
+Extend the existing pg_only cases in test_users_postgres.py:
+
+    @pg_only
+    def test_user_group_default_and_atomic_patch_postgres(temp_postgres_store):
+        user = temp_postgres_store.create_user(
+            "pg-group@example.test", "PG Group", "securepass1"
+        )
+        assert temp_postgres_store.get_user_admin(user["id"])["user_group"] == "unknown"
+        updated = temp_postgres_store.apply_admin_patch(
+            user["id"], user_group="competition", credits=11
+        )
+        assert updated["user_group"] == "competition"
+        assert updated["entitlements"]["credits"] == 11
+
+Add a source-level migration assertion next to the existing twin checks:
+
+    def test_users_postgres_repeats_sqlite_user_group_migration():
+        source = Path("dashboard/backend/users_postgres.py").read_text(
+            encoding="utf-8"
+        )
+        assert "ADD COLUMN IF NOT EXISTS user_group" in source
+
+- [ ] **Step 2: Run the parity and PostgreSQL-focused tests.**
+
+Run: pytest -q dashboard/backend/tests/test_store_twin_parity.py dashboard/backend/tests/test_users_postgres.py -k 'user_group or store_twins'
+
+Expected: FAIL because the PostgreSQL DDL, signature, and projection do not yet match SQLite.
+
+- [ ] **Step 3: Add PostgreSQL DDL, lazy migration, and atomic update.**
+
+Add user_group TEXT NOT NULL DEFAULT 'unknown' to the CREATE TABLE users literal and an ALTER TABLE ... ADD COLUMN IF NOT EXISTS user_group TEXT NOT NULL DEFAULT 'unknown' beside the existing Discord/avatar migrations. Import and reuse the strict parser and tolerant projection from users.py.
+
+In the existing transaction in PostgresUserStore.apply_admin_patch, normalize the optional group once and add a parameterized UPDATE users SET user_group = %s WHERE id = %s before the existing entitlements upsert. Keep the advisory lock and last-admin guard unchanged; read the row back with the existing RETURNING/readback path so the returned admin payload is identical to SQLite.
+
+- [ ] **Step 4: Run both twin suites.**
+
+Run: pytest -q dashboard/backend/tests/test_store_twin_parity.py dashboard/backend/tests/test_user_group_store.py dashboard/backend/tests/test_users_postgres.py -k 'user_group or store_twins'
+
+Expected: PASS when TEST_POSTGRES_URL is configured; without it, live cases are skipped and source-level parity still passes.
+
+- [ ] **Step 5: Commit the PostgreSQL twin.**
+
+    git add dashboard/backend/users_postgres.py dashboard/backend/tests/test_users_postgres.py dashboard/backend/tests/test_store_twin_parity.py
+    git commit -m "feat: mirror user groups in postgres store"
+
+### Task 4: Expose and audit the admin mutation
+
+**Files:**
+- Modify: dashboard/backend/api/routers/admin_users.py
+- Modify: dashboard/backend/api/routers/admin_credits.py
+- Modify: dashboard/backend/tests/test_admin_users.py
+- Modify: dashboard/backend/tests/test_admin_credits_api.py
+
+**Interfaces:**
+- AdminUserPatch.user_group uses the shared UserGroup type and remains optional.
+- PATCH /api/admin/users/{user_id} accepts { "user_group": "organic" }, rejects explicit null with the existing no-null contract, returns 422 for an unsupported value, and returns the saved admin user projection.
+- The audit line includes actor, target, old_group, and new_group without logging email, secrets, or arbitrary request text.
+- GET /api/admin/credits/users includes user_group in each canonical Account Management row.
+
+- [ ] **Step 1: Write HTTP contract tests.**
+
+Add cases to test_admin_users.py:
+
+    def test_admin_can_patch_group_and_public_me_does_not_expose_it(
+        isolated_auth, capsys
+    ):
+        client, store = isolated_auth
+        admin = _signup(client, "group-admin@example.com")
+        target = _signup(client, "group-target@example.com")
+        _promote(store, admin["id"])
+        _login(client, "group-admin@example.com")
+        response = client.patch(
+            "/api/admin/users/" + str(target["id"]),
+            json={"user_group": "organic"},
+        )
+        assert response.status_code == 200
+        assert response.json()["user"]["user_group"] == "organic"
+        audit = capsys.readouterr().out
+        assert "old_group=unknown" in audit
+        assert "new_group=organic" in audit
+        assert "user_group" not in client.get("/api/auth/me").json()["user"]
+
+    def test_admin_group_patch_rejects_null_and_unknown_value(isolated_auth):
+        client, store = isolated_auth
+        admin = _signup(client, "group-validation@example.com")
+        _promote(store, admin["id"])
+        _login(client, "group-validation@example.com")
+        target = _signup(client, "group-invalid@example.com")
+        assert client.patch(
+            "/api/admin/users/" + str(target["id"]),
+            json={"user_group": None},
+        ).status_code == 400
+        assert client.patch(
+            "/api/admin/users/" + str(target["id"]),
+            json={"user_group": "friends"},
+        ).status_code == 422
+
+Update the exact-response assertion in test_admin_credits_api.py::test_admin_user_search_composes_identity_with_bucket_projection to include user_group: unknown.
+
+- [ ] **Step 2: Run the API tests and verify the route still drops the new field.**
+
+Run: pytest -q dashboard/backend/tests/test_admin_users.py dashboard/backend/tests/test_admin_credits_api.py -k 'group or search_composes'
+
+Expected: FAIL because the request model, audit payload, and credits-user projection do not yet contain the group.
+
+- [ ] **Step 3: Wire the shared type, old/new audit values, and credits list projection.**
+
+Add user_group: Optional[UserGroup] = None to AdminUserPatch; include it in explicit-null/no-fields checks and pass it to apply_admin_patch. Read the existing admin row before the atomic call so the audit line can record its coerced old value, then emit:
+
+    _audit(
+        "user_patched",
+        actor=int(admin["id"]),
+        target=int(user_id),
+        old_group=previous_group,
+        new_group=updated["user_group"],
+        role=payload.role,
+        max_concurrent_backtests=payload.max_concurrent_backtests,
+        credits=payload.credits,
+    )
+
+In list_grant_users, copy identity["user_group"] into the response object. Do not add a second editor to the hidden legacy Users table.
+
+- [ ] **Step 4: Run the complete focused admin/API suite.**
+
+Run: pytest -q dashboard/backend/tests/test_admin_users.py dashboard/backend/tests/test_admin_credits_api.py dashboard/backend/tests/test_auth.py -k 'admin or group or me'
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the admin API contract.**
+
+    git add dashboard/backend/api/routers/admin_users.py dashboard/backend/api/routers/admin_credits.py dashboard/backend/tests/test_admin_users.py dashboard/backend/tests/test_admin_credits_api.py
+    git commit -m "feat: expose editable user groups to admins"
+
+### Task 5: Add group-aware Analytics filters and fixed six-row summary
+
+**Files:**
+- Modify: dashboard/backend/domain/analytics/value_queries.py
+- Modify: dashboard/backend/api/routers/admin_analytics.py
+- Modify: dashboard/backend/tests/domain/analytics/test_value_queries.py
+- Modify: dashboard/backend/tests/test_admin_analytics_api.py
+
+**Interfaces:**
+- UserValueFilters gains user_group: UserGroup | None = None; ValueAnalyticsQueryService.list_users() filters on the canonical account group without changing lifecycle/operational/commercial filters.
+- Add UserGroupSummary with fields group, label, users, successful_run_users, repeat_users, total_runs, atl_cost_micro_usd, and paid_users.
+- Add GroupAnalyticsResponse with as_of, groups: Sequence[UserGroupSummary], selected_user_group: UserGroup | None, and availability: SectionAvailability.
+- Add ValueAnalyticsQueryService.get_groups(start: date, end: date, include_internal: bool = False, user_group: UserGroup | None = None, now: datetime | None = None) -> GroupAnalyticsResponse.
+- Add GET /api/admin/analytics/groups?from=YYYY-MM-DD&to=YYYY-MM-DD&user_group=...&include_internal=.... It always serializes six rows in USER_GROUPS order.
+
+- [ ] **Step 1: Add failing domain/API tests for definitions and query state.**
+
+Extend the synthetic user helper in test_value_queries.py so it supplies user_group, and add:
+
+    def test_group_summary_has_six_rows_zeroes_and_fixed_order():
+        service = _service(
+            snapshots={1: _snapshot(1)},
+            user_groups={1: "organic"},
+            group_events=[
+                event(1, "backtest_requested", "2026-09-01T01:00:00+00:00"),
+                event(1, "backtest_completed", "2026-09-01T02:00:00+00:00"),
+                event(1, "backtest_completed", "2026-09-03T02:00:00+00:00"),
+            ],
+        )
+        result = service.get_groups(
+            date(2026, 9, 1), date(2026, 9, 4), now=NOW
+        )
+        assert [row.group for row in result.groups] == [
+            "internal", "invited", "organic", "competition", "partner", "unknown"
+        ]
+        organic = result.groups[2]
+        assert organic.users == 1
+        assert organic.successful_run_users == 1
+        assert organic.repeat_users == 1
+        assert organic.total_runs == 1
+        assert result.groups[0].users == 0
+
+    def test_user_group_filter_applies_to_priority_users():
+        filters = UserValueFilters(user_group="partner", priority=True)
+        assert filters.user_group == "partner"
+
+The synthetic event helper must include UTC timestamps and safe properties so the test proves repeat-day counting and cost filtering without production data.
+
+- [ ] **Step 2: Add failing HTTP validation and endpoint tests.**
+
+In test_admin_analytics_api.py, add cases that assert a valid user_group=organic reaches the service and an unsupported value returns 422; assert the response has six rows even when the selected group has no members.
+
+    def test_group_endpoint_rejects_unknown_group(admin_analytics_api):
+        response = admin_analytics_api.client.get(
+            "/api/admin/analytics/groups",
+            params={
+                "from": "2026-09-01",
+                "to": "2026-09-03",
+                "user_group": "friends",
+            },
+        )
+        assert response.status_code == 422
+
+- [ ] **Step 3: Implement the filter and safe aggregation.**
+
+Import the shared taxonomy. In _value_user_filters, allow and validate user_group, pass it into UserValueFilters, and add the same key to the router allowed query set. In list_users, skip rows whose user.get("user_group") does not match the filter.
+
+Implement get_groups() by:
+1. Loading all eligible admin-projection users in pages of 500 and coercing each group to unknown.
+2. Applying the optional selected-group filter only to the eligible account set.
+3. Loading the selected UTC period metric events through the existing display-safe query store, retaining only backtest_requested, backtest_completed, and model_usage_recorded facts for those user ids.
+4. Counting one backtest_requested as one run attempt, unique completed users, and users whose completed-event UTC date set has at least two entries.
+5. Reusing the existing safe cost_micro_usd extraction and billing-mode checks for model_usage_recorded; sum only platform_credits cost and never BYOK.
+6. Loading batched commercial facts for the same users and counting lifetime_net_purchased_micro > 0 as paid.
+7. Constructing a row for every value in USER_GROUPS, with zeros for absent groups and the display label from USER_GROUP_LABELS. Return availability status partial when an underlying section is incomplete, but never omit rows.
+
+Keep aggregation in the service/query layer; do not add a new event stream or expose raw event properties.
+
+- [ ] **Step 4: Add the /groups router and URL validation.**
+
+Add user_group to _value_range(..., additional=...), parse it with the strict shared parser, and call service.get_groups(...). Map ValidationError/ValueError to the existing 422 contract and preserve the router-wide admin dependency.
+
+- [ ] **Step 5: Run the domain and API tests.**
+
+Run: pytest -q dashboard/backend/tests/domain/analytics/test_value_queries.py dashboard/backend/tests/test_admin_analytics_api.py -k 'group or user_group or value_user'
+
+Expected: PASS, including fixed row order, zero rows, UTC repeat-day semantics, BYOK exclusion, filter propagation, and invalid-query handling.
+
+- [ ] **Step 6: Commit the Analytics contract.**
+
+    git add dashboard/backend/domain/analytics/value_queries.py dashboard/backend/api/routers/admin_analytics.py dashboard/backend/tests/domain/analytics/test_value_queries.py dashboard/backend/tests/test_admin_analytics_api.py
+    git commit -m "feat: add user group analytics summary"
+
+### Task 6: Add the Group editor to canonical Account Management
+
+**Files:**
+- Modify: dashboard/frontend/app.html
+- Modify: dashboard/frontend/js/admin-credits.js
+- Modify: dashboard/frontend/styles.css
+- Modify: dashboard/backend/tests/test_admin_credits_frontend.py
+- Modify: dashboard/backend/tests/test_admin_credits_api.py
+
+**Interfaces:**
+- The canonical adminCreditsUsersTable receives a Group column and one native select.admin-credits-group-select per row with all six labels.
+- The select sends PATCH /api/admin/users/{id} with { user_group: nextValue }, stays disabled while saving, restores the prior value on failure, and replaces the in-memory value with the server response on success.
+- Empty-state colSpan, table accessibility text, and narrow-screen overflow remain correct after adding the ninth column.
+
+- [ ] **Step 1: Add static frontend contract tests.**
+
+Extend test_admin_credits_frontend.py:
+
+    def test_account_management_has_one_group_editor():
+        assert '<th scope="col">Group</th>' in APP_HTML
+        source = Path(
+            "dashboard/frontend/js/admin-credits.js"
+        ).read_text(encoding="utf-8")
+        assert "admin-credits-group-select" in source
+        assert "PATCH" in source and "/api/admin/users/" in source
+        for label in (
+            "Internal", "Invited", "Organic", "Competition", "Partner", "Unknown"
+        ):
+            assert label in source
+
+- [ ] **Step 2: Run the frontend contract test and verify the markup is missing.**
+
+Run: pytest -q dashboard/backend/tests/test_admin_credits_frontend.py dashboard/backend/tests/test_admin_credits_api.py -k 'group or account_management'
+
+Expected: FAIL because the table and renderer have no Group column/control.
+
+- [ ] **Step 3: Add the semantic table column and renderer.**
+
+Insert Group between Account and Role in app.html; change the empty row to colspan="9". In admin-credits.js, define the shared ordered option list and render a native select:
+
+    const USER_GROUP_OPTIONS = [
+      ["internal", "Internal"], ["invited", "Invited"], ["organic", "Organic"],
+      ["competition", "Competition"], ["partner", "Partner"], ["unknown", "Unknown"],
+    ];
+
+    function renderUserGroup(user) {
+      const select = document.createElement("select");
+      select.className = "admin-credits-group-select";
+      select.setAttribute(
+        "aria-label",
+        "Group for " + userName(user)
+      );
+      USER_GROUP_OPTIONS.forEach(([value, label]) => {
+        const option = new Option(
+          label, value, false, value === (user.user_group || "unknown")
+        );
+        select.appendChild(option);
+      });
+      select.addEventListener("change", () => mutateUserGroup(user, select));
+      return select;
+    }
+
+mutateUserGroup captures the previous value, disables the select, sends the single PATCH, applies data.user.user_group on success, and restores the previous value plus an inline status error on failure. Keep role confirmation and Grant mutations unchanged.
+
+- [ ] **Step 4: Add ATL-consistent CSS and responsive behavior.**
+
+Style .admin-credits-group-select with existing input tokens, a bounded minimum width, readable focus ring, and the same dark color scheme as the role select. Keep .admin-credits-users-table horizontally scrollable on narrow screens rather than squeezing labels into unreadable widths.
+
+- [ ] **Step 5: Run the Account Management contracts.**
+
+Run: pytest -q dashboard/backend/tests/test_admin_credits_frontend.py dashboard/backend/tests/test_admin_credits_api.py
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the Account Management UI.**
+
+    git add dashboard/frontend/app.html dashboard/frontend/js/admin-credits.js dashboard/frontend/styles.css dashboard/backend/tests/test_admin_credits_frontend.py dashboard/backend/tests/test_admin_credits_api.py
+    git commit -m "feat: add account management group editor"
+
+### Task 7: Render Group Summary and URL-backed Analytics filtering
+
+**Files:**
+- Modify: dashboard/frontend/app.html
+- Modify: dashboard/frontend/js/admin-analytics-value.js
+- Modify: dashboard/frontend/styles.css
+- Modify: dashboard/backend/tests/test_admin_analytics_value_frontend.py
+
+**Interfaces:**
+- admin-analytics-value.js adds groups: /api/admin/analytics/groups, ordered group labels/colors, state.userFilters.group, and URL key analyticsGroup.
+- readUrlState(), writeUrlState(), setControls(), rangeParams(), and userParams() preserve and send the selected group without altering date-range or include_internal behavior.
+- fetchGroups() loads the summary; renderGroups(payload) renders six rows, horizontal proportional bars scaled to the largest users count, aligned numeric columns, and a text-table fallback with an accessible caption.
+- Group-summary errors follow existing section-level unavailable/stale behavior and do not blank lifecycle or priority-user panels.
+
+- [ ] **Step 1: Add frontend contract tests before markup/code changes.**
+
+Extend test_admin_analytics_value_frontend.py:
+
+    def test_analytics_has_group_filter_and_summary_contract():
+        assert 'id="adminValueGroup"' in APP_HTML
+        source = Path(
+            "dashboard/frontend/js/admin-analytics-value.js"
+        ).read_text(encoding="utf-8")
+        assert "/api/admin/analytics/groups" in source
+        assert "analyticsGroup" in source
+        assert "renderGroups" in source
+        for label in (
+            "Internal", "Invited", "Organic", "Competition", "Partner", "Unknown"
+        ):
+            assert label in APP_HTML or label in source
+
+- [ ] **Step 2: Run the frontend contract test and verify the new surface is absent.**
+
+Run: pytest -q dashboard/backend/tests/test_admin_analytics_value_frontend.py -k group
+
+Expected: FAIL because the Analytics filter, endpoint, and summary table do not yet exist.
+
+- [ ] **Step 3: Add semantic filter and summary markup.**
+
+Place a native User group select with id adminValueGroup in the existing value-filter form, with an All user groups option and the six taxonomy options. Add a Group summary section immediately below the primary headline and before deeper disclosures:
+
+    <section id="adminAnalyticsGroupSummary" class="admin-value-card"
+             aria-labelledby="adminAnalyticsGroupSummaryTitle">
+      <div class="admin-value-section-head">
+        <div>
+          <p class="credits-section-kicker">Where users come from</p>
+          <h4 id="adminAnalyticsGroupSummaryTitle">Group summary</h4>
+        </div>
+        <span id="adminAnalyticsGroupSummaryStatus"
+              class="admin-value-coverage" role="status" aria-live="polite"></span>
+      </div>
+      <div class="admin-value-table-wrap">
+        <table id="adminAnalyticsGroupTable" class="admin-value-group-table">
+          <caption class="sr-only">Users and value signals by user group</caption>
+          <thead>
+            <tr>
+              <th scope="col">Group</th>
+              <th scope="col">Users</th>
+              <th scope="col">Successful run users</th>
+              <th scope="col">Repeat users</th>
+              <th scope="col">Total runs</th>
+              <th scope="col">ATL cost</th>
+              <th scope="col">Paid users</th>
+            </tr>
+          </thead>
+          <tbody id="adminAnalyticsGroupBody"></tbody>
+        </table>
+      </div>
+      <p id="adminAnalyticsGroupFallback" class="admin-value-empty" hidden></p>
+    </section>
+
+- [ ] **Step 4: Implement URL state, request fan-out, and proportional bars.**
+
+Add group to the existing userFilters object and use analyticsGroup in readUrlState() and writeUrlState(). Include user_group in rangeParams() (for /groups) and userParams() (for priority users). On filter change, refresh group summary and priority users while leaving the lifecycle range request independent.
+
+renderGroups() clears and rebuilds the body from the server six rows, computes maxUsers = Math.max(1, ...rows.map(row => row.users)), and sets each bar width to the rounded users/maxUsers percentage in a DOM element with an accessible text value. If the endpoint is unavailable, show the existing unavailable message in the summary status and keep the last successful rows when available.
+
+- [ ] **Step 5: Add compact ATL-theme CSS and narrow-screen overflow.**
+
+Give each row a consistent height, a muted track plus group-colored fill, tabular numeric alignment, and enough minimum table width for all seven columns. Reuse --font-mono, var(--bg-card), var(--border-color), and existing focus tokens; do not introduce emoji or a new card grid of six detached numbers.
+
+- [ ] **Step 6: Run frontend and static route contracts.**
+
+Run: pytest -q dashboard/backend/tests/test_admin_analytics_value_frontend.py dashboard/backend/tests/test_static_routes.py
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the Analytics UI.**
+
+    git add dashboard/frontend/app.html dashboard/frontend/js/admin-analytics-value.js dashboard/frontend/styles.css dashboard/backend/tests/test_admin_analytics_value_frontend.py
+    git commit -m "feat: show user group summary in analytics"
+
+### Task 8: Local browser smoke, review gates, and deployment acceptance
+
+**Files:**
+- Modify only if a focused test exposes a contract mismatch; otherwise no product files.
+- Evidence: temporary local database and screenshot files outside the repository or in an ignored path.
+
+**Interfaces:**
+- Local verification proves the full path: account creation defaults to Unknown, an admin changes a group, the value persists after refresh, and Analytics returns/renders all six rows with the selected filter.
+- CI/review/deployment reporting distinguishes a received Render Deploy Hook from a completed Render build and persistent production behavior.
+
+- [ ] **Step 1: Run the full focused Python suite and syntax checks.**
+
+Run:
+
+    pytest -q \
+      dashboard/backend/tests/test_user_groups.py \
+      dashboard/backend/tests/test_user_group_store.py \
+      dashboard/backend/tests/test_admin_users.py \
+      dashboard/backend/tests/test_admin_credits_api.py \
+      dashboard/backend/tests/test_admin_credits_frontend.py \
+      dashboard/backend/tests/domain/analytics/test_value_queries.py \
+      dashboard/backend/tests/test_admin_analytics_api.py \
+      dashboard/backend/tests/test_admin_analytics_value_frontend.py \
+      dashboard/backend/tests/test_store_twin_parity.py
+    python -m compileall -q dashboard/backend
+    git diff --check
+
+Expected: PASS with no whitespace errors. If TEST_POSTGRES_URL is unset, report PostgreSQL behavioral cases as skipped rather than claiming live parity.
+
+- [ ] **Step 2: Start the app against a temporary database and perform the browser smoke.**
+
+Use a temporary DATABASE_PATH/equivalent local configuration and a synthetic admin account. In the browser:
+1. Open Users -> Account Management and confirm a new row displays Unknown.
+2. Change that row to Organic, wait for the save status, reload, and confirm it remains Organic.
+3. Open Analytics, confirm the User group select is URL-backed, choose Organic, and confirm the summary still shows all six rows with non-zero values only where data exists.
+4. Clear the filter and confirm lifecycle, date range, and include_internal state are unchanged.
+5. Capture screenshots of Account Management and Analytics at desktop and a narrow viewport; inspect the rendered page, not just HTTP 200.
+
+- [ ] **Step 3: Inspect the diff for scope and secrets.**
+
+Run:
+
+    git status --short
+    git diff --stat origin/main...HEAD
+    git diff --name-only --cached
+
+Expected: only planned source/tests/docs are staged; no database files, secrets, .superpowers/, work/, or generated mockups are present.
+
+- [ ] **Step 4: Push the branch and create a reviewable PR without claiming deployment.**
+
+Run the repository CI workflow on feat/admin-user-groups, open or update the Draft PR, and record CI plus visual-smoke results. Explain that Vercel Preview is static-only for this change because its API rewrite targets current production Render.
+
+- [ ] **Step 5: Complete production acceptance only after merge.**
+
+After review and merge to main, wait for the Render build (not merely the Deploy Hook job). Verify /health, OpenAPI's /api/admin/analytics/groups route, the deployed Admin UI, and one real administrator round trip: read Unknown, save Organic, refresh, and filter Analytics by Organic. Report the PR and deployment complete only after those persistence checks pass.
+
+## Plan self-review
+
+- Spec coverage: taxonomy/defaults and boundaries are Task 1; SQLite/PostgreSQL persistence and lazy migration are Tasks 2-3; atomic API/audit/public projection rules are Task 4; filter and six-row definitions are Task 5; Account Management and Analytics UI behavior are Tasks 6-7; local/CI/Render acceptance is Task 8.
+- Placeholder scan: no step relies on TBD, TODO, or an unspecified "add appropriate handling" instruction; each implementation step names a file, interface, and concrete test/command.
+- Type consistency: UserGroup, USER_GROUPS, parse_user_group, and coerce_user_group originate in Task 1 and are reused by store, API, query, and frontend tasks; UserGroupSummary and GroupAnalyticsResponse originate in Task 5 and are the exact response consumed by Task 7.

--- a/docs/superpowers/specs/2026-09-13-admin-user-groups-design.md
+++ b/docs/superpowers/specs/2026-09-13-admin-user-groups-design.md
@@ -1,0 +1,194 @@
+# Admin User Groups and Source Analysis
+
+## Status
+
+Approved direction: independent `user_group` dimension, six visible values.
+
+## Goal
+
+Give ATL administrators a plain, reliable answer to “where did these users
+come from?” and let them correct that classification without changing the
+existing lifecycle, billing, or legacy acquisition semantics.
+
+The first release covers:
+
+1. A canonical `user_group` value on every account.
+2. An admin-only editor in Account Management.
+3. A Group filter and six-row Group Summary in Admin Analytics.
+
+It does not add event tracking, machine-learning segmentation, or a second
+analytics architecture.
+
+## Product semantics
+
+The only allowed values are:
+
+| Stored value | Display label | Meaning |
+| --- | --- | --- |
+| `internal` | Internal | ATL developers, SecureFinAI members, and RCOS/course/research students |
+| `invited` | Invited | Friends or peripheral students explicitly invited to try ATL |
+| `organic` | Organic | People who arrived through GitHub, Discord, the website, or another self-directed path |
+| `competition` | Competition | An official competition team |
+| `partner` | Partner | A partner organisation such as 同花顺, AWS, or NVIDIA |
+| `unknown` | Unknown | The source has not been confirmed yet |
+
+New and historical accounts default to `unknown`. An administrator can change
+the value later. No automatic inference is performed from the old
+`student/community/friend/competition/unknown` acquisition source because those
+values are not one-to-one with the new taxonomy.
+
+`user_group` is deliberately separate from:
+
+- Paid status, which is calculated from Purchased Credits.
+- Lifecycle status (`new`, `onboarding`, `growing`, `core`, `at_risk`, `dormant`).
+- Operational status (`blocked`, `needs_attention`, `healthy`).
+- Existing acquisition `source` and `cohort` data, which remains untouched.
+
+The existing `include_internal` control keeps its current meaning (the
+analytics exclusion list); selecting Group `Internal` does not silently change
+that control.
+
+## Architecture
+
+### Persistence
+
+Add `user_group TEXT NOT NULL DEFAULT 'unknown'` to the account `users` table.
+
+- SQLite and Postgres schemas receive the same logical column.
+- Existing deployments use a lazy `ALTER TABLE ... ADD COLUMN` migration.
+- The value is validated at the store boundary, not only in the HTTP layer.
+- No database file or fixture is edited as part of the change.
+
+The account store remains the source of truth because both Account Management
+and Analytics already read user rows from it. This avoids a separate join table
+and prevents an N+1 lookup for every analytics row.
+
+### Admin API
+
+Extend `PATCH /api/admin/users/{user_id}` with:
+
+```json
+{ "user_group": "organic" }
+```
+
+The existing atomic role/entitlement patch remains atomic; a request that
+changes several supported fields commits them together. Explicit `null` and
+unknown group values are rejected. The response includes the saved group in
+the admin projection. `GET /api/admin/users` and `GET /api/admin/users/{id}`
+also include it. Public account/session payloads do not expose this admin-only
+field.
+
+The mutation writes an operator audit line containing actor, target, old group,
+and new group. It does not create a new analytics event stream.
+
+### Analytics API and query layer
+
+Add `user_group` to the value analytics filter model and its URL-backed query
+state. The filter applies consistently to existing value/priority-user
+queries.
+
+Add a dedicated admin endpoint:
+
+`GET /api/admin/analytics/groups?from=YYYY-MM-DD&to=YYYY-MM-DD&user_group=...`
+
+The response always contains six rows in the fixed taxonomy order, including
+zero rows, plus availability metadata. Each row contains:
+
+- `group` and display `label`
+- `users`
+- `successful_run_users`
+- `repeat_users`
+- `total_runs`
+- `atl_cost_micro_usd`
+- `paid_users`
+
+Definitions:
+
+- Successful run user: at least one successful backtest in the selected period.
+- Repeat user: successful backtests on at least two different UTC dates in the
+  selected period.
+- Paid user: Purchased Credits greater than zero, using the existing credits
+  ledger.
+- ATL cost: settled platform model cost; BYOK usage is excluded.
+
+The summary uses the existing batched value/credits/run stores and does not
+expose prompts, token payloads, or provider responses.
+
+### Frontend
+
+#### Account Management
+
+Add a `Group` column to the canonical Account Management table. Render a native
+`select` with the six labels, preserve the current value while a save is in
+flight, and restore it with an inline error if the request fails. On success,
+update the in-memory row from the server response. The hidden legacy Users
+table is not given a second editor, so there is one obvious source of truth.
+
+#### Analytics
+
+Add a `User group` select beside the existing value filters. Changes update the
+URL-backed filter state and refresh the affected data without changing the
+existing date-range behavior.
+
+Place `Group summary` near the top of the value overview, before the deeper
+retention/commercial disclosures. Use a compact table with one visual bar per
+row (user count as the bar scale) and aligned numeric columns, rather than six
+detached number cards. The fixed rows make zero-valued categories visible and
+keep comparisons easy at a glance. The table remains readable on narrow
+screens via horizontal scrolling, with an accessible caption and a text table
+fallback.
+
+All copy remains English to match the ATL shell and existing analytics UI.
+
+## Data flow
+
+1. Account store bootstraps or lazily migrates `users.user_group`.
+2. Admin list/get projections include the validated group.
+3. An admin changes a row’s native select; the frontend sends the single PATCH.
+4. The store validates and atomically commits the group, then returns the row.
+5. Analytics loads eligible user rows in batches, groups them by `user_group`,
+   and combines existing run, success, repeat, credits, and cost facts.
+6. The frontend renders all six rows and preserves partial availability/error
+   behavior already used by Analytics.
+
+## Error and compatibility behavior
+
+- Missing or malformed group values read as `unknown` at the migration boundary;
+  invalid writes return HTTP 422.
+- A missing user returns the existing HTTP 404 contract.
+- Analytics failures show the existing section-level unavailable state while
+  leaving other overview sections usable.
+- Old acquisition source/cohort records remain readable and unchanged.
+- SQLite and Postgres stores must return the same admin payload shape.
+
+## Verification
+
+Focused tests will cover:
+
+1. SQLite schema migration, defaulting, validation, and atomic patch behavior.
+2. Postgres twin DDL/query parity and admin projection shape.
+3. Admin API success, 404, explicit-null, and invalid-enum responses.
+4. Group summary definitions, fixed six-row ordering, zero groups, and filters.
+5. Frontend source/DOM contracts for the Group select, URL filter, table, and
+   error recovery.
+6. A local browser smoke test with a temporary `DATABASE_PATH` and a screenshot
+   of Account Management plus the Analytics summary.
+
+## Deployment and acceptance
+
+The repository has no Render preview service. Before merge, use local API and
+admin-browser smoke tests plus the protected Vercel Preview for static UI
+checks. Do not claim an end-to-end preview because Vercel Preview proxies API
+requests to the current production backend.
+
+After CI passes and the new branch is reviewed, merge `main`; the existing
+workflow triggers the Render deploy hook. Wait for the Render build, then use a
+real administrator session to:
+
+1. Read a user row and confirm `Unknown` is shown.
+2. Change it to `Organic`, save, refresh, and confirm persistence.
+3. Open Analytics, filter `Organic`, and confirm the six-row summary and counts
+   load without changing unrelated filters.
+
+Only after those checks pass should the GitHub PR be reported as complete.
+

--- a/docs/superpowers/specs/2026-09-13-admin-user-groups-design.md
+++ b/docs/superpowers/specs/2026-09-13-admin-user-groups-design.md
@@ -191,4 +191,3 @@ real administrator session to:
    load without changing unrelated filters.
 
 Only after those checks pass should the GitHub PR be reported as complete.
-


### PR DESCRIPTION
## Summary

- add a fixed six-group taxonomy for admin-managed user source classification: Internal, Invited, Organic, Competition, Partner, and Unknown
- persist `user_group` across SQLite and PostgreSQL stores with lazy migration and store-parity coverage
- add admin-only editing in Account Management and expose six-row group summaries in Analytics with filtering and URL state
- protect account-list updates from stale responses after a group edit

## Product behavior

- new and historical users default to `Unknown`; existing acquisition/cohort fields are not inferred into the new group
- only administrators can view or update the group; regular users and `/api/auth/me` do not expose it
- Analytics always renders all six groups, including zero-value rows
- Account Management is the only editing entry point

## Verification

- `246 passed, 25 skipped, 3 warnings` (the skipped tests require `TEST_POSTGRES_URL`)
- Node syntax checks passed for the changed frontend scripts
- Python backend compile check passed
- `git diff --check` passed
- temporary SQLite/API smoke passed for `Unknown -> Organic`, persistence, six-row summaries, and group filtering
- Playwright browser smoke passed with a temporary database: post-save state remained `Organic` across 24 samples over 1.5 seconds, reload persisted it, and Analytics showed six rows plus `All + 6` group options

Production PostgreSQL, Render deployment, and an online administrator acceptance smoke remain to be run separately.
