### PR TITLE
fix: admin analytics redirect hijacks every page load

### DIFF
--- a/dashboard/backend/tests/test_admin_analytics_frontend.py
+++ b/dashboard/backend/tests/test_admin_analytics_frontend.py
@@ -247,7 +247,7 @@ def test_app_lifecycle_and_cache_versions_are_wired():
     assert 'app.js?v=130' in APP_HTML
     assert 'js/admin-analytics.js?v=6' in APP_HTML
     assert 'js/admin-analytics-value.js?v=5' in APP_HTML
-    assert 'js/admin-tabs.js?v=6' in APP_HTML
+    assert 'js/admin-tabs.js?v=7' in APP_HTML
 
 
 def test_credit_costs_use_the_shared_exact_formatter():

--- a/dashboard/backend/tests/test_admin_credits_frontend.py
+++ b/dashboard/backend/tests/test_admin_credits_frontend.py
@@ -150,4 +150,4 @@ def test_admin_tabs_have_four_tabs_in_usage_order_and_legacy_alias():
 
 def test_admin_visual_assets_use_fresh_cache_versions():
     assert 'js/admin-credits.js?v=6' in APP_HTML
-    assert 'js/admin-tabs.js?v=6' in APP_HTML
+    assert 'js/admin-tabs.js?v=7' in APP_HTML

--- a/dashboard/backend/tests/test_admin_tabs_redirect.py
+++ b/dashboard/backend/tests/test_admin_tabs_redirect.py
@@ -1,0 +1,96 @@
+"""The Analytics-tab redirect fires only on admin intent, never on page load.
+
+PR #467 moved the admin Analytics tab to the standalone /admin-analytics page by
+redirecting from the tab controller's `setTab`. But `setTab('analytics')` is also
+what the controller runs on every `/app` DOMContentLoaded and on every popstate,
+purely to initialise hidden panel state — so after #467 *every* view of the app
+bounced to /admin-analytics the moment it loaded. Those lifecycle calls must set
+panel state without leaving the page; only entering the admin view (the Admin
+menu item, or a `?view=admin` deep link routed by app.js) or clicking the
+Analytics tab may redirect.
+
+The controller is an IIFE over `window`/`document`, so it runs under node against
+a minimal DOM stub that records every navigation.
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ADMIN_TABS_JS = (
+    Path(__file__).resolve().parents[2] / "frontend" / "js" / "admin-tabs.js"
+).read_text(encoding="utf-8")
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("node") is None, reason="node is not installed"
+)
+
+_STUB = r"""
+const nav = [];
+const docListeners = {};
+const winListeners = {};
+globalThis.CustomEvent = class { constructor(type, init) { this.type = type; this.detail = init && init.detail; } };
+globalThis.Event = class { constructor(type) { this.type = type; } };
+globalThis.document = {
+  addEventListener(name, fn) { (docListeners[name] ||= []).push(fn); },
+  dispatchEvent() {},
+  getElementById() { return null; },
+  querySelectorAll() { return []; },
+};
+globalThis.window = {
+  location: {
+    href: 'https://atl.example/app?view=community',
+    assign(u) { nav.push(['assign', u]); },
+    replace(u) { nav.push(['replace', u]); },
+  },
+  history: { state: null, replaceState() {}, pushState() {} },
+  addEventListener(name, fn) { (winListeners[name] ||= []).push(fn); },
+};
+const fire = (map, name) => (map[name] || []).forEach((fn) => fn({}));
+const setHref = (h) => { window.location.href = h; };
+"""
+
+
+def _run(scenario: str) -> list:
+    script = "\n".join([_STUB, ADMIN_TABS_JS, scenario, "console.log(JSON.stringify(nav));"])
+    result = subprocess.run(["node", "-e", script], capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+def test_page_load_on_a_non_admin_view_does_not_redirect():
+    assert _run("fire(docListeners, 'DOMContentLoaded');") == []
+
+
+def test_popstate_does_not_redirect():
+    # app.js owns view routing on popstate; a back/forward that lands on the
+    # admin view reaches onEnter through navigateToPage, not through here.
+    assert _run("fire(docListeners, 'DOMContentLoaded'); fire(winListeners, 'popstate');") == []
+
+
+def test_entering_admin_view_redirects_to_the_analytics_page():
+    nav = _run(
+        "fire(docListeners, 'DOMContentLoaded');"
+        "setHref('https://atl.example/app?view=admin');"
+        "window.AdminTabs.onEnter();"
+    )
+    assert nav == [["replace", "/admin-analytics"]]
+
+
+def test_entering_admin_view_on_another_tab_stays_in_the_console():
+    nav = _run(
+        "fire(docListeners, 'DOMContentLoaded');"
+        "setHref('https://atl.example/app?view=admin&adminTab=providers');"
+        "window.AdminTabs.onEnter();"
+    )
+    assert nav == []
+
+
+def test_redirect_replaces_history_so_back_does_not_loop():
+    # `assign` leaves `/app?view=admin` behind /admin-analytics; Back reloads it,
+    # app.js routes to admin, and the user is redirected forward again forever.
+    assert "window.location.assign('/admin-analytics')" not in ADMIN_TABS_JS
+    assert "window.location.replace('/admin-analytics')" in ADMIN_TABS_JS

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -2706,7 +2706,7 @@
     <script src="js/admin-credits.js?v=6" defer></script>
     <script src="js/admin-analytics.js?v=6" defer></script>
     <script src="js/admin-analytics-value.js?v=5" defer></script>
-    <script src="js/admin-tabs.js?v=6" defer></script>
+    <script src="js/admin-tabs.js?v=7" defer></script>
     <script src="js/leaderboard.js?v=33" defer></script>
     <script src="home-page.js?v=50" defer></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and

--- a/dashboard/frontend/js/admin-tabs.js
+++ b/dashboard/frontend/js/admin-tabs.js
@@ -11,13 +11,21 @@
     return ALLOWED_TABS.has(normalizedValue) ? normalizedValue : DEFAULT_TAB;
   }
 
-  function setTab(value, { updateUrl = true } = {}) {
+  // `leave` gates the hand-off to the standalone /admin-analytics page. It is
+  // true only on admin *intent* — entering the admin view, clicking the tab.
+  // The page-load and popstate calls below pass false: they run on every /app
+  // load to initialise hidden panel state, and a redirect there bounced every
+  // view of the app to /admin-analytics (PR #467 regression).
+  function setTab(value, { updateUrl = true, leave = true } = {}) {
     const tab = normalizeTab(value);
-    if (tab === 'analytics') {
+    if (tab === 'analytics' && leave) {
       // The Analytics tab now lives on the standalone /admin-analytics page
       // (preview with synthetic data). Leave the in-app panel in place but
       // never show it; providers/users/activity still render here.
-      window.location.assign('/admin-analytics');
+      // `replace`, not `assign`: `/app?view=admin` must not stay in history,
+      // or Back reloads it, app.js routes to admin, and we redirect forward
+      // again — a loop the user cannot escape with the Back button.
+      window.location.replace('/admin-analytics');
       return tab;
     }
     const tablist = document.getElementById('adminTabs');
@@ -64,7 +72,7 @@
     });
     window.addEventListener('popstate', () => {
       const requested = new URL(window.location.href).searchParams.get('adminTab');
-      setTab(requested || DEFAULT_TAB, { updateUrl: false });
+      setTab(requested || DEFAULT_TAB, { updateUrl: false, leave: false });
     });
   }
 
@@ -88,6 +96,14 @@
     input?.focus();
   }
 
+  // Page load only initialises panel state; app.js routes `?view=admin` to
+  // navigateToPage('admin') → onEnter, which is where the redirect belongs.
+  function init() {
+    bind();
+    const requested = new URL(window.location.href).searchParams.get('adminTab');
+    setTab(requested || DEFAULT_TAB, { leave: false });
+  }
+
   window.AdminTabs = { onEnter, openAccountManagement, setTab };
-  document.addEventListener('DOMContentLoaded', onEnter);
+  document.addEventListener('DOMContentLoaded', init);
 })();


### PR DESCRIPTION
Regression from #467: \`admin-tabs.js\` calls \`setTab('analytics')\` on every \`/app\` DOMContentLoaded and popstate to set panel state, and the redirect lived in \`setTab\`, so every view bounced to \`/admin-analytics\`.

- Redirect now fires only on admin intent (Admin menu / \`?view=admin\` via \`onEnter\`, or the tab button); page-load and popstate pass \`leave: false\`.
- \`location.replace\` instead of \`assign\` so Back does not loop through \`/app?view=admin\`.
- \`admin-tabs.js?v=7\` cache bust; node-driven tests in \`test_admin_tabs_redirect.py\` pin the four paths.

Full suite green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013X7GCMF9zdDC2gqX2KhM5Y