### PR TITLE
test: fix admin groups analytics route contracts

### DIFF
--- a/dashboard/backend/tests/test_app_composition.py
+++ b/dashboard/backend/tests/test_app_composition.py
@@ -73,6 +73,7 @@ EXPECTED_ADMIN_ANALYTICS_ROUTES = {
     ("GET", "/admin/analytics/retention", "get_retention"),
     ("GET", "/admin/analytics/commercial", "get_commercial"),
     ("GET", "/admin/analytics/operational", "get_operational"),
+    ("GET", "/admin/analytics/groups", "get_groups"),
     ("GET", "/admin/analytics/users", "list_users"),
     ("GET", "/admin/analytics/users/{user_id}", "get_user_profile"),
     (
@@ -146,6 +147,7 @@ EXPECTED_FULL_CONTRACT = {
     ("GET", "/api/admin/analytics/retention"),
     ("GET", "/api/admin/analytics/commercial"),
     ("GET", "/api/admin/analytics/operational"),
+    ("GET", "/api/admin/analytics/groups"),
     ("GET", "/api/admin/analytics/users"),
     ("GET", "/api/admin/analytics/users/{user_id}"),
     ("GET", "/api/admin/analytics/users/{user_id}/activity"),


### PR DESCRIPTION
PR #465 added GET /api/admin/analytics/groups, but the composition tests still expect the previous route set. This causes both test_admin_analytics_router_contract and test_full_route_contract_unchanged to fail and blocks the Render deployment in [CI run 34723182459](https://github.com/Open-Finance-Lab/AgenticTrading/actions/runs/34723182459).

Add the groups endpoint to the explicit per-router and full-app expected contracts. The existing exact-match and single-registration checks remain intact. This is a two-line test-only change.

Validation:
- Local composition and admin analytics API suites: 54 passed (Python 3.12), including both previously failing tests and the existing non-admin access check for the groups endpoint.
- Command: `python -m pytest dashboard/backend/tests/test_app_composition.py dashboard/backend/tests/test_admin_analytics_api.py --timeout=180 -p no:cacheprovider -q`
- `git diff --check` passed.
- Original CI: 4,754 passed, 49 skipped, and only the two route-contract failures.
- Full GitHub CI on Python 3.13 is running.